### PR TITLE
Fix return inlining.

### DIFF
--- a/FernFlower-Patches/0030-Improve-stack-var-processor-output.patch
+++ b/FernFlower-Patches/0030-Improve-stack-var-processor-output.patch
@@ -37,6 +37,50 @@ index 9942e12..7f80109 100644
                  }
                }
                else {
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
+index 767f6bdb..261756b9 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
+@@ -132,6 +132,11 @@ public class SimplifyExprentsHelper {
+       }
+ 
+       Exprent next = list.get(index + 1);
++      if (isAssignmentReturn(current, next)) {
++        list.remove(index);
++        res = true;
++        continue;
++      }
+ 
+       // constructor invocation
+       if (isConstructorInvocationRemote(list, index)) {
+@@ -339,6 +344,27 @@ public class SimplifyExprentsHelper {
+     return 0;
+   }
+ 
++  private static boolean isAssignmentReturn(Exprent first, Exprent second) {
++    //If assignment then exit.
++    if (first.type == Exprent.EXPRENT_ASSIGNMENT && second.type == Exprent.EXPRENT_EXIT) {
++      AssignmentExprent assignment = (AssignmentExprent) first;
++      ExitExprent exit = (ExitExprent) second;
++      //if simple assign and exit is return and return isn't void
++      if (assignment.getCondType() == AssignmentExprent.CONDITION_NONE && exit.getExitType() == ExitExprent.EXIT_RETURN && exit.getValue() != null) {
++        if (assignment.getLeft().type == Exprent.EXPRENT_VAR && exit.getValue().type == Exprent.EXPRENT_VAR) {
++          VarExprent assignmentLeft = (VarExprent) assignment.getLeft();
++          VarExprent exitValue = (VarExprent) exit.getValue();
++          //If the assignment before the return is immediately used in the return, inline it.
++          if (assignmentLeft.equals(exitValue) && !assignmentLeft.isStack() && !exitValue.isStack()) {
++            exit.replaceExprent(exitValue, assignment.getRight());
++            return true;
++          }
++        }
++      }
++    }
++    return false;
++  }
++
+   private static boolean isTrivialStackAssignment(Exprent first) {
+     if (first.type == Exprent.EXPRENT_ASSIGNMENT) {
+       AssignmentExprent asf = (AssignmentExprent)first;
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/StackVarsProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/StackVarsProcessor.java
 index 1232e64..500c5eb 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/StackVarsProcessor.java


### PR DESCRIPTION
Fixes cases where an assignment to a local variable then an immediate return isn't inlined. [1.16-pre1 diff](https://gist.github.com/covers1624/c08dc243c9984e21d272d4e600049e40)
Also more clearly shows some catch blocks not capturing simple return statements, which is something to be looked into.