### PR TITLE
MOD HAS DIRECT REFERENCE System.exit() THIS IS NOT ALLOWED REROUTING TO FML!

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,5 @@ task eclipse() {
 }
 
 if (!JavaVersion.current().java9Compatible) {
-    println("You must build this with JDK 9")
-    System.exit(1)
+    throw new RuntimeException("You must build this with JDK 9")
 }


### PR DESCRIPTION
This PR throws an exception instead of using System.exit when using an incompatible JDK version.

System.exit kills the gradle daemon, which is rather annoying due to the loading time (and also creates a _lot_ of verbose debug output which is rather confusing); the exception just fails the build.