### PR TITLE
Partially obf/deobf relevant fixes

### DIFF
--- a/FernFlower-Patches/0018-Enhance-Generic-Invocations-Temporarily.patch
+++ b/FernFlower-Patches/0018-Enhance-Generic-Invocations-Temporarily.patch
@@ -154,7 +154,7 @@ index 740b37c..a2906b1 100644
      StructClass cl = DecompilerContext.getStructContext().getClass(classname);
      if (cl == null || matches.size() == 1) {
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructClass.java b/src/org/jetbrains/java/decompiler/struct/StructClass.java
-index 39fe8a6..e7e1e4e 100644
+index 39fe8a6..8c34061 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructClass.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructClass.java
 @@ -130,6 +130,31 @@ public class StructClass extends StructMember {
@@ -170,7 +170,7 @@ index 39fe8a6..e7e1e4e 100644
 +
 +    if (superClass != null) {
 +      StructClass cls = DecompilerContext.getStructContext().getClass((String)superClass.value);
-+      ret = cls.getMethodRecursive(name, descriptor);
++      ret = cls != null ? cls.getMethodRecursive(name, descriptor) : null;
 +      if (ret != null) {
 +        return ret;
 +      }
@@ -178,7 +178,7 @@ index 39fe8a6..e7e1e4e 100644
 +
 +    for (String intf : getInterfaceNames()) {
 +      StructClass cls = DecompilerContext.getStructContext().getClass(intf);
-+      ret = cls.getMethodRecursive(name, descriptor);
++      ret = cls != null ? cls.getMethodRecursive(name, descriptor) : null;
 +      if (ret != null) {
 +        return ret;
 +      }

--- a/FernFlower-Patches/0019-Prevent-leading-dot-for-unpackaged-classes.patch
+++ b/FernFlower-Patches/0019-Prevent-leading-dot-for-unpackaged-classes.patch
@@ -1,0 +1,22 @@
+From 16d98ecd7d946b5cff00f779ac5b1a27ee00f6a0 Mon Sep 17 00:00:00 2001
+From: Thiakil <xander@thiakil.com>
+Date: Sat, 19 May 2018 19:56:27 +0800
+Subject: [PATCH] Prevent leading dot for unpackaged classes
+
+
+diff --git a/src/org/jetbrains/java/decompiler/main/collectors/ImportCollector.java b/src/org/jetbrains/java/decompiler/main/collectors/ImportCollector.java
+index 5e2d064..7100c63 100644
+--- a/src/org/jetbrains/java/decompiler/main/collectors/ImportCollector.java
++++ b/src/org/jetbrains/java/decompiler/main/collectors/ImportCollector.java
+@@ -115,7 +115,7 @@ public class ImportCollector {
+     if (existsDefaultClass ||
+         (mapSimpleNames.containsKey(shortName) && !packageName.equals(mapSimpleNames.get(shortName)))) {
+       //  don't return full name because if the class is a inner class, full name refers to the parent full name, not the child full name
+-      return result == null ? fullName : (packageName + "." + result);
++      return result == null ? fullName : ((!packageName.isEmpty() ? (packageName + ".") : "") + result);
+     }
+     else if (!mapSimpleNames.containsKey(shortName)) {
+       mapSimpleNames.put(shortName, packageName);
+-- 
+2.16.1.windows.1
+


### PR DESCRIPTION
Not sure if you'd want these, but when decompiling partially obfuscated classes class names can be output with a leading period/dot.

Example:
```
package net.minecraft.world.biome;

import <snip>

public abstract class Biome {
   public static final Logger LOGGER = LogManager.getLogger();
   public static final .bym<.buo> b = new .byq();
   public static final .bym<.buo> c = new .byu();
   public static final .bym<.buo> d = new .byp();
   public static final .bym<.buo> e = new .bzm();
   public static final .bym<.buo> f = new .bzn();
   public static final .bxo<.bxf> g = new .bwz();
```

Second patch just prevents a NPE that seems to crop up.