### PR TITLE
Fix ambiguous lambdas

### DIFF
--- a/FernFlower-Patches/0029-Fix-ambiguous-lambdas.patch
+++ b/FernFlower-Patches/0029-Fix-ambiguous-lambdas.patch
@@ -1,0 +1,145 @@
+From e279651cd223af9a9a2ab8a8dcb339eeb94580a4 Mon Sep 17 00:00:00 2001
+From: Justin <jrd2558@gmail.com>
+Date: Wed, 19 Sep 2018 22:51:00 -0700
+Subject: [PATCH] Fix ambiguous lambdas
+
+
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
+index a3170fd9..b23f562b 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
+@@ -883,6 +883,9 @@ public class ExprProcessor implements CodeConstants {
+       (castNull && rightType.type == CodeConstants.TYPE_NULL && !UNDEFINED_TYPE_STRING.equals(getTypeName(leftType))) ||
+       (castNarrowing && isIntConstant(exprent) && isNarrowedIntType(leftType));
+ 
++    boolean castLambda = !cast && exprent.type == Exprent.EXPRENT_NEW && !leftType.equals(rightType) &&
++                          lambdaNeedsCast(leftType, (NewExprent)exprent);
++
+     boolean quote = cast && exprent.getPrecedence() >= FunctionExprent.getPrecedence(FunctionExprent.FUNCTION_CAST);
+ 
+     // cast instead to 'byte' / 'short' when int constant is used as a value for 'Byte' / 'Short'
+@@ -897,6 +900,8 @@ public class ExprProcessor implements CodeConstants {
+ 
+     if (cast) buffer.append('(').append(getCastTypeName(leftType)).append(')');
+ 
++    if (castLambda) buffer.append('(').append(getCastTypeName(rightType)).append(')');
++
+     if (quote) buffer.append('(');
+ 
+     if (exprent.type == Exprent.EXPRENT_CONST) {
+@@ -929,4 +934,12 @@ public class ExprProcessor implements CodeConstants {
+     return VarType.VARTYPE_INT.isStrictSuperset(type) ||
+            type.equals(VarType.VARTYPE_BYTE_OBJ) || type.equals(VarType.VARTYPE_SHORT_OBJ);
+   }
++
++  private static boolean lambdaNeedsCast(VarType left, NewExprent exprent) {
++    if (exprent.isLambda() && !exprent.isMethodReference()) {
++      StructClass cls = DecompilerContext.getStructContext().getClass(left.value);
++      return cls == null || cls.getMethod(exprent.getLambdaMethodKey()) == null;
++    }
++    return false;
++  }
+ }
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
+index a2906b1d..dc536d75 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
+@@ -733,7 +733,8 @@ public class InvocationExprent extends Exprent {
+       if (md.params.length == lstParameters.size()) {
+         boolean exact = true;
+         for (int i = 0; i < md.params.length; i++) {
+-          if (!md.params[i].equals(lstParameters.get(i).getExprType())) {
++          Exprent exp = lstParameters.get(i);
++          if (!md.params[i].equals(exp.getExprType()) || (exp.type == EXPRENT_NEW && ((NewExprent)exp).isLambda() && !((NewExprent)exp).isMethodReference())) {
+             exact = false;
+             missed.set(i);
+           }
+@@ -747,7 +748,8 @@ public class InvocationExprent extends Exprent {
+       boolean failed = false;
+       MethodDescriptor md = MethodDescriptor.parseDescriptor(mtt.getDescriptor());
+       for (int i = 0; i < lstParameters.size(); i++) {
+-        VarType ptype = lstParameters.get(i).getExprType();
++        Exprent exp = lstParameters.get(i);
++        VarType ptype = exp.getExprType();
+         if (!missed.get(i)) {
+           if (!md.params[i].equals(ptype)) {
+             failed = true;
+@@ -755,6 +757,17 @@ public class InvocationExprent extends Exprent {
+           }
+         }
+         else {
++          if (exp.type == EXPRENT_NEW) {
++            NewExprent newExp = (NewExprent)exp;
++            if (newExp.isLambda() && !newExp.isMethodReference() && !DecompilerContext.getStructContext().instanceOf(md.params[i].value, exp.getExprType().value)) {
++              StructClass pcls = DecompilerContext.getStructContext().getClass(md.params[i].value);
++              if (pcls != null && pcls.getMethod(newExp.getLambdaMethodKey()) == null) {
++                failed = true;
++                break;
++              }
++              continue;
++            }
++          }
+           if (md.params[i].type == CodeConstants.TYPE_OBJECT) {
+             if (ptype.type != CodeConstants.TYPE_NULL) {
+               if (!DecompilerContext.getStructContext().instanceOf(ptype.value, md.params[i].value)) {
+@@ -781,7 +794,10 @@ public class InvocationExprent extends Exprent {
+       for (StructMethod mtt : mtds) {
+ 
+         if (mtt.getSignature() != null && mtt.getSignature().parameterTypes.get(i).isGeneric()) {
+-          break;
++          Exprent exp = lstParameters.get(i);
++          if (exp.type != EXPRENT_NEW || !((NewExprent)exp).isLambda() || ((NewExprent)exp).isMethodReference()) {
++            break;
++          }
+         }
+ 
+         MethodDescriptor md = MethodDescriptor.parseDescriptor(mtt.getDescriptor());
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
+index ad5bcbb5..2c8a5dc8 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
+@@ -7,6 +7,7 @@ import org.jetbrains.java.decompiler.code.CodeConstants;
+ import org.jetbrains.java.decompiler.main.ClassWriter;
+ import org.jetbrains.java.decompiler.main.ClassesProcessor.ClassNode;
+ import org.jetbrains.java.decompiler.main.DecompilerContext;
++import org.jetbrains.java.decompiler.struct.consts.PrimitiveConstant;
+ import org.jetbrains.java.decompiler.util.TextBuffer;
+ import org.jetbrains.java.decompiler.main.collectors.BytecodeMappingTracer;
+ import org.jetbrains.java.decompiler.main.extern.IFernflowerLogger;
+@@ -34,6 +35,7 @@ public class NewExprent extends Exprent {
+   private boolean isVarArgParam;
+   private boolean anonymous;
+   private boolean lambda;
++  private boolean methodReference = false;
+   private boolean enumConst;
+   private List<VarType> genericArgs = new ArrayList<>();
+ 
+@@ -54,6 +56,7 @@ public class NewExprent extends Exprent {
+         anonymous = true;
+         if (node.type == ClassNode.CLASS_LAMBDA) {
+           lambda = true;
++          methodReference = node.lambdaInformation.is_method_reference;
+         }
+       }
+     }
+@@ -509,4 +512,17 @@ public class NewExprent extends Exprent {
+   public void setEnumConst(boolean enumConst) {
+     this.enumConst = enumConst;
+   }
++
++  public boolean isMethodReference() {
++    return methodReference;
++  }
++
++  public String getLambdaMethodKey() {
++    ClassNode node = DecompilerContext.getClassProcessor().getMapRootClasses().get(newType.value);
++    if (node != null && constructor != null) {
++      String descriptor = ((PrimitiveConstant)constructor.getBootstrapArguments().get(0)).getString();
++      return InterpreterUtil.makeUniqueKey(node.lambdaInformation.method_name, descriptor);
++    }
++    return "";
++  }
+ }
+-- 
+2.17.1 (Apple Git-112)
+


### PR DESCRIPTION
Casts lambda type when the type cannot be directly inferred.
Casts lambda type to prevent ambiguous method calls.

[1.13.1 Diff](https://gist.github.com/JDLogic/6247e95b5d36bee4463f7aab6ca53201)