### PR TITLE
Properly detect short names shadowed in inner classes

### DIFF
--- a/FernFlower-Patches/0023-Fix-shortname-imports-that-are-shadowed-by-super-cla.patch
+++ b/FernFlower-Patches/0023-Fix-shortname-imports-that-are-shadowed-by-super-cla.patch
@@ -1,4 +1,4 @@
-From 64a148b85727f2c23da782848cc2e00e6031705a Mon Sep 17 00:00:00 2001
+From dadd7a8d9acb144e59bf8e1d37959d159bab0939 Mon Sep 17 00:00:00 2001
 From: Justin <jrd2558@gmail.com>
 Date: Fri, 27 Jul 2018 14:02:27 -0700
 Subject: [PATCH] Fix shortname imports that are shadowed by super class inner
@@ -6,10 +6,59 @@ Subject: [PATCH] Fix shortname imports that are shadowed by super class inner
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/collectors/ImportCollector.java b/src/org/jetbrains/java/decompiler/main/collectors/ImportCollector.java
-index 7b8c3b4..30db0cd 100644
+index 7b8c3b4..4ddb755 100644
 --- a/src/org/jetbrains/java/decompiler/main/collectors/ImportCollector.java
 +++ b/src/org/jetbrains/java/decompiler/main/collectors/ImportCollector.java
