### PR TITLE
Give nicer output for float and double literals

### DIFF
--- a/FernFlower-Patches/0024-Give-nicer-output-for-float-and-double-literals.patch
+++ b/FernFlower-Patches/0024-Give-nicer-output-for-float-and-double-literals.patch
@@ -1,0 +1,214 @@
+From 58107d2c58db4b01be8d259287c33f57095a8c75 Mon Sep 17 00:00:00 2001
+From: Pokechu22 <Pokechu022@gmail.com>
+Date: Fri, 3 Aug 2018 14:15:46 -0700
+Subject: [PATCH] Give nicer output for float and double literals
+
+
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
+index cd08934..c72dde1 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
+@@ -33,6 +33,67 @@ public class ConstExprent extends Exprent {
+     CHAR_ESCAPES.put(0x27, "\\\'"); /* \u0027: single quote ' */
+     CHAR_ESCAPES.put(0x5C, "\\\\"); /* \u005c: backslash \ */
+   }
++  private static final Map<Double, String[]> PI_DOUBLES = new HashMap<>();
++  private static final Map<Float, String[]> PI_FLOATS = new HashMap<>();
++  static {
++    final double PI_D = Math.PI;
++    final float PI_F = (float)Math.PI;
++    PI_DOUBLES.put(PI_D, new String[] { "", "" });
++    PI_DOUBLES.put(-PI_D, new String[] { "-", "" });
++    PI_FLOATS.put(PI_F, new String[] { "", "" });
++    PI_FLOATS.put(-PI_F, new String[] { "-", "" });
++
++    PI_DOUBLES.put(PI_D * 2D, new String[] { "(", " * 2D)" });
++    PI_DOUBLES.put(-PI_D * 2D, new String[] { "(-", " * 2D)" });
++    PI_FLOATS.put(PI_F * 2F, new String[] { "(", " * 2F)" });
++    PI_FLOATS.put(-PI_F * 2F, new String[] { "(-", " * 2F)" });
++
++    PI_DOUBLES.put(PI_D / 2D, new String[] { "(", " / 2D)" });
++    PI_DOUBLES.put(-PI_D / 2D, new String[] { "(-", " / 2D)" });
++    PI_FLOATS.put(PI_F / 2F, new String[] { "(", " / 2F)" });
++    PI_FLOATS.put(-PI_F / 2F, new String[] { "(-", " / 2F)" });
++
++    PI_DOUBLES.put(PI_D * 1.5D, new String[] { "(", " * 1.5D)" });
++    PI_DOUBLES.put(-PI_D * 1.5D, new String[] { "(-", " * 1.5D)" });
++    PI_FLOATS.put(PI_F * 1.5F, new String[] { "(", " * 1.5F)" });
++    PI_FLOATS.put(-PI_F * 1.5F, new String[] { "(-", " * 1.5F)" });
++
++    PI_DOUBLES.put(PI_D / 3D, new String[] { "(", " / 3D)" });
++    PI_DOUBLES.put(-PI_D / 3D, new String[] { "(-", " / 3D)" });
++    PI_FLOATS.put(PI_F / 3F, new String[] { "(", " / 3F)" });
++    PI_FLOATS.put(-PI_F / 3F, new String[] { "(-", " / 3F)" });
++
++    PI_DOUBLES.put(PI_D / 4D, new String[] { "(", " / 4D)" });
++    PI_DOUBLES.put(-PI_D / 4D, new String[] { "(-", " / 4D)" });
++    PI_FLOATS.put(PI_F / 4F, new String[] { "(", " / 4F)" });
++    PI_FLOATS.put(-PI_F / 4F, new String[] { "(-", " / 4F)" });
++
++    PI_DOUBLES.put(PI_D / 5D, new String[] { "(", " / 5D)" });
++    PI_DOUBLES.put(-PI_D / 5D, new String[] { "(-", " / 5D)" });
++    PI_FLOATS.put(PI_F / 5F, new String[] { "(", " / 5F)" });
++    PI_FLOATS.put(-PI_F / 5F, new String[] { "(-", " / 5F)" });
++
++    PI_DOUBLES.put(PI_D / 6D, new String[] { "(", " / 6D)" });
++    PI_DOUBLES.put(-PI_D / 6D, new String[] { "(-", " / 6D)" });
++    PI_FLOATS.put(PI_F / 6F, new String[] { "(", " / 6F)" });
++    PI_FLOATS.put(-PI_F / 6F, new String[] { "(-", " / 6F)" });
++
++    PI_DOUBLES.put(PI_D / 8D, new String[] { "(", " / 8D)" });
++    PI_DOUBLES.put(-PI_D / 8D, new String[] { "(-", " / 8D)" });
++    PI_FLOATS.put(PI_F / 8F, new String[] { "(", " / 8F)" });
++    PI_FLOATS.put(-PI_F / 8F, new String[] { "(-", " / 8F)" });
++
++    PI_DOUBLES.put(PI_D / 10D, new String[] { "(", " / 10D)" });
++    PI_DOUBLES.put(-PI_D / 10D, new String[] { "(-", " / 10D)" });
++    PI_FLOATS.put(PI_F / 10F, new String[] { "(", " / 10F)" });
++    PI_FLOATS.put(-PI_F / 10F, new String[] { "(-", " / 10F)" });
++
++    // Radian/degree conversions
++    PI_DOUBLES.put(PI_D / 180D, new String[] { "(", " / 180D)" });
++    PI_DOUBLES.put(180D / PI_D, new String[] { "(180D / ", ")" });
++    PI_FLOATS.put(PI_F / 180F, new String[] { "(", " / 180F)" });
++    PI_FLOATS.put(180F / PI_F, new String[] { "(180F / ", ")" });
++  }
+ 
+   private VarType constType;
+   private final Object value;
+@@ -159,34 +220,7 @@ public class ConstExprent extends Exprent {
+         return new TextBuffer(value.toString()).append('L');
+ 
+       case CodeConstants.TYPE_FLOAT:
+-        float floatVal = (Float)value;
+-        if (!literal) {
+-          if (Float.isNaN(floatVal)) {
+-            return new FieldExprent("NaN", "java/lang/Float", true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer);
+-          }
+-          else if (floatVal == Float.POSITIVE_INFINITY) {
+-            return new FieldExprent("POSITIVE_INFINITY", "java/lang/Float", true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer);
+-          }
+-          else if (floatVal == Float.NEGATIVE_INFINITY) {
+-            return new FieldExprent("NEGATIVE_INFINITY", "java/lang/Float", true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer);
+-          }
+-          else if (floatVal == Float.MAX_VALUE) {
+-            return new FieldExprent("MAX_VALUE", "java/lang/Float", true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer);
+-          }
+-          else if (floatVal == Float.MIN_VALUE) {
+-            return new FieldExprent("MIN_VALUE", "java/lang/Float", true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer);
+-          }
+-        }
+-        else if (Float.isNaN(floatVal)) {
+-          return new TextBuffer("0.0F / 0.0F");
+-        }
+-        else if (floatVal == Float.POSITIVE_INFINITY) {
+-          return new TextBuffer("1.0F / 0.0F");
+-        }
+-        else if (floatVal == Float.NEGATIVE_INFINITY) {
+-          return new TextBuffer("-1.0F / 0.0F");
+-        }
+-        return new TextBuffer(trimZeros(value.toString())).append('F');
++        return createFloat(literal, (Float)value, tracer);
+ 
+       case CodeConstants.TYPE_DOUBLE:
+         double doubleVal = (Double)value;
+@@ -203,9 +237,32 @@ public class ConstExprent extends Exprent {
+           else if (doubleVal == Double.MAX_VALUE) {
+             return new FieldExprent("MAX_VALUE", "java/lang/Double", true, null, FieldDescriptor.DOUBLE_DESCRIPTOR, bytecode).toJava(0, tracer);
+           }
++          else if (doubleVal == Double.MIN_NORMAL) {
++            return new FieldExprent("MIN_NORMAL", "java/lang/Double", true, null, FieldDescriptor.DOUBLE_DESCRIPTOR, bytecode).toJava(0, tracer);
++          }
+           else if (doubleVal == Double.MIN_VALUE) {
+             return new FieldExprent("MIN_VALUE", "java/lang/Double", true, null, FieldDescriptor.DOUBLE_DESCRIPTOR, bytecode).toJava(0, tracer);
+           }
++          else if (doubleVal == Math.E) {
++            return new FieldExprent("E", "java/lang/Math", true, null, FieldDescriptor.DOUBLE_DESCRIPTOR, bytecode).toJava(0, tracer);
++          }
++          else if (PI_DOUBLES.containsKey(doubleVal)) {
++            String[] parts = PI_DOUBLES.get(doubleVal);
++            return getPiDouble(tracer).enclose(parts[0], parts[1]);
++          }
++
++          // Check for cases where a float literal has been upcasted to a double.
++          // (for instance, double d = .01F results in 0.009999999776482582D without this)
++          float nearestFloatVal = (float)doubleVal;
++          if (doubleVal == (double)nearestFloatVal) {
++            // Value can be represented precisely as both a float and a double.
++            // Now check if the string representation as a float is nicer/shorter.
++            // If they're the same, there's no point in the cast and such (e.g. don't decompile 1.0D as (double)1.0F).
++            if (Float.toString(nearestFloatVal).length() < Double.toString(doubleVal).length()) {
++              // Include a cast to prevent using the wrong method call in ambiguous cases.
++              return createFloat(literal, nearestFloatVal, tracer).prepend("(double)");
++            }
++          }
+         }
+         else if (Double.isNaN(doubleVal)) {
+           return new TextBuffer("0.0D / 0.0D");
+@@ -234,7 +291,62 @@ public class ConstExprent extends Exprent {
+ 
+     throw new RuntimeException("invalid constant type: " + constType);
+   }
+-  
++
++  private TextBuffer createFloat(boolean literal, float floatVal, BytecodeMappingTracer tracer) {
++    if (!literal) {
++      // Float constants, some of which can't be represented directly
++      if (Float.isNaN(floatVal)) {
++        return new FieldExprent("NaN", "java/lang/Float", true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer);
++      }
++      else if (floatVal == Float.POSITIVE_INFINITY) {
++        return new FieldExprent("POSITIVE_INFINITY", "java/lang/Float", true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer);
++      }
++      else if (floatVal == Float.NEGATIVE_INFINITY) {
++        return new FieldExprent("NEGATIVE_INFINITY", "java/lang/Float", true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer);
++      }
++      else if (floatVal == Float.MAX_VALUE) {
++        return new FieldExprent("MAX_VALUE", "java/lang/Float", true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer);
++      }
++      else if (floatVal == Float.MIN_NORMAL) {
++        return new FieldExprent("MIN_NORMAL", "java/lang/Float", true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer);
++      }
++      else if (floatVal == Float.MIN_VALUE) {
++        return new FieldExprent("MIN_VALUE", "java/lang/Float", true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer);
++      }
++      // Math constants
++      else if (floatVal == (float)Math.E) {
++        return new FieldExprent("E", "java/lang/Math", true, null, FieldDescriptor.DOUBLE_DESCRIPTOR, bytecode).toJava(0, tracer).prepend("(float)");
++      }
++      else if (PI_FLOATS.containsKey(floatVal)) {
++        String[] parts = PI_FLOATS.get(floatVal);
++        return getPiFloat(tracer).enclose(parts[0], parts[1]);
++      }
++    }
++    else {
++      // Check for special values that can't be used directly in code
++      // (and we can't replace with the constant due to the user requesting not to)
++      if (Float.isNaN(floatVal)) {
++        return new TextBuffer("0.0F / 0.0F");
++      }
++      else if (floatVal == Float.POSITIVE_INFINITY) {
++        return new TextBuffer("1.0F / 0.0F");
++      }
++      else if (floatVal == Float.NEGATIVE_INFINITY) {
++        return new TextBuffer("-1.0F / 0.0F");
++      }
++    }
++    return new TextBuffer(trimZeros(Float.toString(floatVal))).append('F');
++  }
++
++  private TextBuffer getPiDouble(BytecodeMappingTracer tracer) {
++    return new FieldExprent("PI", "java/lang/Math", true, null, FieldDescriptor.DOUBLE_DESCRIPTOR, bytecode).toJava(0, tracer);
++  }
++
++  private TextBuffer getPiFloat(BytecodeMappingTracer tracer) {
++    // java.lang.Math doesn't have a float version of pi, unfortunately
++    return getPiDouble(tracer).prepend("(float)");
++  }
++
+   // Different JVM implementations/version display Floats and Doubles with different number of trailing zeros.
+   // This trims them all down to only the necessary amount.
+   private static String trimZeros(String value) {
+-- 
+2.17.0
+


### PR DESCRIPTION
This replaces PR #23.  MC source diff [from master](https://gist.github.com/Pokechu22/a81add210098319038991f2bec12ba56) and [from that PR](https://gist.github.com/Pokechu22/24f566d9307daf1377a22cc788466197).

The main difference is that this implementation also cleans up fractions of Pi.  While ForgeGradle previously [handled this itself](https://github.com/MinecraftForge/ForgeGradle/blob/c9bb57920456fb8e982c43c71d8726102d307b09/src/main/java/net/minecraftforge/gradle/util/mcp/McpCleanup.java#L250-L251), this is something that really belongs in the decompiler.  I don't include some of the factors that it had there (2 Pi / 9, 2 Pi / 5, 7 Pi / 100, and 185 Pi / 100), but most of those are extremely rare in practice (they only appear once or in fact never appear in MC source, while other ones do); I also added a few more of them that weren't there (e.g. Pi / 180, which appears in radian conversions).

One thing about this that is slightly ugly is the casts; since there is no `Math.PI_FLOAT`, `(float)Math.PI` is used instead.  I'm almost certain Mojang has some kind of `float MathHelper.PI = (float)Math.PI` that causes some of these weird cases.  If we decide to reintroduce a field like that, it should be fairly easy to switch to referencing that.  An extra ugly side effect of this is that code like `(double)((float)Math.PI * 2F)` is generated in some places; being able to omit both casts when context allows it would be nice eventually.