### PR TITLE
Check method access when looking for ambiguous method calls

### DIFF
--- a/FernFlower-Patches/0010-Rework-of-Generics-system-for-better-output.patch
+++ b/FernFlower-Patches/0010-Rework-of-Generics-system-for-better-output.patch
@@ -1,4 +1,4 @@
-From 6efbc3b4e49b8915bc86e68a4c4b2103b35b0df8 Mon Sep 17 00:00:00 2001
+From d47b2e0eb06c6aaf79b8c8606d32e02888d6d15f Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Fri, 14 Apr 2017 17:09:41 -0700
 Subject: [PATCH] Rework of Generics system for better output
@@ -385,7 +385,7 @@ index f75d751..9c706f7 100644
 \ No newline at end of file
 +}
 diff --git a/src/org/jetbrains/java/decompiler/main/Fernflower.java b/src/org/jetbrains/java/decompiler/main/Fernflower.java
-index 1ad0080..f1cb1d2 100644
+index 1ad0080..5ba8d13 100644
 --- a/src/org/jetbrains/java/decompiler/main/Fernflower.java
 +++ b/src/org/jetbrains/java/decompiler/main/Fernflower.java
 @@ -6,6 +6,7 @@ package org.jetbrains.java.decompiler.main;
@@ -409,10 +409,15 @@ index 1ad0080..f1cb1d2 100644
  
  public class Fernflower implements IDecompiledData {
    private final StructContext structContext;
-@@ -35,6 +40,10 @@ public class Fernflower implements IDecompiledData {
+@@ -35,6 +40,15 @@ public class Fernflower implements IDecompiledData {
      }
  
      DecompilerContext.initContext(options, logger, structContext, classProcessor, interceptor);
++
++    String vendor = System.getProperty("java.vendor", "missing vendor");
++    String javaVersion = System.getProperty("java.version", "missing java version");
++    String jvmVersion = System.getProperty("java.vm.version", "missing jvm version");
++    logger.writeMessage(String.format("JVM info: %s - %s - %s", vendor, javaVersion, jvmVersion), IFernflowerLogger.Severity.INFO);
 +
 +    if (DecompilerContext.getOption(IFernflowerPreferences.INCLUDE_ENTIRE_CLASSPATH)) {
 +      ClasspathScanner.addAllClasspath(structContext);
@@ -2941,5 +2946,5 @@ index 0000000..c45ac50
 +  }
 +}
 -- 
-2.14.1.windows.1
+2.17.2 (Apple Git-113)
 

--- a/FernFlower-Patches/0018-Enhance-Generic-Invocations-Temporarily.patch
+++ b/FernFlower-Patches/0018-Enhance-Generic-Invocations-Temporarily.patch
@@ -1,4 +1,4 @@
-From e7f97804d33f94828df08331d7042c0747adddff Mon Sep 17 00:00:00 2001
+From fbf3ef737adc8d748dfdb693ce67bf2438240115 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Fri, 16 Feb 2018 22:04:00 -0800
 Subject: [PATCH] Enhance Generic Invocations Temporarily.
@@ -54,10 +54,27 @@ index 9025746..bf30fd0 100644
 \ No newline at end of file
 +}
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 740b37c..a2906b1 100644
+index 740b37c..8e798b0 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-@@ -481,6 +481,22 @@ public class InvocationExprent extends Exprent {
+@@ -394,6 +394,7 @@ public class InvocationExprent extends Exprent {
+         isEnum = newNode.classStruct.hasModifier(CodeConstants.ACC_ENUM) && DecompilerContext.getOption(IFernflowerPreferences.DECOMPILE_ENUM);
+       }
+     }
++    StructClass currCls = ((ClassNode)DecompilerContext.getProperty(DecompilerContext.CURRENT_CLASS_NODE)).classStruct;
+     List<StructMethod> matches = getMatchedDescriptors();
+     BitSet setAmbiguousParameters = getAmbiguousParameters(matches);
+     StructMethod desc = null;
+@@ -454,7 +455,7 @@ public class InvocationExprent extends Exprent {
+         if (stClass != null) {
+           nextMethod:
+           for (StructMethod mt : stClass.getMethods()) {
+-            if (name.equals(mt.getName())) {
++            if (name.equals(mt.getName()) && canAccess(currCls, mt)) {
+               MethodDescriptor md = MethodDescriptor.parseDescriptor(mt.getDescriptor());
+               if (md.params.length == descriptor.params.length) {
+                 for (int x = 0; x < md.params.length; x++) {
+@@ -481,6 +482,22 @@ public class InvocationExprent extends Exprent {
  
      }
  
@@ -80,7 +97,11 @@ index 740b37c..a2906b1 100644
  
      boolean firstParameter = true;
      for (int i = start; i < lstParameters.size(); i++) {
-@@ -646,24 +662,62 @@ public class InvocationExprent extends Exprent {
+@@ -643,27 +660,98 @@ public class InvocationExprent extends Exprent {
+ 
+   private List<StructMethod> getMatchedDescriptors() {
+     List<StructMethod> matches = new ArrayList<>();
++    StructClass currCls = ((ClassNode)DecompilerContext.getProperty(DecompilerContext.CURRENT_CLASS_NODE)).classStruct;
      StructClass cl = DecompilerContext.getStructContext().getClass(classname);
      if (cl == null) return matches;
  
@@ -105,7 +126,7 @@ index 740b37c..a2906b1 100644
 +      for (StructMethod mt : cls.getMethods()) {
 +        if (name.equals(mt.getName())) {
 +          MethodDescriptor md = MethodDescriptor.parseDescriptor(mt.getDescriptor());
-+          if (matches(md.params, descriptor.params)) {
++          if (matches(md.params, descriptor.params) && canAccess(currCls, mt)) {
 +            matches.add(mt);
 +          }
 +        }
@@ -150,6 +171,38 @@ index 740b37c..a2906b1 100644
 +    return false;
 +  }
 +
++  private boolean canAccess(StructClass currCls, StructMethod mt) {
++    if (mt.hasModifier(CodeConstants.ACC_PUBLIC)) {
++      return true;
++    }
++    else if (mt.hasModifier(CodeConstants.ACC_PRIVATE)) {
++      return mt.getClassStruct().qualifiedName.equals(currCls.qualifiedName);
++    }
++    else if (mt.hasModifier(CodeConstants.ACC_PROTECTED)) {
++      boolean samePackage = isInSamePackage(currCls.qualifiedName, mt.getClassStruct().qualifiedName);
++      return samePackage || DecompilerContext.getStructContext().instanceOf(currCls.qualifiedName, mt.getClassStruct().qualifiedName);
++    }
++    else {
++      return isInSamePackage(currCls.qualifiedName, mt.getClassStruct().qualifiedName);
++    }
++  }
++
++  private boolean isInSamePackage(String class1, String class2) {
++    int pos1 = class1.lastIndexOf('/');
++    int pos2 = class2.lastIndexOf('/');
++    if (pos1 != pos2) {
++      return false;
++    }
++
++    if (pos1 == -1) {
++      return true;
++    }
++
++    String pkg1 = class1.substring(0, pos1);
++    String pkg2 = class2.substring(0, pos2);
++    return pkg1.equals(pkg2);
++  }
++
    private BitSet getAmbiguousParameters(List<StructMethod> matches) {
      StructClass cl = DecompilerContext.getStructContext().getClass(classname);
      if (cl == null || matches.size() == 1) {
@@ -190,5 +243,5 @@ index 39fe8a6..e7e1e4e 100644
      return interfaceNames[i];
    }
 -- 
-2.14.1.windows.1
+2.17.2 (Apple Git-113)
 

--- a/FernFlower-Patches/0022-Synthetic-getClass-cleanup.patch
+++ b/FernFlower-Patches/0022-Synthetic-getClass-cleanup.patch
@@ -1,4 +1,4 @@
-From 1c094fe69d4841c2d4cb3807a5a244affda47336 Mon Sep 17 00:00:00 2001
+From 2bf7ff28e0fc4dfaaf3bc837438e5a196bd104d1 Mon Sep 17 00:00:00 2001
 From: Justin <jrd2558@gmail.com>
 Date: Thu, 26 Jul 2018 13:28:40 -0700
 Subject: [PATCH] Synthetic getClass cleanup
@@ -94,7 +94,7 @@ index b71a264..0b0fb48 100644
                String classname = newExpr.getNewType().value;
                ClassNode node = DecompilerContext.getClassProcessor().getMapRootClasses().get(classname);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index a2906b1..6a35ad4 100644
+index 8e798b0..caaf3bd 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -61,6 +61,7 @@ public class InvocationExprent extends Exprent {
@@ -113,7 +113,7 @@ index a2906b1..6a35ad4 100644
    }
  
    @Override
-@@ -898,6 +900,14 @@ public class InvocationExprent extends Exprent {
+@@ -932,6 +934,14 @@ public class InvocationExprent extends Exprent {
      return bootstrapArguments;
    }
  

--- a/FernFlower-Patches/0029-Fix-ambiguous-lambdas.patch
+++ b/FernFlower-Patches/0029-Fix-ambiguous-lambdas.patch
@@ -1,4 +1,4 @@
-From 29a38693b8e7ea989fab718306dc8a7e97cf430f Mon Sep 17 00:00:00 2001
+From 1314bac5cc5be1728f30bde4f85508bb4b6f6062 Mon Sep 17 00:00:00 2001
 From: Justin <jrd2558@gmail.com>
 Date: Wed, 19 Sep 2018 22:51:00 -0700
 Subject: [PATCH] Fix ambiguous lambdas
@@ -41,10 +41,10 @@ index 12cf86d..1759538 100644
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 6a35ad4..5e8bfcc 100644
+index caaf3bd..12b2483 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-@@ -735,7 +735,8 @@ public class InvocationExprent extends Exprent {
+@@ -769,7 +769,8 @@ public class InvocationExprent extends Exprent {
        if (md.params.length == lstParameters.size()) {
          boolean exact = true;
          for (int i = 0; i < md.params.length; i++) {
@@ -54,7 +54,7 @@ index 6a35ad4..5e8bfcc 100644
              exact = false;
              missed.set(i);
            }
-@@ -749,7 +750,8 @@ public class InvocationExprent extends Exprent {
+@@ -783,7 +784,8 @@ public class InvocationExprent extends Exprent {
        boolean failed = false;
        MethodDescriptor md = MethodDescriptor.parseDescriptor(mtt.getDescriptor());
        for (int i = 0; i < lstParameters.size(); i++) {
@@ -64,7 +64,7 @@ index 6a35ad4..5e8bfcc 100644
          if (!missed.get(i)) {
            if (!md.params[i].equals(ptype)) {
              failed = true;
-@@ -757,6 +759,17 @@ public class InvocationExprent extends Exprent {
+@@ -791,6 +793,17 @@ public class InvocationExprent extends Exprent {
            }
          }
          else {
@@ -82,7 +82,7 @@ index 6a35ad4..5e8bfcc 100644
            if (md.params[i].type == CodeConstants.TYPE_OBJECT) {
              if (ptype.type != CodeConstants.TYPE_NULL) {
                if (!DecompilerContext.getStructContext().instanceOf(ptype.value, md.params[i].value)) {
-@@ -783,7 +796,10 @@ public class InvocationExprent extends Exprent {
+@@ -817,7 +830,10 @@ public class InvocationExprent extends Exprent {
        for (StructMethod mtt : mtds) {
  
          if (mtt.getSignature() != null && mtt.getSignature().parameterTypes.get(i).isGeneric()) {
@@ -141,5 +141,5 @@ index ad5bcbb..2c8a5dc 100644
 +  }
  }
 -- 
-2.19.1.windows.1
+2.17.2 (Apple Git-113)
 

--- a/FernFlower-Patches/0030-Fix-super-qualifier-for-default-interfaces.patch
+++ b/FernFlower-Patches/0030-Fix-super-qualifier-for-default-interfaces.patch
@@ -1,11 +1,11 @@
-From 4e4cacced287d20c8a8f5d351b428642423a9762 Mon Sep 17 00:00:00 2001
+From eea86a7039714a70e50fac6c1c59a9b5af2a6a16 Mon Sep 17 00:00:00 2001
 From: Justin <jrd2558@gmail.com>
 Date: Wed, 19 Sep 2018 23:09:10 -0700
 Subject: [PATCH] Fix super qualifier for default interfaces
 
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 5e8bfcc..2ed9539 100644
+index 12b2483..5c66d04 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -301,7 +301,9 @@ public class InvocationExprent extends Exprent {
@@ -40,5 +40,5 @@ index c979356..00c61db 100644
    @Test public void testGroovyClass() { doTest("pkg/TestGroovyClass"); }
    @Test public void testGroovyTrait() { doTest("pkg/TestGroovyTrait"); }
 -- 
-2.19.1.windows.1
+2.17.2 (Apple Git-113)
 

--- a/FernFlower-Patches/0031-Improve-inferred-generic-types.patch
+++ b/FernFlower-Patches/0031-Improve-inferred-generic-types.patch
@@ -1,4 +1,4 @@
-From c633c6509923b9608f10179d02b71301a3cd449a Mon Sep 17 00:00:00 2001
+From dac609fc379ccd535ddb5ebcd3b7fd2d004dc4e3 Mon Sep 17 00:00:00 2001
 From: Justin <jrd2558@gmail.com>
 Date: Tue, 30 Apr 2019 10:34:56 -0700
 Subject: [PATCH] Improve inferred generic types
@@ -194,7 +194,7 @@ index bf30fd0..1da5acf 100644
    public void getBytecodeRange(BitSet values) {
      measureBytecode(values, lstOperands);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 2ed9539..6700268 100644
+index 5c66d04..469fdac 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -53,6 +53,7 @@ public class InvocationExprent extends Exprent {
@@ -534,8 +534,8 @@ index 2ed9539..6700268 100644
      List<VarVersionPair> mask = null;
      boolean isEnum = false;
      if (functype == TYP_INIT) {
-@@ -400,28 +621,6 @@ public class InvocationExprent extends Exprent {
-     }
+@@ -401,28 +622,6 @@ public class InvocationExprent extends Exprent {
+     StructClass currCls = ((ClassNode)DecompilerContext.getProperty(DecompilerContext.CURRENT_CLASS_NODE)).classStruct;
      List<StructMethod> matches = getMatchedDescriptors();
      BitSet setAmbiguousParameters = getAmbiguousParameters(matches);
 -    StructMethod desc = null;
@@ -563,7 +563,7 @@ index 2ed9539..6700268 100644
  
      // omit 'new Type[] {}' for the last parameter of a vararg method call
      if (lstParameters.size() == descriptor.params.length && isVarArgCall()) {
-@@ -485,20 +684,33 @@ public class InvocationExprent extends Exprent {
+@@ -486,20 +685,33 @@ public class InvocationExprent extends Exprent {
  
      }
  
@@ -610,7 +610,7 @@ index 2ed9539..6700268 100644
      }
  
  
-@@ -537,6 +749,11 @@ public class InvocationExprent extends Exprent {
+@@ -538,6 +750,11 @@ public class InvocationExprent extends Exprent {
          */
  
          Exprent param = unboxIfNeeded(lstParameters.get(i));
@@ -622,7 +622,7 @@ index 2ed9539..6700268 100644
          // 'byte' and 'short' literals need an explicit narrowing type cast when used as a parameter
          ExprProcessor.getCastedExprent(param, types[i], buff, indent, true, ambiguous, true, tracer);
  
-@@ -552,8 +769,6 @@ public class InvocationExprent extends Exprent {
+@@ -553,8 +770,6 @@ public class InvocationExprent extends Exprent {
        }
      }
  
@@ -631,7 +631,7 @@ index 2ed9539..6700268 100644
      return buf;
    }
  
-@@ -814,6 +1029,155 @@ public class InvocationExprent extends Exprent {
+@@ -848,6 +1063,155 @@ public class InvocationExprent extends Exprent {
      return ambiguous;
    }
  
@@ -787,7 +787,7 @@ index 2ed9539..6700268 100644
    @Override
    public void replaceExprent(Exprent oldExpr, Exprent newExpr) {
      if (oldExpr == instance) {
-@@ -926,6 +1290,18 @@ public class InvocationExprent extends Exprent {
+@@ -960,6 +1324,18 @@ public class InvocationExprent extends Exprent {
      return isSyntheticGetClass;
    }
  


### PR DESCRIPTION
Fixes #48 with both Eclipse J8_OpenJ9 and Oracle J8_Hotspot now producing the same output.

As mentioned in the linked issue, OpenJ9 adds a private `System.arraycopy` method for jit to reference. This private method made calls to the public method seem ambiguous when they should not be. This was fixed by only matching methods that can be properly accessed.

[1.14.2 MC Diff](https://gist.github.com/JDLogic/593083f131d1914fb7553478844fca66)
Note: There are two diffs. One is using Eclipse J8_OpenJ9 and the other is using Oracle J8_Hotspot.