-@@ -132,8 +132,28 @@ public class ImportCollector {
+@@ -20,7 +20,7 @@ public class ImportCollector {
+   private final Set<String> setNotImportedNames = new HashSet<>();
+   // set of field names in this class and all its predecessors.
+   private final Set<String> setFieldNames = new HashSet<>();
+-  private final Set<String> setInnerClassNames = new HashSet<>();
++  private final Map<String, Map<String, String>> mapInnerClassNames = new HashMap<>();
+   private final String currentPackageSlash;
+   private final String currentPackagePoint;
+ 
+@@ -38,36 +38,18 @@ public class ImportCollector {
+     }
+ 
+     Map<String, StructClass> classes = DecompilerContext.getStructContext().getClasses();
+-    LinkedList<String> queue = new LinkedList<>();
+     StructClass currentClass = root.classStruct;
+     while (currentClass != null) {
+-      if (currentClass.superClass != null) {
+-        queue.add(currentClass.superClass.getString());
+-      }
+-
+-      Collections.addAll(queue, currentClass.getInterfaceNames());
+-
+       // all field names for the current class ..
+       for (StructField f : currentClass.getFields()) {
+         setFieldNames.add(f.getName());
+       }
+ 
+-      // .. all inner classes for the current class ..
+-      StructInnerClassesAttribute attribute = currentClass.getAttribute(StructGeneralAttribute.ATTRIBUTE_INNER_CLASSES);
+-      if (attribute != null) {
+-        for (StructInnerClassesAttribute.Entry entry : attribute.getEntries()) {
+-          if (entry.enclosingName != null && entry.enclosingName.equals(currentClass.qualifiedName)) {
+-            setInnerClassNames.add(entry.simpleName);
+-          }
+-        }
+-      }
+-
+       // .. and traverse through parent.
+-      currentClass = !queue.isEmpty() ? classes.get(queue.removeFirst()) : null;
+-      while (currentClass == null && !queue.isEmpty()) {
+-        currentClass = classes.get(queue.removeFirst());
+-      }
++      currentClass = currentClass.superClass != null ? classes.get(currentClass.superClass.getString()) : null;
+     }
++
++    collectConflictingShortNames(root, new HashMap<>());
+   }
+ 
+   /**
+@@ -132,8 +114,31 @@ public class ImportCollector {
      // 3) inner class with the same short name in the current class, a super class, or an implemented interface
      boolean existsDefaultClass =
        (context.getClass(currentPackageSlash + shortName) != null && !packageName.equals(currentPackagePoint)) || // current package
@@ -17,7 +66,10 @@ index 7b8c3b4..30db0cd 100644
 -      setInnerClassNames.contains(shortName); // inner class
 +      (context.getClass(shortName) != null && !currentPackagePoint.isEmpty());
 +
-+    if (!existsDefaultClass && setInnerClassNames.contains(shortName)) {
++    ClassNode currCls = (ClassNode)DecompilerContext.getProperty(DecompilerContext.CURRENT_CLASS_NODE);
++    String mapKey = currCls == null ? "" : currCls.classStruct.qualifiedName;
++    Map<String, String> innerClassNames = mapInnerClassNames.getOrDefault(mapKey, new HashMap<>());
++    if (!existsDefaultClass && innerClassNames.containsKey(shortName) && !innerClassNames.get(shortName).equals(fullName)) {
 +      // if the class being accessed is also an inner class
 +      // attempt to import the outer class and reference OuterClass.InnerClass
 +      if (context.getClass(packageName.replace('.', '/') + "$" + shortName) != null) {
@@ -27,7 +79,7 @@ index 7b8c3b4..30db0cd 100644
 +          shortName = packageName.substring(lastDot + 1);
 +          packageName = packageName.substring(0, lastDot);
 +
-+          if (setInnerClassNames.contains(result.replace('.', '$'))) {
++          if (innerClassNames.containsKey(shortName)  && !innerClassNames.get(shortName).equals(packageName + '.' + shortName)) {
 +            existsDefaultClass = true;
 +            result = null;
 +          }
@@ -40,6 +92,51 @@ index 7b8c3b4..30db0cd 100644
  
      if (existsDefaultClass ||
          (mapSimpleNames.containsKey(shortName) && !packageName.equals(mapSimpleNames.get(shortName)))) {
+@@ -181,4 +186,43 @@ public class ImportCollector {
+       .map(ent -> ent.getValue() + "." + ent.getKey())
+       .collect(Collectors.toList());
+   }
++
++  private void collectConflictingShortNames(ClassNode root, Map<String, String> rootNames) {
++    Map<String, String> names = new HashMap<>(rootNames);
++    getSuperClassInnerClasses(root, names);
++    mapInnerClassNames.put(root.classStruct.qualifiedName, names);
++
++    for (ClassNode nested : root.nested) {
++      collectConflictingShortNames(nested, names);
++    }
++  }
++
++  private void getSuperClassInnerClasses(ClassNode node, Map<String, String> names) {
++    Map<String, StructClass> classes = DecompilerContext.getStructContext().getClasses();
++    LinkedList<String> queue = new LinkedList<>();
++    StructClass currentClass = node.classStruct;
++    while (currentClass != null) {
++      if (currentClass.superClass != null) {
++        queue.add(currentClass.superClass.getString());
++      }
++
++      Collections.addAll(queue, currentClass.getInterfaceNames());
++
++      // .. all inner classes for the current class ..
++      StructInnerClassesAttribute attribute = currentClass.getAttribute(StructGeneralAttribute.ATTRIBUTE_INNER_CLASSES);
++      if (attribute != null) {
++        for (StructInnerClassesAttribute.Entry entry : attribute.getEntries()) {
++          if (entry.enclosingName != null && entry.enclosingName.equals(currentClass.qualifiedName)) {
++            names.put(entry.simpleName, entry.innerName.replace('/', '.').replace('$', '.'));
++          }
++        }
++      }
++
++      // .. and traverse through parent.
++      currentClass = !queue.isEmpty() ? classes.get(queue.removeFirst()) : null;
++      while (currentClass == null && !queue.isEmpty()) {
++        currentClass = classes.get(queue.removeFirst());
++      }
++    }
++  }
+ }
+\ No newline at end of file
 -- 
-2.27.0.windows.1
+2.27.0
 

--- a/FernFlower-Patches/0030-Improve-stack-var-processor-output.patch
+++ b/FernFlower-Patches/0030-Improve-stack-var-processor-output.patch
@@ -1,4 +1,4 @@
-From bdb20d5c42423d86f88612ba4629f9b00d0f36b7 Mon Sep 17 00:00:00 2001
+From fd50a735ee4cef9dacff4bd808bca4b664d2567f Mon Sep 17 00:00:00 2001
 From: Justin <jrd2558@gmail.com>
 Date: Sun, 25 Aug 2019 18:02:16 -0700
 Subject: [PATCH] Improve stack var processor output
@@ -38,7 +38,7 @@ index 9942e12..7f80109 100644
                }
                else {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
-index 767f6bdb..261756b9 100644
+index 767f6bd..261756b 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
 @@ -132,6 +132,11 @@ public class SimplifyExprentsHelper {
@@ -641,5 +641,5 @@ index 58eda68..fc10e17 100644
    }
  
 -- 
-2.27.0.windows.1
+2.27.0
 

--- a/FernFlower-Patches/0032-Simple-lambda-syntax-support-isl-0-to-disable.patch
+++ b/FernFlower-Patches/0032-Simple-lambda-syntax-support-isl-0-to-disable.patch
@@ -1,11 +1,11 @@
-From 2eca411101f06332f440e0568684ff9e4cee11da Mon Sep 17 00:00:00 2001
+From e8c8ba2d1464345fae9c35c81f9b7261177dfdd7 Mon Sep 17 00:00:00 2001
 From: Justin <jrd2558@gmail.com>
 Date: Fri, 20 Dec 2019 08:35:30 -0700
 Subject: [PATCH] Simple lambda syntax support, --isl=0 to disable.
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 69b1dc4..232ea1d 100644
+index 69b1dc4..507df08 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -11,6 +11,7 @@ import org.jetbrains.java.decompiler.main.rels.MethodWrapper;
@@ -16,7 +16,23 @@ index 69b1dc4..232ea1d 100644
  import org.jetbrains.java.decompiler.modules.decompiler.vars.VarTypeProcessor;
  import org.jetbrains.java.decompiler.modules.decompiler.vars.VarVersionPair;
  import org.jetbrains.java.decompiler.modules.renamer.PoolInterceptor;
-@@ -97,6 +98,8 @@ public class ClassWriter {
+@@ -80,7 +81,14 @@ public class ClassWriter {
+       if (node.lambdaInformation.is_method_reference) {
+         if (!node.lambdaInformation.is_content_method_static && method_object != null) {
+           // reference to a virtual method
+-          buffer.append(method_object.toJava(indent, tracer));
++          String instance = method_object.toJava(indent, tracer).toString();
++          // If the instance is casted, then we need to wrap it
++          if (!instance.isEmpty() && instance.charAt(0) == '(' && instance.charAt(instance.length() - 1) != ')') {
++            buffer.append('(').append(instance).append(')');
++          }
++          else {
++            buffer.append(instance);
++          }
+         }
+         else {
+           // reference to a static method
+@@ -97,6 +105,8 @@ public class ClassWriter {
          MethodDescriptor md_content = MethodDescriptor.parseDescriptor(node.lambdaInformation.content_method_descriptor);
          MethodDescriptor md_lambda = MethodDescriptor.parseDescriptor(node.lambdaInformation.method_descriptor);
  
@@ -25,7 +41,7 @@ index 69b1dc4..232ea1d 100644
          if (!lambdaToAnonymous) {
            buffer.append('(');
  
-@@ -120,16 +123,60 @@ public class ClassWriter {
+@@ -120,16 +130,60 @@ public class ClassWriter {
            }
  
            buffer.append(") ->");
@@ -112,5 +128,5 @@ index 01b9cef..41f7389 100644
      defaults.put(LOG_LEVEL, IFernflowerLogger.Severity.INFO.name());
      defaults.put(MAX_PROCESSING_METHOD, "0");
 -- 
-2.27.0.windows.1
+2.27.0
 

--- a/FernFlower-Patches/0035-Add-only-argument-It-will-filter-what-classes-are-de.patch
+++ b/FernFlower-Patches/0035-Add-only-argument-It-will-filter-what-classes-are-de.patch
@@ -1,4 +1,4 @@
-From af242ae227560e52473f6865a72843fa7eb17447 Mon Sep 17 00:00:00 2001
+From a66ecb7e8f5e2090fe1064a4e0c593fefe6dd936 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Wed, 10 Jun 2020 09:59:19 -0700
 Subject: [PATCH] Add -only argument It will filter what classes are decompiled
@@ -125,5 +125,5 @@ index 5393dde..2b6e9ed 100644
      try {
        engine.decompileContext();
 -- 
-2.27.0.windows.1
+2.27.0
 


### PR DESCRIPTION
Also, added wrapping for a casted method reference instances (see EntitySelectionContext).

[mc 1.16-pre1 diff](https://gist.github.com/JDLogic/afa623e2d5d385660cb69b8098b5ea46)