### PR TITLE
Fix the rest of the cases where getClass removal did not work (closes #9)

### DIFF
--- a/FernFlower-Patches/0022-Fix-getClass-removal-not-working-for-some-lambdas.patch
+++ b/FernFlower-Patches/0022-Fix-getClass-removal-not-working-for-some-lambdas.patch
@@ -1,14 +1,44 @@
-From 048c1fab82a216d2eff2499255d69537e7e6dcf2 Mon Sep 17 00:00:00 2001
-From: JDLogic <jrd2558@gmail.com>
-Date: Wed, 25 Jul 2018 20:51:39 -0700
+From c667a5da05e9e57c87a3f2f56d9cc583f9318ac3 Mon Sep 17 00:00:00 2001
+From: Justin <jrd2558@gmail.com>
+Date: Thu, 26 Jul 2018 13:28:40 -0700
 Subject: [PATCH] Fix getClass removal not working for some lambdas
 
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
-index b71a264..d6e972e 100644
+index b71a264..2764c18 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
-@@ -473,8 +473,8 @@ public class SimplifyExprentsHelper {
+@@ -78,6 +78,10 @@ public class SimplifyExprentsHelper {
+           if (processClass14 && (changed = collapseInlinedClass14(st))) {
+             break;
+           }
++
++          if (!st.getStats().isEmpty() && hasQualifiedNewGetClass(st, st.getStats().get(0))) {
++            break;
++          }
+         }
+ 
+         res |= changed;
+@@ -469,21 +473,40 @@ public class SimplifyExprentsHelper {
+     return false;
+   }
+ 
++  private static boolean hasQualifiedNewGetClass(Statement parent, Statement child) {
++    if (child.type == Statement.TYPE_BASICBLOCK && child.getExprents() != null && !child.getExprents().isEmpty()) {
++      Exprent firstExpr = child.getExprents().get(child.getExprents().size() - 1);
++
++      if (parent.type == Statement.TYPE_IF) {
++        if (isQualifiedNewGetClass(firstExpr, ((IfStatement)parent).getHeadexprent().getCondition())) {
++          child.getExprents().remove(firstExpr);
++          return true;
++        }
++      }
++      // TODO DoStatements ?
++    }
++    return false;
++  }
++
+   private static boolean isQualifiedNewGetClass(Exprent first, Exprent second) {
      if (first.type == Exprent.EXPRENT_INVOCATION) {
        InvocationExprent invocation = (InvocationExprent)first;
  
@@ -17,9 +47,14 @@ index b71a264..d6e972e 100644
 +      if (!invocation.isStatic() && (invocation.getInstance().type == Exprent.EXPRENT_VAR || invocation.getInstance().type == Exprent.EXPRENT_FIELD)
 +        && invocation.getName().equals("getClass") && invocation.getStringDescriptor().equals("()Ljava/lang/Class;")) {
  
-         List<Exprent> lstExprents = second.getAllExprents();
+-        List<Exprent> lstExprents = second.getAllExprents();
++        LinkedList<Exprent> lstExprents = new LinkedList<>();
          lstExprents.add(second);
-@@ -483,7 +483,9 @@ public class SimplifyExprentsHelper {
+ 
+-        for (Exprent expr : lstExprents) {
++        while (!lstExprents.isEmpty()){
++          Exprent expr = lstExprents.removeFirst();
++          lstExprents.addAll(expr.getAllExprents());
            if (expr.type == Exprent.EXPRENT_NEW) {
              NewExprent newExpr = (NewExprent)expr;
              if (newExpr.getConstructor() != null && !newExpr.getConstructor().getLstParameters().isEmpty() &&


### PR DESCRIPTION
This fixes two more instances where a `getClass` invocation preceding a lambda was not removed. 

- Where an if statement condition has a method invocation with a lambda parameter
- Where a return statement has a method invocation with a lambda parameter

[Resulting MC diff](https://gist.github.com/JDLogic/4f251a7056f1437734f86f1c6ed44b02)