### PR TITLE
Inverted floating point comparisons

### DIFF
--- a/FernFlower-Patches/0022-Fix-incorrect-decompilation-of-inverted-floating-poi.patch
+++ b/FernFlower-Patches/0022-Fix-incorrect-decompilation-of-inverted-floating-poi.patch
@@ -1,0 +1,355 @@
+From 76dfa9f180041fac7daeba51680a1465426de53d Mon Sep 17 00:00:00 2001
+From: malte0811 <malte0811@web.de>
+Date: Mon, 23 Jul 2018 15:53:01 +0200
+Subject: [PATCH] Fix incorrect decompilation of inverted floating point
+ comparisons with NaN
+
+
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/SecondaryFunctionsHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/SecondaryFunctionsHelper.java
+index a7c804b..149c7ed 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/SecondaryFunctionsHelper.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SecondaryFunctionsHelper.java
+@@ -168,8 +168,18 @@ public class SecondaryFunctionsHelper {
+                   }
+                 }
+               }
+-
+               if (desttype >= 0) {
++                if (functype != FunctionExprent.FUNCTION_LCMP) {
++                  boolean oneForNan = functype == FunctionExprent.FUNCTION_DCMPL || functype == FunctionExprent.FUNCTION_FCMPL;
++                  boolean trueForOne = desttype == FunctionExprent.FUNCTION_LT || desttype == FunctionExprent.FUNCTION_LE;
++                  boolean trueForNan = oneForNan == trueForOne;
++                  if (trueForNan) {
++                    List<Exprent> operands = new ArrayList<>();
++                    operands.add(new FunctionExprent(funcsnot[desttype - FunctionExprent.FUNCTION_EQ],
++                      funcexpr.getLstOperands(), funcexpr.bytecode));
++                    return new FunctionExprent(FunctionExprent.FUNCTION_BOOL_NOT, operands, funcexpr.bytecode);
++                  }
++                }
+                 return new FunctionExprent(desttype, funcexpr.getLstOperands(), funcexpr.bytecode);
+               }
+             }
+@@ -394,10 +404,6 @@ public class SecondaryFunctionsHelper {
+               }
+             case FunctionExprent.FUNCTION_EQ:
+             case FunctionExprent.FUNCTION_NE:
+-            case FunctionExprent.FUNCTION_LT:
+-            case FunctionExprent.FUNCTION_GE:
+-            case FunctionExprent.FUNCTION_GT:
+-            case FunctionExprent.FUNCTION_LE:
+               fparam.setFuncType(funcsnot[ftype - FunctionExprent.FUNCTION_EQ]);
+               return fparam;
+           }
+diff --git a/test/org/jetbrains/java/decompiler/SingleClassesTest.java b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+index d7e814c..eb86822 100644
+--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
++++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+@@ -100,4 +100,5 @@ public class SingleClassesTest extends SingleClassesTestBase {
+   @Test public void testGroovyClass() { doTest("pkg/TestGroovyClass"); }
+   @Test public void testGroovyTrait() { doTest("pkg/TestGroovyTrait"); }
+   @Test public void testPrivateClasses() { doTest("pkg/PrivateClasses"); }
++  @Test public void testInvertedFloatComparison() { doTest("pkg/TestInvertedFloatComparison"); }
+ }
+\ No newline at end of file
+diff --git a/testData/classes/pkg/TestInvertedFloatComparison.class b/testData/classes/pkg/TestInvertedFloatComparison.class
+new file mode 100644
+index 0000000000000000000000000000000000000000..29c1432cb3f7dd7619183278468cc9f6101eaf9c
+GIT binary patch
+literal 1332
+zcmb7@%TC)s6o&sv?3ftm3I)_Fu%HQxL_&x~RiUa}sz?+Tpf0+bgi&NLcIr613P@Ze
+z+DhGY(^aJ|`T#ss)v?D%?P8`<y*T4@e7^ZSqnZ0(KYjvO$AXI@9ypkDFwanW>4$!@
+z$xv*y-!WKQ(Xn8t?fIeDpPcnYe8l^KtXP2<j~VRN_ICR{L*+2xgVVQslz+Bcy<S>(
+z!YJ9xI-OxGcp_p3SJvK8QcmaD`7q%DgO@i`niF|i`-9~b_b{5o1F`F;KeTux#z`+c
+z7jYtvcY}y0ThZBw$No49J16{{d$3?LJR6-3yZ`8AsHffCfQQ5GLH|Sy5-g!0_b7cD
+zkV}UxV@YOD<jCY`uYL#nCST-&Wh`aIqKs20%b2!yGYs&aw=b{ZSYKcjzsh>yFQNoj
+zR%{g9SLwV{n9ku&?w@}2_@jY!i7jWWrxjlr;3~mN?CHdJ2DVA85?6HMi(3OcN3arC
+zbmGqj_93xKT-Azi4DeHemAI-Ce=@Mk#42%3C%!a^R|r<(+W&}GiB;mdR&3hp4#7%X
+z*NIJAy+*7OH+13))8X16Scw}tvFUKVAXbT+TCwRmZ4#`+O`X_uon8~G#537Vo&60^
+CeUmo;
+
+literal 0
+HcmV?d00001
+
+diff --git a/testData/results/TestInvertedFloatComparison.dec b/testData/results/TestInvertedFloatComparison.dec
+new file mode 100644
+index 0000000..03d684a
+--- /dev/null
++++ b/testData/results/TestInvertedFloatComparison.dec
+@@ -0,0 +1,199 @@
++package pkg;
++
++public class TestInvertedFloatComparison {
++   public boolean less(double var1, double var3) {
++      return var1 < var3;// 6
++   }
++
++   public boolean less(int var1, int var2) {
++      return var1 < var2;// 10
++   }
++
++   public boolean notLess(double var1, double var3) {
++      return !(var1 < var3);// 14
++   }
++
++   public boolean notLess(int var1, int var2) {
++      return var1 >= var2;// 18
++   }
++
++   public boolean greater(double var1, double var3) {
++      return var1 > var3;// 22
++   }
++
++   public boolean greater(int var1, int var2) {
++      return var1 > var2;// 26
++   }
++
++   public boolean notGreater(double var1, double var3) {
++      return !(var1 > var3);// 30
++   }
++
++   public boolean notGreater(int var1, int var2) {
++      return var1 <= var2;// 34
++   }
++
++   public boolean lessEqual(double var1, double var3) {
++      return var1 <= var3;// 38
++   }
++
++   public boolean lessEqual(int var1, int var2) {
++      return var1 <= var2;// 42
++   }
++
++   public boolean notLessEqual(double var1, double var3) {
++      return !(var1 <= var3);// 46
++   }
++
++   public boolean notLessEqual(int var1, int var2) {
++      return var1 > var2;// 50
++   }
++
++   public boolean greaterEqual(double var1, double var3) {
++      return var1 >= var3;// 54
++   }
++
++   public boolean greaterEqual(int var1, int var2) {
++      return var1 >= var2;// 58
++   }
++
++   public boolean notGreaterEqual(double var1, double var3) {
++      return !(var1 >= var3);// 62
++   }
++
++   public boolean notGreaterEqual(int var1, int var2) {
++      return var1 < var2;// 66
++   }
++}
++
++class 'pkg/TestInvertedFloatComparison' {
++   method 'less (DD)Z' {
++      0      4
++      1      4
++      2      4
++      b      4
++   }
++
++   method 'less (II)Z' {
++      0      8
++      1      8
++      2      8
++      a      8
++   }
++
++   method 'notLess (DD)Z' {
++      0      12
++      1      12
++      2      12
++      b      12
++   }
++
++   method 'notLess (II)Z' {
++      0      16
++      1      16
++      2      16
++      a      16
++   }
++
++   method 'greater (DD)Z' {
++      0      20
++      1      20
++      2      20
++      b      20
++   }
++
++   method 'greater (II)Z' {
++      0      24
++      1      24
++      2      24
++      a      24
++   }
++
++   method 'notGreater (DD)Z' {
++      0      28
++      1      28
++      2      28
++      b      28
++   }
++
++   method 'notGreater (II)Z' {
++      0      32
++      1      32
++      2      32
++      a      32
++   }
++
++   method 'lessEqual (DD)Z' {
++      0      36
++      1      36
++      2      36
++      b      36
++   }
++
++   method 'lessEqual (II)Z' {
++      0      40
++      1      40
++      2      40
++      a      40
++   }
++
++   method 'notLessEqual (DD)Z' {
++      0      44
++      1      44
++      2      44
++      b      44
++   }
++
++   method 'notLessEqual (II)Z' {
++      0      48
++      1      48
++      2      48
++      a      48
++   }
++
++   method 'greaterEqual (DD)Z' {
++      0      52
++      1      52
++      2      52
++      b      52
++   }
++
++   method 'greaterEqual (II)Z' {
++      0      56
++      1      56
++      2      56
++      a      56
++   }
++
++   method 'notGreaterEqual (DD)Z' {
++      0      60
++      1      60
++      2      60
++      b      60
++   }
++
++   method 'notGreaterEqual (II)Z' {
++      0      64
++      1      64
++      2      64
++      a      64
++   }
++}
++
++Lines mapping:
++6 <-> 5
++10 <-> 9
++14 <-> 13
++18 <-> 17
++22 <-> 21
++26 <-> 25
++30 <-> 29
++34 <-> 33
++38 <-> 37
++42 <-> 41
++46 <-> 45
++50 <-> 49
++54 <-> 53
++58 <-> 57
++62 <-> 61
++66 <-> 65
+diff --git a/testData/src/pkg/TestInvertedFloatComparison.java b/testData/src/pkg/TestInvertedFloatComparison.java
+new file mode 100644
+index 0000000..a660d33
+--- /dev/null
++++ b/testData/src/pkg/TestInvertedFloatComparison.java
+@@ -0,0 +1,68 @@
++package pkg;
++
++public class TestInvertedFloatComparison
++{
++  public boolean less(double a, double b) {
++    return a < b;
++  }
++
++  public boolean less(int a, int b) {
++    return a < b;
++  }
++
++  public boolean notLess(double a, double b) {
++    return !(a < b);
++  }
++
++  public boolean notLess(int a, int b) {
++    return !(a < b);
++  }
++
++  public boolean greater(double a, double b) {
++    return a > b;
++  }
++
++  public boolean greater(int a, int b) {
++    return a > b;
++  }
++
++  public boolean notGreater(double a, double b) {
++    return !(a > b);
++  }
++
++  public boolean notGreater(int a, int b) {
++    return !(a > b);
++  }
++
++  public boolean lessEqual(double a, double b) {
++    return a <= b;
++  }
++
++  public boolean lessEqual(int a, int b) {
++    return a <= b;
++  }
++
++  public boolean notLessEqual(double a, double b) {
++    return !(a <= b);
++  }
++
++  public boolean notLessEqual(int a, int b) {
++    return !(a <= b);
++  }
++
++  public boolean greaterEqual(double a, double b) {
++    return a >= b;
++  }
++
++  public boolean greaterEqual(int a, int b) {
++    return a >= b;
++  }
++
++  public boolean notGreaterEqual(double a, double b) {
++    return !(a >= b);
++  }
++
++  public boolean notGreaterEqual(int a, int b) {
++    return !(a >= b);
++  }
++}
+\ No newline at end of file
+-- 
+2.18.0
+

--- a/FernFlower-Patches/0022-Fix-incorrect-decompilation-of-inverted-floating-poi.patch
+++ b/FernFlower-Patches/0022-Fix-incorrect-decompilation-of-inverted-floating-poi.patch
@@ -1,4 +1,4 @@
-From 76dfa9f180041fac7daeba51680a1465426de53d Mon Sep 17 00:00:00 2001
+From d0d1f231f23130fd9a73abcc4bde6f61f7629b53 Mon Sep 17 00:00:00 2001
 From: malte0811 <malte0811@web.de>
 Date: Mon, 23 Jul 2018 15:53:01 +0200
 Subject: [PATCH] Fix incorrect decompilation of inverted floating point
@@ -6,7 +6,7 @@ Subject: [PATCH] Fix incorrect decompilation of inverted floating point
 
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/SecondaryFunctionsHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/SecondaryFunctionsHelper.java
-index a7c804b..149c7ed 100644
+index a7c804b..859f2cb 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/SecondaryFunctionsHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SecondaryFunctionsHelper.java
 @@ -168,8 +168,18 @@ public class SecondaryFunctionsHelper {
@@ -29,17 +29,41 @@ index a7c804b..149c7ed 100644
                  return new FunctionExprent(desttype, funcexpr.getLstOperands(), funcexpr.bytecode);
                }
              }
-@@ -394,10 +404,6 @@ public class SecondaryFunctionsHelper {
+@@ -378,6 +388,7 @@ public class SecondaryFunctionsHelper {
+           FunctionExprent fparam = (FunctionExprent)param;
+ 
+           int ftype = fparam.getFuncType();
++          boolean canSimplify = false;
+           switch (ftype) {
+             case FunctionExprent.FUNCTION_BOOL_NOT:
+               Exprent newexpr = fparam.getLstOperands().get(0);
+@@ -394,12 +405,24 @@ public class SecondaryFunctionsHelper {
                }
              case FunctionExprent.FUNCTION_EQ:
              case FunctionExprent.FUNCTION_NE:
--            case FunctionExprent.FUNCTION_LT:
--            case FunctionExprent.FUNCTION_GE:
--            case FunctionExprent.FUNCTION_GT:
--            case FunctionExprent.FUNCTION_LE:
-               fparam.setFuncType(funcsnot[ftype - FunctionExprent.FUNCTION_EQ]);
-               return fparam;
++              canSimplify = true;
+             case FunctionExprent.FUNCTION_LT:
+             case FunctionExprent.FUNCTION_GE:
+             case FunctionExprent.FUNCTION_GT:
+             case FunctionExprent.FUNCTION_LE:
+-              fparam.setFuncType(funcsnot[ftype - FunctionExprent.FUNCTION_EQ]);
+-              return fparam;
++              if (!canSimplify) {
++                operands = fparam.getLstOperands();
++                VarType left = operands.get(0).getExprType();
++                VarType right = operands.get(1).getExprType();
++                VarType commonSupertype = VarType.getCommonSupertype(left, right);
++                if (commonSupertype != null) {
++                  canSimplify = commonSupertype.type != CodeConstants.TYPE_FLOAT && commonSupertype.type != CodeConstants.TYPE_DOUBLE;
++                }
++              }
++              if (canSimplify) {
++                fparam.setFuncType(funcsnot[ftype - FunctionExprent.FUNCTION_EQ]);
++                return fparam;
++              }
            }
+         }
+       }
 diff --git a/test/org/jetbrains/java/decompiler/SingleClassesTest.java b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
 index d7e814c..eb86822 100644
 --- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java


### PR DESCRIPTION
`a>b` is not the same as `!(a<=b)` for floating point numbers, if `a` or `b` are `NaN`, the first will be false and the second will be true. There is a case of this in `IndirectMerger` in MC 1.13.
There don't seem to be any contributing guidelines for this repo, please tell me if I did anything wrong.