### PR TITLE
fix extra semicolon in empty blocks

### DIFF
--- a/FernFlower-Patches/0024-fix-extra-semicolon.patch
+++ b/FernFlower-Patches/0024-fix-extra-semicolon.patch
@@ -1,0 +1,25 @@
+From 0bc480185ebcc1e18bfb9cff7ca15141bbc4a8fc Mon Sep 17 00:00:00 2001
+From: temp1011 <34900092+temp1011@users.noreply.github.com>
+Date: Mon, 30 Jul 2018 11:50:09 +0100
+Subject: [PATCH] fixing extra line
+
+
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
+index a3170fd..15f82d8 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
+@@ -778,11 +778,6 @@ public class ExprProcessor implements CodeConstants {
+       }
+     }
+ 
+-    if (buf.length() == 0 && semicolon) {
+-      buf.appendIndent(indent).append(";").appendLineSeparator();
+-      tracer.incrementCurrentSourceLine();
+-    }
+-
+     return buf;
+   }
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
Here is the [diff](https://gist.github.com/temp1011/64fd62095f23249067c8b5ff09928c72) (hopefully I did it right). ~~Seems like my version of FF in MCPConfig was slightly out of date so it accidently includes the results of some other PRs, sorry about that.~~ Hopefully the places where the extra semicolon has been removed are clear.

Some of the empty for loops seen in the diff seem to be bugs anyway, not sure what causes them though.

Hope this helps.