### PR TITLE
Make decompilation threaded

### DIFF
--- a/FernFlower-Patches/0029-Improve-inferred-generic-types.patch
+++ b/FernFlower-Patches/0029-Improve-inferred-generic-types.patch
@@ -72,14 +72,14 @@ index 4bd94d9f47c9d15ef571412a28b97a0fbbfd45ef..6ed64f77930f44a9c6bd17d2eca51de9
  
    private static VarType guessType(int val, boolean boolPermitted) {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
-index 58c3471ff26529c091a44670828d272755e75f7d..09cbfdc37b929ab03b99e16d47566331ade154a0 100644
+index 58c3471ff26529c091a44670828d272755e75f7d..8074782862f3842a95050212df0ac5d778f20091 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
 @@ -54,6 +54,8 @@ public abstract class Exprent implements IMatchable {
    public static final int EXPRENT_ANNOTATION = 13;
    public static final int EXPRENT_ASSERT = 14;
  
-+  protected static Map<String, VarType> inferredLambdaTypes = new HashMap<>();
++  protected static ThreadLocal<Map<String, VarType>> inferredLambdaTypes = ThreadLocal.withInitial(HashMap::new);
 +
    public final int type;
    public final int id;
@@ -909,7 +909,7 @@ index 43db4dcfe8e32f8809a2a8743eb04a49e6942f18..25b88c34b98821413c947cf597a46e1d
    public void getBytecodeRange(BitSet values) {
      measureBytecode(values, lstParameters);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
-index bf254b8d843526d872092f4b0a000b13baef518a..9290b94f6590fa559b79b241a40da3e0f1253045 100644
+index bf254b8d843526d872092f4b0a000b13baef518a..d6b2cc514e99d037dcdf2143839fef8336db0c66 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
 @@ -5,7 +5,16 @@ import org.jetbrains.java.decompiler.code.CodeConstants;
@@ -1215,12 +1215,13 @@ index bf254b8d843526d872092f4b0a000b13baef518a..9290b94f6590fa559b79b241a40da3e0
      ClassNode node = DecompilerContext.getClassProcessor().getMapRootClasses().get(className);
      return node != null && node.type == ClassNode.CLASS_ANONYMOUS;
    }
-@@ -427,6 +546,154 @@ public class NewExprent extends Exprent {
+@@ -427,6 +546,155 @@ public class NewExprent extends Exprent {
      return null;
    }
  
 +  private static VarType getLambdaReturnType(ClassNode node, StructMethod desc, VarType upperBound, Map<VarType, VarType> genericsMap) {
 +    ClassWrapper wrapper = node.getWrapper();
++    Map<String, VarType> inferredLambdaTypes = Exprent.inferredLambdaTypes.get();
 +
 +    if (wrapper != null) {
 +      MethodWrapper mt = wrapper.getMethodWrapper(node.lambdaInformation.content_method_name, node.lambdaInformation.content_method_descriptor);
@@ -1370,7 +1371,7 @@ index bf254b8d843526d872092f4b0a000b13baef518a..9290b94f6590fa559b79b241a40da3e0
    @Override
    public void replaceExprent(Exprent oldExpr, Exprent newExpr) {
      if (oldExpr == constructor) {
-@@ -531,4 +798,10 @@ public class NewExprent extends Exprent {
+@@ -531,4 +799,10 @@ public class NewExprent extends Exprent {
      }
      return "";
    }
@@ -1382,7 +1383,7 @@ index bf254b8d843526d872092f4b0a000b13baef518a..9290b94f6590fa559b79b241a40da3e0
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
-index b681b11cad3899d90c5f04df50b2ae021bea3021..e30acc8a02cbfc5e95da42a7daf365a2974144a7 100644
+index b681b11cad3899d90c5f04df50b2ae021bea3021..eb9beb2b6e71170d5aced6432365ab33ed361bb3 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
 @@ -14,6 +14,7 @@ import org.jetbrains.java.decompiler.modules.decompiler.vars.CheckTypesResult;
@@ -1393,16 +1394,14 @@ index b681b11cad3899d90c5f04df50b2ae021bea3021..e30acc8a02cbfc5e95da42a7daf365a2
  import org.jetbrains.java.decompiler.struct.StructMethod;
  import org.jetbrains.java.decompiler.struct.attr.StructGeneralAttribute;
  import org.jetbrains.java.decompiler.struct.attr.StructLocalVariableTableAttribute;
-@@ -239,7 +240,23 @@ public class VarExprent extends Exprent {
+@@ -239,7 +240,21 @@ public class VarExprent extends Exprent {
  
      VarType vt = null;
      if (processor != null) {
 -      vt = processor.getVarType(getVarVersionPair());
 +      String name = processor.getVarName(getVarVersionPair());
-+      if (inferredLambdaTypes.containsKey(name)) {
-+        vt = inferredLambdaTypes.get(name);
-+      }
-+      else {
++      vt = Exprent.inferredLambdaTypes.get().get(name);
++      if (vt == null) {
 +        vt = processor.getVarType(getVarVersionPair());
 +        if (processor.getThisVars().containsKey(getVarVersionPair())) {
 +          String qaulName = processor.getThisVars().get(getVarVersionPair());

--- a/FernFlower-Patches/0030-Improve-stack-var-processor-output.patch
+++ b/FernFlower-Patches/0030-Improve-stack-var-processor-output.patch
@@ -335,7 +335,7 @@ index 25b88c34b98821413c947cf597a46e1dfe16c762..9bbdb537498de8dd02f0638760e24a37
  
    @Override
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
-index e30acc8a02cbfc5e95da42a7daf365a2974144a7..821062d824197b9955bbadff1af0c643f15d3d41 100644
+index eb9beb2b6e71170d5aced6432365ab33ed361bb3..4767d4c7d2923b86df789d84667a842468af7e50 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
 @@ -49,6 +49,7 @@ public class VarExprent extends Exprent {
@@ -354,7 +354,7 @@ index e30acc8a02cbfc5e95da42a7daf365a2974144a7..821062d824197b9955bbadff1af0c643
      return var;
    }
  
-@@ -317,6 +319,14 @@ public class VarExprent extends Exprent {
+@@ -315,6 +317,14 @@ public class VarExprent extends Exprent {
      return lvt;
    }
  

--- a/FernFlower-Patches/0039-Make-decomp-threaded.patch
+++ b/FernFlower-Patches/0039-Make-decomp-threaded.patch
@@ -1,0 +1,803 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: covers1624 <laughlan.cov@internode.on.net>
+Date: Sat, 20 Jun 2020 00:48:35 +0930
+Subject: [PATCH] Make decomp threaded
+
+`-thr <number>` anything < 1 is treaded as single threaded.
+`-thr AUTO` to auto select, (default)
+
+diff --git a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
+index eafddccc870786ee6f68412420ddd52e1b5b6992..533714ec176abe3e3689c4722095a90888333874 100644
+--- a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
++++ b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
+@@ -35,7 +35,8 @@ public class ClassesProcessor implements CodeConstants {
+   public static final int AVERAGE_CLASS_SIZE = 16 * 1024;
+ 
+   private final StructContext context;
+-  private final Map<String, ClassNode> mapRootClasses = new HashMap<>();
++  //TODO, This is synchronized because LambdaProcessor adds classes to this. Figure out a way to not sync this map.
++  private final Map<String, ClassNode> mapRootClasses = Collections.synchronizedMap(new HashMap<>());
+   private final Set<String> whitelist = new HashSet<>();
+ 
+   private static class Inner {
+@@ -360,14 +361,13 @@ public class ClassesProcessor implements CodeConstants {
+     return true;
+   }
+ 
+-  public void writeClass(StructClass cl, TextBuffer buffer) throws IOException {
++  public void processClass(StructClass cl) throws IOException {
+     ClassNode root = mapRootClasses.get(cl.qualifiedName);
+     if (root.type != ClassNode.CLASS_ROOT) {
+       return;
+     }
+-
+-    DecompilerContext.getLogger().startReadingClass(cl.qualifiedName);
+-    try {
++    DecompilerContext.getLogger().startProcessingClass(cl.qualifiedName);
++    {
+       ImportCollector importCollector = new ImportCollector(root);
+       DecompilerContext.startClass(importCollector);
+ 
+@@ -382,7 +382,18 @@ public class ClassesProcessor implements CodeConstants {
+       new NestedClassProcessor().processClass(root, root);
+ 
+       new NestedMemberAccess().propagateMemberAccess(root);
++    }
++    DecompilerContext.getLogger().endProcessingClass();
++  }
++
++  public void writeClass(StructClass cl, TextBuffer buffer) throws IOException {
++    ClassNode root = mapRootClasses.get(cl.qualifiedName);
++    if (root.type != ClassNode.CLASS_ROOT) {
++      return;
++    }
+ 
++    DecompilerContext.getLogger().startReadingClass(cl.qualifiedName);
++    try {
+       TextBuffer classBuffer = new TextBuffer(AVERAGE_CLASS_SIZE);
+       new ClassWriter().classToJava(root, classBuffer, 0, null);
+ 
+@@ -397,7 +408,7 @@ public class ClassesProcessor implements CodeConstants {
+         buffer.appendLineSeparator();
+       }
+ 
+-      int import_lines_written = importCollector.writeImports(buffer);
++      int import_lines_written = DecompilerContext.getImportCollector().writeImports(buffer);
+       if (import_lines_written > 0) {
+         buffer.appendLineSeparator();
+       }
+diff --git a/src/org/jetbrains/java/decompiler/main/DecompilerContext.java b/src/org/jetbrains/java/decompiler/main/DecompilerContext.java
+index 95baa7dfec5a9c8dcde30a288499aa127aeffa4b..8bbe04c2f404b6c43a6a216bf2a99d3b69a2ad93 100644
+--- a/src/org/jetbrains/java/decompiler/main/DecompilerContext.java
++++ b/src/org/jetbrains/java/decompiler/main/DecompilerContext.java
+@@ -11,6 +11,7 @@ import org.jetbrains.java.decompiler.main.extern.IVariableNamingFactory;
+ import org.jetbrains.java.decompiler.modules.renamer.PoolInterceptor;
+ import org.jetbrains.java.decompiler.struct.StructContext;
+ 
++import java.util.HashMap;
+ import java.util.Map;
+ import java.util.Objects;
+ 
+@@ -28,12 +29,14 @@ public class DecompilerContext {
+   private final ClassesProcessor classProcessor;
+   private final PoolInterceptor poolInterceptor;
+   private final IVariableNamingFactory renamerFactory;
++  private final int threads;
+   private ImportCollector importCollector;
+   private VarProcessor varProcessor;
+   private CounterContainer counterContainer;
+   private BytecodeSourceMapper bytecodeSourceMapper;
+ 
+   public DecompilerContext(Map<String, Object> properties,
++                           int threads,
+                            IFernflowerLogger logger,
+                            StructContext structContext,
+                            ClassesProcessor classProcessor,
+@@ -45,6 +48,7 @@ public class DecompilerContext {
+     Objects.requireNonNull(classProcessor);
+ 
+     this.properties = properties;
++    this.threads = threads;
+     this.logger = logger;
+     this.structContext = structContext;
+     this.classProcessor = classProcessor;
+@@ -53,6 +57,18 @@ public class DecompilerContext {
+     this.counterContainer = new CounterContainer();
+   }
+ 
++  //Safe to not copy some of the fields.
++  @SuppressWarnings ("CopyConstructorMissesField")
++  private DecompilerContext(DecompilerContext other) {
++    this.properties = new HashMap<>(other.properties);
++    this.logger = other.logger;
++    this.structContext = other.structContext;
++    this.classProcessor = other.classProcessor;
++    this.poolInterceptor = other.poolInterceptor;
++    this.renamerFactory = other.renamerFactory;
++    this.threads = other.threads;
++  }
++
+   // *****************************************************************************
+   // context setup and update
+   // *****************************************************************************
+@@ -67,6 +83,14 @@ public class DecompilerContext {
+     currentContext.set(context);
+   }
+ 
++  public static void cloneContext(DecompilerContext root) {
++    DecompilerContext current = getCurrentContext();
++    if (current == null) {
++      current = new DecompilerContext(root);
++      setCurrentContext(current);
++    }
++  }
++
+   public static void setProperty(String key, Object value) {
+     getCurrentContext().properties.put(key, value);
+   }
+@@ -101,6 +125,10 @@ public class DecompilerContext {
+            IFernflowerPreferences.LINE_SEPARATOR_UNX : IFernflowerPreferences.LINE_SEPARATOR_WIN;
+   }
+ 
++  public static int getThreads() {
++    return getCurrentContext().threads;
++  }
++
+   public static IFernflowerLogger getLogger() {
+     return getCurrentContext().logger;
+   }
+diff --git a/src/org/jetbrains/java/decompiler/main/Fernflower.java b/src/org/jetbrains/java/decompiler/main/Fernflower.java
+index 469b313a958cf8aca35fe98fc809880d12db671e..22cb517d3ab2901bb7d88e38802eb2825584b78d 100644
+--- a/src/org/jetbrains/java/decompiler/main/Fernflower.java
++++ b/src/org/jetbrains/java/decompiler/main/Fernflower.java
+@@ -26,6 +26,10 @@ public class Fernflower implements IDecompiledData {
+   private final IdentifierConverter converter;
+ 
+   public Fernflower(IBytecodeProvider provider, IResultSaver saver, Map<String, Object> customProperties, IFernflowerLogger logger) {
++    this(provider, saver, customProperties, logger, 0);
++  }
++
++  public Fernflower(IBytecodeProvider provider, IResultSaver saver, Map<String, Object> customProperties, IFernflowerLogger logger, int threads) {
+     Map<String, Object> properties = new HashMap<>(IFernflowerPreferences.DEFAULTS);
+     if (customProperties != null) {
+       properties.putAll(customProperties);
+@@ -70,7 +74,7 @@ public class Fernflower implements IDecompiledData {
+       }
+     }
+ 
+-    DecompilerContext context = new DecompilerContext(properties, logger, structContext, classProcessor, interceptor, renamerFactory);
++    DecompilerContext context = new DecompilerContext(properties, threads, logger, structContext, classProcessor, interceptor, renamerFactory);
+     DecompilerContext.setCurrentContext(context);
+ 
+     String vendor = System.getProperty("java.vendor", "missing vendor");
+@@ -138,6 +142,17 @@ public class Fernflower implements IDecompiledData {
+     }
+   }
+ 
++  @Override
++  public boolean processClass(StructClass cl) {
++    try {
++      classProcessor.processClass(cl);
++      return true;
++    } catch (Throwable t) {
++      DecompilerContext.getLogger().writeMessage("Class " + cl.qualifiedName + " couldn't be processed.", t);
++      return false;
++    }
++  }
++
+   @Override
+   public String getClassContent(StructClass cl) {
+     try {
+diff --git a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
+index 2b6e9ed5d2cf8e3781c9b33b1489fee9447d8181..ac1fc2f7588fb23b9d0232e675492f3d7c5c10fc 100644
+--- a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
++++ b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
+@@ -5,6 +5,7 @@ import org.jetbrains.java.decompiler.main.DecompilerContext;
+ import org.jetbrains.java.decompiler.main.Fernflower;
+ import org.jetbrains.java.decompiler.main.extern.IBytecodeProvider;
+ import org.jetbrains.java.decompiler.main.extern.IFernflowerLogger;
++import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
+ import org.jetbrains.java.decompiler.main.extern.IResultSaver;
+ import org.jetbrains.java.decompiler.util.InterpreterUtil;
+ 
+@@ -109,7 +110,7 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
+       return;
+     }
+ 
+-    PrintStreamLogger logger = new PrintStreamLogger(System.out);
++    IFernflowerLogger logger = new ThreadedPrintStreamLogger(System.out);
+     ConsoleDecompiler decompiler = new ConsoleDecompiler(destination, mapOptions, logger);
+ 
+     for (File library : libraries) {
+@@ -147,7 +148,25 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
+ 
+   protected ConsoleDecompiler(File destination, Map<String, Object> options, IFernflowerLogger logger) {
+     root = destination;
+-    engine = new Fernflower(this, root.isDirectory() ? this : new SingleFileSaver(destination), options, logger);
++
++    String thr = options != null ? (String) options.getOrDefault(IFernflowerPreferences.THREADS, "AUTO") : "AUTO";
++    int threads;
++    if ("AUTO".equals(thr)) {
++      threads = Runtime.getRuntime().availableProcessors();
++    } else {
++      try {
++        threads = Integer.parseInt(thr);
++      } catch (NumberFormatException e) {
++        throw new RuntimeException("Malformed threads option: " + thr);
++      }
++    }
++
++    IResultSaver saver = root.isDirectory() ? this : new SingleFileSaver(destination);
++    if (threads > 1) {
++      saver = new ThreadSafeResultSaver(root);
++    }
++
++    engine = new Fernflower(this, saver, options, logger, threads);
+   }
+ 
+   public void addSource(File source) {
+diff --git a/src/org/jetbrains/java/decompiler/main/decompiler/PrintStreamLogger.java b/src/org/jetbrains/java/decompiler/main/decompiler/PrintStreamLogger.java
+index ff3b9b3dd27f5f07ebc80f6ca4ac3c632c93c83d..4398128ff456563af17a51479e563bb90f5badcb 100644
+--- a/src/org/jetbrains/java/decompiler/main/decompiler/PrintStreamLogger.java
++++ b/src/org/jetbrains/java/decompiler/main/decompiler/PrintStreamLogger.java
+@@ -31,6 +31,22 @@ public class PrintStreamLogger extends IFernflowerLogger {
+     }
+   }
+ 
++  @Override
++  public void startProcessingClass(String className) {
++    if (accepts(Severity.INFO)) {
++      writeMessage("PreProcessing class " + className, Severity.INFO);
++      ++indent;
++    }
++  }
++
++  @Override
++  public void endProcessingClass() {
++    if (accepts(Severity.INFO)) {
++      --indent;
++      writeMessage("... done", Severity.INFO);
++    }
++  }
++
+   @Override
+   public void startReadingClass(String className) {
+     if (accepts(Severity.INFO)) {
+diff --git a/src/org/jetbrains/java/decompiler/main/decompiler/ThreadSafeResultSaver.java b/src/org/jetbrains/java/decompiler/main/decompiler/ThreadSafeResultSaver.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..f434fc92661e1337acfd2ebc7576fbd43f15622f
+--- /dev/null
++++ b/src/org/jetbrains/java/decompiler/main/decompiler/ThreadSafeResultSaver.java
+@@ -0,0 +1,227 @@
++// Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
++package org.jetbrains.java.decompiler.main.decompiler;
++
++import org.jetbrains.java.decompiler.main.DecompilerContext;
++import org.jetbrains.java.decompiler.main.extern.IFernflowerLogger;
++import org.jetbrains.java.decompiler.main.extern.IResultSaver;
++import org.jetbrains.java.decompiler.util.InterpreterUtil;
++
++import java.io.*;
++import java.nio.charset.StandardCharsets;
++import java.util.HashMap;
++import java.util.HashSet;
++import java.util.Map;
++import java.util.Set;
++import java.util.concurrent.ExecutionException;
++import java.util.concurrent.ExecutorService;
++import java.util.concurrent.Executors;
++import java.util.concurrent.Future;
++import java.util.jar.JarOutputStream;
++import java.util.jar.Manifest;
++import java.util.zip.ZipEntry;
++import java.util.zip.ZipFile;
++import java.util.zip.ZipOutputStream;
++
++/**
++ * File saver supporting both, Threaded saving and 'SingleFile' mode.
++ */
++//TODO, Split off default impl inside ConsoleDecompiler and make this extend that.
++public class ThreadSafeResultSaver implements IResultSaver {
++
++  private final Map<String, ArchiveContext> archiveContexts = new HashMap<>();
++  private final File target;
++  private final boolean archiveMode;//Latch for Archive mode.
++  private ArchiveContext singeArchiveCtx;
++
++  public ThreadSafeResultSaver(File target) {
++    this.target = target;
++    this.archiveMode = !target.isDirectory();
++  }
++
++  private ArchiveContext getCtx(String path) {
++    if (archiveMode) {
++      return singeArchiveCtx;
++    }
++    return archiveContexts.get(path);
++  }
++
++  @Override
++  public void createArchive(String path, String archiveName, Manifest manifest) {
++    if (archiveMode && singeArchiveCtx != null) {
++      throw new UnsupportedOperationException("Attempted to write multiple archives at the same time.");
++    }
++    File file = archiveMode ? target : new File(getAbsolutePath(path), archiveName);
++    ArchiveContext ctx = getCtx(file.getPath());
++    if (ctx != null) {
++      throw new RuntimeException("Archive already open for: " + file);
++    }
++    try {
++      if (!(file.createNewFile() || file.isFile())) {
++        throw new IOException("Cannot create file " + file);
++      }
++      FileOutputStream fos = new FileOutputStream(file);
++      ZipOutputStream zos = manifest != null ? new JarOutputStream(fos, manifest) : new ZipOutputStream(fos);
++      ctx = new ArchiveContext(file, zos);
++      if (archiveMode) {
++        singeArchiveCtx = ctx;
++      } else {
++        archiveContexts.put(file.getPath(), ctx);
++      }
++    } catch (IOException e) {
++      DecompilerContext.getLogger().writeMessage("Cannot create archive " + file, e);
++    }
++  }
++
++  @Override
++  public void saveDirEntry(String path, String archiveName, String entryName) {
++    saveClassEntry(path, archiveName, null, entryName, null);
++  }
++
++  @Override
++  public void copyEntry(String source, String path, String archiveName, String entryName) {
++    String file = new File(getAbsolutePath(path), archiveName).getPath();
++    ArchiveContext ctx = getCtx(file);
++    if (ctx == null) {
++      throw new RuntimeException("Archive closed and tried to copy entry '" + entryName + "' from '" + source + "' to '" + file + "'.");
++    }
++    ctx.submit(() -> {
++      if (!ctx.addEntry(entryName)) {
++        return;
++      }
++      try (ZipFile srcArchive = new ZipFile(new File(source))) {
++        ZipEntry entry = srcArchive.getEntry(entryName);
++        if (entry != null) {
++          try (InputStream in = srcArchive.getInputStream(entry)) {
++            ctx.stream.putNextEntry(new ZipEntry(entryName));
++            InterpreterUtil.copyStream(in, ctx.stream);
++          }
++        }
++      } catch (IOException e) {
++        DecompilerContext.getLogger().writeMessage("Cannot copy entry " + entryName + " from " + source + " to " + file, e);
++      }
++    });
++  }
++
++  @Override
++  public void saveClassEntry(String path, String archiveName, String qualifiedName, String entryName, String content) {
++    String file = new File(getAbsolutePath(path), archiveName).getPath();
++    ArchiveContext ctx = getCtx(file);
++    if (ctx == null) {
++      throw new RuntimeException("Archive closed and tried to write entry '" + entryName + "' to '" + file + "'.");
++    }
++    ctx.submit(() -> {
++      if (!ctx.addEntry(entryName)) {
++        return;
++      }
++      try {
++        ctx.stream.putNextEntry(new ZipEntry(entryName));
++        if (content != null) {
++          ctx.stream.write(content.getBytes(StandardCharsets.UTF_8));
++        }
++      } catch (IOException e) {
++        DecompilerContext.getLogger().writeMessage("Cannot write entry " + entryName + " to " + file, e);
++      }
++    });
++  }
++
++  @Override
++  public void closeArchive(String path, String archiveName) {
++    String file = new File(getAbsolutePath(path), archiveName).getPath();
++    ArchiveContext ctx = getCtx(file);
++    if (ctx == null) {
++      throw new RuntimeException("Tried to close closed archive '" + file + "'.");
++    }
++    //Submit a job at the end of the executor.
++    Future<?> closeFuture = ctx.submit(() -> {
++      try {
++        ctx.stream.close();
++      } catch (IOException e) {
++        DecompilerContext.getLogger().writeMessage("Cannot close " + file, IFernflowerLogger.Severity.WARN, e);
++      }
++    });
++
++    //Ask the executor to shutdown gracefully.
++    ctx.executor.shutdown();
++
++    try {
++      //Wait for our future to execute.
++      closeFuture.get();
++    } catch (InterruptedException | ExecutionException e) {
++      throw new RuntimeException(e);
++    }
++    if (archiveMode) {
++      singeArchiveCtx = null;
++    } else {
++      //We are done.
++      archiveContexts.remove(file);
++    }
++  }
++
++  @Override
++  public void saveFolder(String path) {
++    if (archiveMode) {
++      if (!"".equals(path)) {
++        throw new UnsupportedOperationException("Targeted a single output, but tried to create a directory");
++      }
++      return;
++    }
++    File dir = new File(getAbsolutePath(path));
++    if (!(dir.mkdirs() || dir.isDirectory())) {
++      throw new RuntimeException("Cannot create directory " + dir);
++    }
++  }
++
++  @Override
++  public void copyFile(String source, String path, String entryName) {
++    if (archiveMode) {
++      throw new UnsupportedOperationException("Targeted a single output, but tried to copy file");
++    }
++    try {
++      InterpreterUtil.copyFile(new File(source), new File(getAbsolutePath(path), entryName));
++    } catch (IOException ex) {
++      DecompilerContext.getLogger().writeMessage("Cannot copy " + source + " to " + entryName, ex);
++    }
++  }
++
++  @Override
++  public void saveClassFile(String path, String qualifiedName, String entryName, String content, int[] mapping) {
++    if (archiveMode) {
++      throw new UnsupportedOperationException("Targeted a single output, but tried to save a class file");
++    }
++    File file = new File(getAbsolutePath(path), entryName);
++    try (Writer out = new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8)) {
++      out.write(content);
++    } catch (IOException ex) {
++      DecompilerContext.getLogger().writeMessage("Cannot write class file " + file, ex);
++    }
++  }
++
++  private String getAbsolutePath(String path) {
++    return new File(target, path).getAbsolutePath();
++  }
++
++  private static class ArchiveContext {
++
++    public final File file;
++    public final ZipOutputStream stream;
++    public final ExecutorService executor = Executors.newSingleThreadExecutor();
++    public final Set<String> savedEntries = new HashSet<>();
++
++    private ArchiveContext(File file, ZipOutputStream stream) {
++      this.file = file;
++      this.stream = stream;
++    }
++
++    public Future<?> submit(Runnable runnable) {
++      return executor.submit(runnable);
++    }
++
++    public boolean addEntry(String entryName) {
++      boolean added = savedEntries.add(entryName);
++      if (!added) {
++        DecompilerContext.getLogger().writeMessage("Zip entry " + entryName + " already exists in " + file, IFernflowerLogger.Severity.WARN);
++      }
++      return added;
++    }
++  }
++}
+diff --git a/src/org/jetbrains/java/decompiler/main/decompiler/ThreadedPrintStreamLogger.java b/src/org/jetbrains/java/decompiler/main/decompiler/ThreadedPrintStreamLogger.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..fe8608901ab47ede002a24b3ad2199150bc8bbf0
+--- /dev/null
++++ b/src/org/jetbrains/java/decompiler/main/decompiler/ThreadedPrintStreamLogger.java
+@@ -0,0 +1,114 @@
++// Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
++package org.jetbrains.java.decompiler.main.decompiler;
++
++import org.jetbrains.java.decompiler.main.extern.IFernflowerLogger;
++import org.jetbrains.java.decompiler.util.TextUtil;
++
++import java.io.PrintStream;
++import java.util.concurrent.atomic.AtomicInteger;
++
++public class ThreadedPrintStreamLogger extends IFernflowerLogger {
++
++  private final PrintStream stream;
++  private final ThreadLocal<AtomicInteger> indent = ThreadLocal.withInitial(AtomicInteger::new);
++
++  public ThreadedPrintStreamLogger(PrintStream printStream) {
++    stream = printStream;
++  }
++
++  @Override
++  public void writeMessage(String message, Severity severity) {
++    if (accepts(severity)) {
++      Thread th = Thread.currentThread();
++      stream.println(th.getName() + ": " + severity.prefix + TextUtil.getIndentString(indent.get().get()) + message);
++    }
++  }
++
++  @Override
++  public void writeMessage(String message, Severity severity, Throwable t) {
++    if (accepts(severity)) {
++      writeMessage(message, severity);
++      t.printStackTrace(stream);
++    }
++  }
++
++  @Override
++  public void startProcessingClass(String className) {
++    if (accepts(Severity.INFO)) {
++      writeMessage("PreProcessing class " + className, Severity.INFO);
++      indent.get().incrementAndGet();
++    }
++  }
++
++  @Override
++  public void endProcessingClass() {
++    if (accepts(Severity.INFO)) {
++      indent.get().decrementAndGet();
++      writeMessage("... done", Severity.INFO);
++    }
++  }
++
++  @Override
++  public void startReadingClass(String className) {
++    if (accepts(Severity.INFO)) {
++      writeMessage("Decompiling class " + className, Severity.INFO);
++      indent.get().incrementAndGet();
++    }
++  }
++
++  @Override
++  public void endReadingClass() {
++    if (accepts(Severity.INFO)) {
++      indent.get().decrementAndGet();
++      writeMessage("... done", Severity.INFO);
++    }
++  }
++
++  @Override
++  public void startClass(String className) {
++    if (accepts(Severity.INFO)) {
++      writeMessage("Processing class " + className, Severity.TRACE);
++      indent.get().decrementAndGet();
++    }
++  }
++
++  @Override
++  public void endClass() {
++    if (accepts(Severity.INFO)) {
++      indent.get().decrementAndGet();
++      writeMessage("... proceeded", Severity.TRACE);
++    }
++  }
++
++  @Override
++  public void startMethod(String methodName) {
++    if (accepts(Severity.INFO)) {
++      writeMessage("Processing method " + methodName, Severity.TRACE);
++      indent.get().decrementAndGet();
++    }
++  }
++
++  @Override
++  public void endMethod() {
++    if (accepts(Severity.INFO)) {
++      indent.get().decrementAndGet();
++      writeMessage("... proceeded", Severity.TRACE);
++    }
++  }
++
++  @Override
++  public void startWriteClass(String className) {
++    if (accepts(Severity.INFO)) {
++      writeMessage("Writing class " + className, Severity.TRACE);
++      indent.get().decrementAndGet();
++    }
++  }
++
++  @Override
++  public void endWriteClass() {
++    if (accepts(Severity.INFO)) {
++      indent.get().decrementAndGet();
++      writeMessage("... written", Severity.TRACE);
++    }
++  }
++}
+diff --git a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerLogger.java b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerLogger.java
+index c9ece039b0d986c1d84b62426a65e6780ddc80e1..3ca43800b47e1d26a1dc036f21cb6e6e83ed5138 100644
+--- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerLogger.java
++++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerLogger.java
+@@ -31,6 +31,10 @@ public abstract class IFernflowerLogger {
+     writeMessage(message, Severity.ERROR, t);
+   }
+ 
++  public void startProcessingClass(String className) {}
++
++  public void endProcessingClass() { }
++
+   public void startReadingClass(String className) { }
+ 
+   public void endReadingClass() { }
+diff --git a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
+index 41f7389f3931a6a3c87647f7fde98f04c37af5c0..a2be81c2a329812c30ffe2606cae2b5f7ab43c3c 100644
+--- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
++++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
+@@ -38,6 +38,7 @@ public interface IFernflowerPreferences {
+   String INCLUDE_ENTIRE_CLASSPATH = "iec";
+   String EXPLICIT_GENERIC_ARGUMENTS = "ega";
+   String INLINE_SIMPLE_LAMBDAS = "isl";
++  String THREADS = "thr";
+ 
+   String LOG_LEVEL = "log";
+   String MAX_PROCESSING_METHOD = "mpm";
+@@ -92,6 +93,7 @@ public interface IFernflowerPreferences {
+     defaults.put(INCLUDE_ENTIRE_CLASSPATH, "0");
+     defaults.put(EXPLICIT_GENERIC_ARGUMENTS, "0");
+     defaults.put(INLINE_SIMPLE_LAMBDAS, "1");
++    defaults.put(THREADS, "AUTO");
+ 
+     defaults.put(LOG_LEVEL, IFernflowerLogger.Severity.INFO.name());
+     defaults.put(MAX_PROCESSING_METHOD, "0");
+diff --git a/src/org/jetbrains/java/decompiler/struct/ContextUnit.java b/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
+index fde588174ace52b073d205bd0fa045632a725df5..dfdf9837e0aebbdbfcb862a384e5a787971478bb 100644
+--- a/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
++++ b/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
+@@ -14,8 +14,14 @@ import java.io.IOException;
+ import java.nio.charset.StandardCharsets;
+ import java.util.ArrayList;
+ import java.util.List;
++import java.util.concurrent.ExecutionException;
++import java.util.concurrent.ExecutorService;
++import java.util.concurrent.Executors;
++import java.util.concurrent.Future;
+ import java.util.jar.JarFile;
+ import java.util.jar.Manifest;
++import java.util.stream.Collectors;
++import java.util.stream.IntStream;
+ import java.util.zip.ZipFile;
+ 
+ public class ContextUnit {
+@@ -118,7 +124,10 @@ public class ContextUnit {
+           StructClass cl = classes.get(i);
+           String entryName = decompiledData.getClassEntryName(cl, classEntries.get(i));
+           if (entryName != null) {
+-            String content = decompiledData.getClassContent(cl);
++            String content = null;
++            if (decompiledData.processClass(cl)) {
++              content = decompiledData.getClassContent(cl);
++            }
+             if (content != null) {
+               int[] mapping = null;
+               if (DecompilerContext.getOption(IFernflowerPreferences.BYTECODE_SOURCE_MAPPING)) {
+@@ -149,13 +158,64 @@ public class ContextUnit {
+           }
+         }
+ 
+-        // classes
+-        for (int i = 0; i < classes.size(); i++) {
+-          StructClass cl = classes.get(i);
+-          String entryName = decompiledData.getClassEntryName(cl, classEntries.get(i));
+-          if (entryName != null) {
+-            String content = decompiledData.getClassContent(cl);
+-            resultSaver.saveClassEntry(archivePath, filename, cl.qualifiedName, entryName, content);
++        //Whooo threads!
++        int threads = DecompilerContext.getThreads();
++        if (threads > 1) {
++
++          DecompilerContext rootContext = DecompilerContext.getCurrentContext();
++          ExecutorService executor = Executors.newFixedThreadPool(threads);
++
++          //Compute the classes we need to decomp.
++          List<ClassContext> toProcess = IntStream.range(0, classes.size()).parallel()
++            .mapToObj(i -> {
++              StructClass cl = classes.get(i);
++              return new ClassContext(cl, decompiledData.getClassEntryName(cl, classEntries.get(i)));
++            })
++            .filter(e -> e.entryName != null)
++            .collect(Collectors.toList());
++          List<Future<?>> futures = new ArrayList<>(toProcess.size());
++
++          //Submit preprocessor jobs.
++          for (ClassContext clCtx : toProcess) {
++            futures.add(executor.submit(() -> {
++              DecompilerContext.cloneContext(rootContext);
++              clCtx.ctx = DecompilerContext.getCurrentContext();
++              clCtx.shouldContinue = decompiledData.processClass(clCtx.cl);
++              DecompilerContext.setCurrentContext(null);
++            }));
++          }
++
++          //Ask the executor to shutdown
++          executor.shutdown();
++          waitForAll(futures);
++          futures.clear();
++
++          executor = Executors.newFixedThreadPool(threads);
++
++          // classes
++          for (ClassContext clCtx : toProcess) {
++            if (clCtx.shouldContinue) {
++              futures.add(executor.submit(() -> {
++                DecompilerContext.setCurrentContext(clCtx.ctx);
++                String content = decompiledData.getClassContent(clCtx.cl);
++                resultSaver.saveClassEntry(archivePath, filename, clCtx.cl.qualifiedName, clCtx.entryName, content);
++                DecompilerContext.setCurrentContext(null);
++              }));
++            }
++          }
++          executor.shutdown();
++          waitForAll(futures);
++        } else {
++          // classes
++          for (int i = 0; i < classes.size(); i++) {
++            StructClass cl = classes.get(i);
++            String entryName = decompiledData.getClassEntryName(cl, classEntries.get(i));
++            if (entryName != null) {
++              if (decompiledData.processClass(cl)) {
++                String content = decompiledData.getClassContent(cl);
++                resultSaver.saveClassEntry(archivePath, filename, cl.qualifiedName, entryName, content);
++              }
++            }
+           }
+         }
+ 
+@@ -163,6 +223,16 @@ public class ContextUnit {
+     }
+   }
+ 
++  private static void waitForAll(List<Future<?>> futures) {
++    for (Future<?> future : futures) {
++      try {
++        future.get();
++      } catch (InterruptedException | ExecutionException e) {
++        throw new RuntimeException(e);
++      }
++    }
++  }
++
+   public void setManifest(Manifest manifest) {
+     this.manifest = manifest;
+   }
+@@ -174,4 +244,17 @@ public class ContextUnit {
+   public List<StructClass> getClasses() {
+     return classes;
+   }
++
++  private static class ClassContext {
++    public final StructClass cl;
++    public final String entryName;
++    public boolean shouldContinue;
++    public DecompilerContext ctx;
++
++    private ClassContext(StructClass cl, String entryName) {
++      this.cl = cl;
++      this.entryName = entryName;
++    }
++  }
++
+ }
+diff --git a/src/org/jetbrains/java/decompiler/struct/IDecompiledData.java b/src/org/jetbrains/java/decompiler/struct/IDecompiledData.java
+index b3b38dd0c7fca39a4b90d2dd0bf9b91fb8ec2568..356a2a40d9e2834bbdf114c5b4745e72570e8ac6 100644
+--- a/src/org/jetbrains/java/decompiler/struct/IDecompiledData.java
++++ b/src/org/jetbrains/java/decompiler/struct/IDecompiledData.java
+@@ -5,5 +5,7 @@ public interface IDecompiledData {
+ 
+   String getClassEntryName(StructClass cl, String entryname);
+ 
++  boolean processClass(StructClass cl);
++
+   String getClassContent(StructClass cl);
+ }


### PR DESCRIPTION
Changes:
- Separate pre-processing and writing of classes to separate steps.
- Fire off each pre-processor step into an Executor.
- Waits for pre-process to finish.
- Fires off writing classes into an Executor.
- Makes `ClassesProcessor.mapRootClasses` synchronized due to LambdaProcessor  adding classes during pre-processing. Not ideal but no real simple way to fix that..
- Makes `Exprent.inferredLambdaTypes` ThreadLocal.
- Adds a new ResultSaver, Thread-safe merge of `ConsoleDecompiler` and `SingleFileSaver`