### PR TITLE
 Convert references to -Double.MAX_VALUE and similar

### DIFF
--- a/FernFlower-Patches/0024-Give-nicer-output-for-float-and-double-literals.patch
+++ b/FernFlower-Patches/0024-Give-nicer-output-for-float-and-double-literals.patch
@@ -1,11 +1,11 @@
-From 58107d2c58db4b01be8d259287c33f57095a8c75 Mon Sep 17 00:00:00 2001
+From 22ed255131d9594e619d9de1149ee3b7fcb4c813 Mon Sep 17 00:00:00 2001
 From: Pokechu22 <Pokechu022@gmail.com>
 Date: Fri, 3 Aug 2018 14:15:46 -0700
 Subject: [PATCH] Give nicer output for float and double literals
 
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
-index cd08934..c72dde1 100644
+index cd08934..7960445 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
 @@ -33,6 +33,67 @@ public class ConstExprent extends Exprent {
@@ -112,7 +112,7 @@ index cd08934..c72dde1 100644
  
        case CodeConstants.TYPE_DOUBLE:
          double doubleVal = (Double)value;
-@@ -203,9 +237,32 @@ public class ConstExprent extends Exprent {
+@@ -203,9 +237,41 @@ public class ConstExprent extends Exprent {
            else if (doubleVal == Double.MAX_VALUE) {
              return new FieldExprent("MAX_VALUE", "java/lang/Double", true, null, FieldDescriptor.DOUBLE_DESCRIPTOR, bytecode).toJava(0, tracer);
            }
@@ -122,6 +122,15 @@ index cd08934..c72dde1 100644
            else if (doubleVal == Double.MIN_VALUE) {
              return new FieldExprent("MIN_VALUE", "java/lang/Double", true, null, FieldDescriptor.DOUBLE_DESCRIPTOR, bytecode).toJava(0, tracer);
            }
++          else if (doubleVal == -Double.MAX_VALUE) {
++            return new FieldExprent("MAX_VALUE", "java/lang/Double", true, null, FieldDescriptor.DOUBLE_DESCRIPTOR, bytecode).toJava(0, tracer).prepend("-");
++          }
++          else if (doubleVal == -Double.MIN_NORMAL) {
++            return new FieldExprent("MIN_NORMAL", "java/lang/Double", true, null, FieldDescriptor.DOUBLE_DESCRIPTOR, bytecode).toJava(0, tracer).prepend("-");
++          }
++          else if (doubleVal == -Double.MIN_VALUE) {
++            return new FieldExprent("MIN_VALUE", "java/lang/Double", true, null, FieldDescriptor.DOUBLE_DESCRIPTOR, bytecode).toJava(0, tracer).prepend("-");
++          }
 +          else if (doubleVal == Math.E) {
 +            return new FieldExprent("E", "java/lang/Math", true, null, FieldDescriptor.DOUBLE_DESCRIPTOR, bytecode).toJava(0, tracer);
 +          }
@@ -145,7 +154,7 @@ index cd08934..c72dde1 100644
          }
          else if (Double.isNaN(doubleVal)) {
            return new TextBuffer("0.0D / 0.0D");
-@@ -234,7 +291,62 @@ public class ConstExprent extends Exprent {
+@@ -234,7 +300,71 @@ public class ConstExprent extends Exprent {
  
      throw new RuntimeException("invalid constant type: " + constType);
    }
@@ -171,6 +180,15 @@ index cd08934..c72dde1 100644
 +      }
 +      else if (floatVal == Float.MIN_VALUE) {
 +        return new FieldExprent("MIN_VALUE", "java/lang/Float", true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer);
++      }
++      else if (floatVal == -Float.MAX_VALUE) {
++        return new FieldExprent("MAX_VALUE", "java/lang/Float", true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer).prepend("-");
++      }
++      else if (floatVal == -Float.MIN_NORMAL) {
++        return new FieldExprent("MIN_NORMAL", "java/lang/Float", true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer).prepend("-");
++      }
++      else if (floatVal == -Float.MIN_VALUE) {
++        return new FieldExprent("MIN_VALUE", "java/lang/Float", true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer).prepend("-");
 +      }
 +      // Math constants
 +      else if (floatVal == (float)Math.E) {

--- a/FernFlower-Patches/0030-Fix-super-qualifier-for-default-interfaces.patch
+++ b/FernFlower-Patches/0030-Fix-super-qualifier-for-default-interfaces.patch
@@ -1,11 +1,11 @@
-From 19f0588a95a93bbf6706cb76c2091d2b296e3111 Mon Sep 17 00:00:00 2001
+From aa0004a612d6aedcc101ab420247cd99b0ab6279 Mon Sep 17 00:00:00 2001
 From: Justin <jrd2558@gmail.com>
 Date: Wed, 19 Sep 2018 23:09:10 -0700
 Subject: [PATCH] Fix super qualifier for default interfaces
 
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index a2906b1d..50b86264 100644
+index dc536d7..f5ec40d 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -299,7 +299,9 @@ public class InvocationExprent extends Exprent {
@@ -20,7 +20,7 @@ index a2906b1d..50b86264 100644
            }
          }
 diff --git a/test/org/jetbrains/java/decompiler/SingleClassesTest.java b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
-index 89bab11f..e5e3db65 100644
+index 89bab11..e5e3db6 100644
 --- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
 +++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
 @@ -88,6 +88,7 @@ public class SingleClassesTest extends SingleClassesTestBase {
@@ -40,5 +40,5 @@ index 89bab11f..e5e3db65 100644
    @Test public void testGroovyClass() { doTest("pkg/TestGroovyClass"); }
    @Test public void testGroovyTrait() { doTest("pkg/TestGroovyTrait"); }
 -- 
-2.17.1 (Apple Git-112)
+2.17.0
 


### PR DESCRIPTION
I missed doing this in #24, and only thought of it while in the process of upstreaming.  [Diff for 1.13 between `1.5.380.22` and `1.5.380.24-float-literals-3`](https://gist.github.com/Pokechu22/20c49eb4daacf258fe2ee6a69cbf2f3a).

This also fixes there being two patches numbered 0029, one from #34 and one from #35.