### PR TITLE
Give nicer output float literals that were upcasted to doubles

### DIFF
--- a/FernFlower-Patches/0024-Give-nicer-output-float-literals-that-were-upcasted-.patch
+++ b/FernFlower-Patches/0024-Give-nicer-output-float-literals-that-were-upcasted-.patch
@@ -1,0 +1,34 @@
+From aaa97e37ac34c30ff794283124eebcbad3dec409 Mon Sep 17 00:00:00 2001
+From: Pokechu22 <Pokechu022@gmail.com>
+Date: Fri, 3 Aug 2018 14:15:46 -0700
+Subject: [PATCH] Give nicer output float literals that were upcasted to
+ doubles
+
+
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
+index cd08934..06a4abf 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
+@@ -206,6 +206,19 @@ public class ConstExprent extends Exprent {
+           else if (doubleVal == Double.MIN_VALUE) {
+             return new FieldExprent("MIN_VALUE", "java/lang/Double", true, null, FieldDescriptor.DOUBLE_DESCRIPTOR, bytecode).toJava(0, tracer);
+           }
++
++          // Check for cases where a float literal has been upcasted to a double.
++          // (for instance, double d = .01F results in 0.009999999776482582D without this)
++          float nearestFloatVal = (float)doubleVal;
++          if (doubleVal == (double)nearestFloatVal) {
++            // Value can be represented precisely as both a float and a double.
++            // Now check if the string representation as a float is nicer/shorter.
++            // If they're the same, there's no point in the cast and such (e.g. don't decompile 1.0D as (double)1.0F).
++            if (Float.toString(nearestFloatVal).length() < Double.toString(doubleVal).length()) {
++              // Include a cast to prevent using the wrong method call in ambiguous cases.
++              return new TextBuffer().append("(double)").append(trimZeros(Float.toString(nearestFloatVal))).append('F');
++            }
++          }
+         }
+         else if (Double.isNaN(doubleVal)) {
+           return new TextBuffer("0.0D / 0.0D");
+-- 
+2.17.0
+


### PR DESCRIPTION
[Diff for MC code](https://gist.github.com/Pokechu22/eb8befd87db204143bb2d05940025f7b).

This works by checking if a double value is equal to itself when converted to a float and back; if that is the case, then it is likely that it was originally a float literal.  A second check is done to make sure that the float literal is shorter than the double literal, to avoid treating `1` as a float and such.

The resultant code is `(double)0.01F` instead of `0.009999999776482582D`, which is much nicer.  Ideally, it'd be nice to eliminate the explicit `(double)` cast entirely, but there are cases where that'd cause ambiguity problems and as far as I can tell there's no easy way to check if it'd be safe to omit the explicit cast.