### PR TITLE
Update patches for new GItPatcher

### DIFF
--- a/FernFlower-Patches/0001-Git-filter-and-setup.patch
+++ b/FernFlower-Patches/0001-Git-filter-and-setup.patch
@@ -1,11 +1,11 @@
-From 054d91c0c439eb93af1cf54b9bdc6bca05cda0e3 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Tue, 11 Apr 2017 20:44:39 -0700
 Subject: [PATCH] Git filter and setup
 
 
 diff --git a/.gitattributes b/.gitattributes
-index f1df734..972529a 100644
+index f1df734f9f0bc7080a99140482eedf28bfe6b166..972529aebd1f5daa057f1fe9606c79be1dc4f64f 100644
 --- a/.gitattributes
 +++ b/.gitattributes
 @@ -1 +1,42 @@
@@ -54,7 +54,7 @@ index f1df734..972529a 100644
 + 
 \ No newline at end of file
 diff --git a/.gitignore b/.gitignore
-index 3537b26..c52eb2e 100644
+index 3537b26a5b9d0579ae764825988f08a14d29517b..c52eb2e815432be8d1f1e6b61cffdcce68af85bb 100644
 --- a/.gitignore
 +++ b/.gitignore
 @@ -1,3 +1,231 @@
@@ -295,7 +295,7 @@ index 3537b26..c52eb2e 100644
 +!testData/classes/**
 diff --git a/build.gradle b/build.gradle
 deleted file mode 100644
-index 9694117..0000000
+index 9694117119040d9a0c060dab67d1d5a36973d040..0000000000000000000000000000000000000000
 --- a/build.gradle
 +++ /dev/null
 @@ -1,25 +0,0 @@
@@ -2302,7 +2302,7 @@ z#GlBA?SDu9eedGme!&YL*H4~~&cE@zoOb?cmheA5<1hU#KWSpS|8Gk7-@GvYsq=q)
 oE`N5K{P4N_EZYFE|K@>tBMk;v2mOd$WCD5z@VD^x{P^qt0dz#mIsgCw
 
 diff --git a/gradle/wrapper/gradle-wrapper.properties b/gradle/wrapper/gradle-wrapper.properties
-index 657de85..a4b4429 100644
+index 657de8507468e0ce75005e8870f2a95ae849b5ce..a4b4429748d92848a3d820c7b099fbeb941066ae 100644
 --- a/gradle/wrapper/gradle-wrapper.properties
 +++ b/gradle/wrapper/gradle-wrapper.properties
 @@ -1,6 +1,5 @@
@@ -2314,7 +2314,7 @@ index 657de85..a4b4429 100644
  zipStorePath=wrapper/dists
 -distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip
 diff --git a/gradlew b/gradlew
-index cccdd3d..2fe81a7 100755
+index cccdd3d517fc5249beaefa600691cf150f2fa3e6..2fe81a7d95e4f9ad2c9b2a046707d36ceb3980b3 100755
 --- a/gradlew
 +++ b/gradlew
 @@ -1,5 +1,21 @@
@@ -2407,7 +2407,7 @@ index cccdd3d..2fe81a7 100755
 -
  exec "$JAVACMD" "$@"
 diff --git a/gradlew.bat b/gradlew.bat
-index f955316..62bd9b9 100644
+index f9553162f122c71b34635112e717c3e733b5b212..62bd9b9ccefea2b65ae41e5d9a545e2021b90a1d 100644
 --- a/gradlew.bat
 +++ b/gradlew.bat
 @@ -1,3 +1,19 @@
@@ -2443,6 +2443,3 @@ index f955316..62bd9b9 100644
  
  @rem Find java.exe
  if defined JAVA_HOME goto findJavaFromJavaHome
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0002-Test-Framework-upgrades.patch
+++ b/FernFlower-Patches/0002-Test-Framework-upgrades.patch
@@ -1,11 +1,11 @@
-From 8501ffc3202fcefbf1aee705eff430d4cf34b1d8 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Tue, 11 Apr 2017 23:18:58 -0700
 Subject: [PATCH] Test Framework upgrades
 
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
-index bb303e8..cc1f537 100644
+index bb303e84f33161a4b4fd40a73aa48d29981d9ef2..cc1f537e71af0748b7b97d7d8489198e2a677cc9 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
 @@ -110,6 +110,10 @@ public class Exprent implements IMatchable {
@@ -20,7 +20,7 @@ index bb303e8..cc1f537 100644
      throw new RuntimeException("not implemented");
    }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java
-index b5e8213..b905da5 100644
+index b5e82131dd20ea45a02ff62e085695417111adfe..b905da55c9b3bd7dc48123559809a1d7ed9eaf9c 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java
 @@ -469,6 +469,10 @@ public class Statement implements IMatchable {
@@ -35,7 +35,7 @@ index b5e8213..b905da5 100644
      throw new RuntimeException("not implemented");
    }
 diff --git a/test/org/jetbrains/java/decompiler/DecompilerTestFixture.java b/test/org/jetbrains/java/decompiler/DecompilerTestFixture.java
-index 4c5641f..7d29c19 100644
+index 4c5641fec76837a51094d4a54800d5b7475446ca..7d29c198014cbfee8092fd31461208ce58e7f775 100644
 --- a/test/org/jetbrains/java/decompiler/DecompilerTestFixture.java
 +++ b/test/org/jetbrains/java/decompiler/DecompilerTestFixture.java
 @@ -23,6 +23,7 @@ public class DecompilerTestFixture {
@@ -71,7 +71,7 @@ index 4c5641f..7d29c19 100644
    private static boolean isTestDataDir(File dir) {
      return dir.isDirectory() && new File(dir, "classes").isDirectory() && new File(dir, "results").isDirectory();
 diff --git a/test/org/jetbrains/java/decompiler/SingleClassesTest.java b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
-index 1d0dc62..2b60ca1 100644
+index 1d0dc62d75e0ece79fd0af5757c202360fa800e0..2b60ca149c39b5dbe8a6191be44d1d607b9cbe18 100644
 --- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
 +++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
 @@ -1,37 +1,20 @@
@@ -172,7 +172,7 @@ index 1d0dc62..2b60ca1 100644
 \ No newline at end of file
 diff --git a/test/org/jetbrains/java/decompiler/SingleClassesTestBase.java b/test/org/jetbrains/java/decompiler/SingleClassesTestBase.java
 new file mode 100644
-index 0000000..9f073c2
+index 0000000000000000000000000000000000000000..9f073c2625764dd865f162420264e27ac923318d
 --- /dev/null
 +++ b/test/org/jetbrains/java/decompiler/SingleClassesTestBase.java
 @@ -0,0 +1,89 @@
@@ -266,6 +266,3 @@ index 0000000..9f073c2
 +  }
 +}
 \ No newline at end of file
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0003-Fix-initializers-for-anon-and-synthetic-classes.patch
+++ b/FernFlower-Patches/0003-Fix-initializers-for-anon-and-synthetic-classes.patch
@@ -1,11 +1,11 @@
-From 9bd94d6cee203cbe024f1040b84d4969897a907d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Wed, 12 Apr 2017 13:21:00 -0700
 Subject: [PATCH] Fix initializers for anon and synthetic classes
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 72fefe4..1182bd1 100644
+index 72fefe4c1c0aa322154541d54b1ccb35cc2154d1..1182bd193cb0aef1ebacbcd8d6427dd79af9715f 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -41,6 +41,7 @@ public class ClassWriter {
@@ -17,7 +17,7 @@ index 72fefe4..1182bd1 100644
      if (node.type == ClassNode.CLASS_ROOT &&
          !cl.isVersionGE_1_5() &&
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
-index 1ee22f2..0041f13 100644
+index 1ee22f210c1828c5ce7adc09a468e5bd649cc637..0041f13df8b5336da5b9891df0e399cbc2de4e3c 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 @@ -87,6 +87,31 @@ public class ClassesProcessor implements CodeConstants {
@@ -53,7 +53,7 @@ index 1ee22f2..0041f13 100644
                String enclClassName = entry.outerNameIdx != 0 ? entry.enclosingName : cl.qualifiedName;
                if (enclClassName == null || innerName.equals(enclClassName)) {
 diff --git a/src/org/jetbrains/java/decompiler/main/InitializerProcessor.java b/src/org/jetbrains/java/decompiler/main/InitializerProcessor.java
-index b929d0d..ba039e6 100644
+index b929d0d142711abdcd3f67cb429c91b7260d6e2b..ba039e6c83007aca9bce0a33229b28c7b82dc398 100644
 --- a/src/org/jetbrains/java/decompiler/main/InitializerProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/InitializerProcessor.java
 @@ -13,6 +13,9 @@ import org.jetbrains.java.decompiler.modules.decompiler.stats.Statements;
@@ -128,6 +128,3 @@ index b929d0d..ba039e6 100644
 -}
 \ No newline at end of file
 +}
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0004-Fix-field-initalizers.patch
+++ b/FernFlower-Patches/0004-Fix-field-initalizers.patch
@@ -1,11 +1,11 @@
-From 89cd2b7f01d21647b587708c76fb3a20cc98587c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Wed, 12 Apr 2017 10:51:55 -0700
 Subject: [PATCH] Fix field initalizers
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/InitializerProcessor.java b/src/org/jetbrains/java/decompiler/main/InitializerProcessor.java
-index ba039e6..0bfe8ad 100644
+index ba039e6c83007aca9bce0a33229b28c7b82dc398..0bfe8adc334822dc880d69164106bad814c4ffc5 100644
 --- a/src/org/jetbrains/java/decompiler/main/InitializerProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/InitializerProcessor.java
 @@ -3,6 +3,7 @@ package org.jetbrains.java.decompiler.main;
@@ -248,7 +248,7 @@ index ba039e6..0bfe8ad 100644
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
-index 642a86b..c79f1a6 100644
+index 642a86be9a791759e04cc74ad12ffca4436dfbf6..c79f1a6fc6d13c3e61d877624c18b117a5567ce6 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
 @@ -31,18 +31,24 @@ public class FieldExprent extends Exprent {
@@ -327,7 +327,7 @@ z<BWBrM`IJ2QGxr6yLz()p0~umT@n;j{=*u$vbHW9HKC}}7M?_C9O+7)J(-o9N<PN2
 GhW!C-@ghk8
 
 diff --git a/testData/results/TestClashName.dec b/testData/results/TestClashName.dec
-index 2a9a731..43348ea 100644
+index 2a9a731549e4bee8fe6ff812211e5a7930252017..43348ea674adf840021a807e16fd231a51939c1d 100644
 --- a/testData/results/TestClashName.dec
 +++ b/testData/results/TestClashName.dec
 @@ -7,25 +7,14 @@ public class TestClashName extends ext.TestClashNameParent implements TestClashN
@@ -454,7 +454,7 @@ index 2a9a731..43348ea 100644
 +78 <-> 26
 +82 <-> 30
 diff --git a/testData/results/TestClassFields.dec b/testData/results/TestClassFields.dec
-index ea272ea..852ae47 100644
+index ea272ead5c52deca629cb12876748960044559e0..852ae473bdfa591e28aa9b132f9f358ee1fc6eeb 100644
 --- a/testData/results/TestClassFields.dec
 +++ b/testData/results/TestClassFields.dec
 @@ -3,16 +3,14 @@ package pkg;
@@ -501,7 +501,7 @@ index ea272ea..852ae47 100644
 +9
 +16
 diff --git a/testData/src/pkg/TestClassFields.java b/testData/src/pkg/TestClassFields.java
-index 8a77fe0..6e31d5c 100644
+index 8a77fe0038a8aad333b5004ca17c5d5d6edfa62d..6e31d5c7515e942c26821ad3320a2eb4dfead920 100644
 --- a/testData/src/pkg/TestClassFields.java
 +++ b/testData/src/pkg/TestClassFields.java
 @@ -2,19 +2,17 @@ package pkg;
@@ -527,6 +527,3 @@ index 8a77fe0..6e31d5c 100644
    }
  }
 \ No newline at end of file
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0005-Fix-output-discrepancies-based-on-running-JVM.patch
+++ b/FernFlower-Patches/0005-Fix-output-discrepancies-based-on-running-JVM.patch
@@ -1,11 +1,11 @@
-From 9196954728e53471d9914f8d4dbeac31fba9f477 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Wed, 12 Apr 2017 10:08:10 -0700
 Subject: [PATCH] Fix output discrepancies based on running JVM
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
-index 0041f13..a347589 100644
+index 0041f13df8b5336da5b9891df0e399cbc2de4e3c..a34758940dbce0c5bac8dff269386af752c63d91 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 @@ -229,6 +229,7 @@ public class ClassesProcessor implements CodeConstants {
@@ -39,7 +39,7 @@ index 0041f13..a347589 100644
        public String method_name;
        public String method_descriptor;
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/LambdaProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/LambdaProcessor.java
-index fd0f261..36156fe 100644
+index fd0f261cf8fb07c523b5a870e8a4c3a54a96f2ef..36156fe90fcde67b25a50af529eca1209cfbce55 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/LambdaProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/LambdaProcessor.java
 @@ -108,6 +108,8 @@ public class LambdaProcessor {
@@ -60,7 +60,7 @@ index fd0f261..36156fe 100644
        }
      }
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-index da17532..3625c48 100644
+index da175324e5b04e7980225f97d1b30d729d5d46a2..3625c482744fe98f41fda3736355c50b7ed514e6 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 @@ -217,6 +217,7 @@ public class NestedClassProcessor {
@@ -72,7 +72,7 @@ index da17532..3625c48 100644
          return true;
        }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java
-index 2c5e3eb..bc3cb33 100644
+index 2c5e3eb49c1e030cb847c803bcf984909b37e414..bc3cb3311e6b132f46025ed498a6fc7e6d583d02 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java
 @@ -193,7 +193,7 @@ public class DomHelper {
@@ -117,7 +117,7 @@ index 2c5e3eb..bc3cb33 100644
                }
                else {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
-index 966cd44..010566b 100644
+index 966cd442c8b991aeae0055a114f01426debb59da..010566ba18cc005e72ddcbf7eea17f0f533a87d9 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 @@ -797,6 +797,7 @@ public class ExprProcessor implements CodeConstants {
@@ -129,7 +129,7 @@ index 966cd44..010566b 100644
      for (Exprent expr : lst) {
        if (buf.length() > 0 && expr.type == Exprent.EXPRENT_VAR && ((VarExprent)expr).isClassDef()) {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java
-index 240ee3e..bcd6a6c 100644
+index 240ee3e49c333d052cad169661a1e241042ee55b..bcd6a6c52620e19cf9f7cba7679dfe493ee54528 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java
 @@ -486,10 +486,17 @@ public class FinallyProcessor {
@@ -171,7 +171,7 @@ index 240ee3e..bcd6a6c 100644
  
        if (entry.getValue()) {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/LabelHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/LabelHelper.java
-index 9c150b5..017218b 100644
+index 9c150b51644beabafdf832a7fdcdbddecbfe9500..017218b7bee3fbf993b890b4e007f65c0a84f177 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/LabelHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/LabelHelper.java
 @@ -19,7 +19,7 @@ public class LabelHelper {
@@ -193,7 +193,7 @@ index 9c150b5..017218b 100644
      }
    }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/DominatorTreeExceptionFilter.java b/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/DominatorTreeExceptionFilter.java
-index d8b587f..318d95c 100644
+index d8b587fff8b748fd4187453c31a5b39e43bc8ecb..318d95cd5427cda3ec721797c181fe68cb95b6db 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/DominatorTreeExceptionFilter.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/DominatorTreeExceptionFilter.java
 @@ -13,10 +13,10 @@ public class DominatorTreeExceptionFilter {
@@ -228,7 +228,7 @@ index d8b587f..318d95c 100644
          for (Statement st : lstPreds) {
            set.add(st.id);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/FastExtendedPostdominanceHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/FastExtendedPostdominanceHelper.java
-index 71ef24b..e8568f4 100644
+index 71ef24b4bf403112f7c5438c135ec06c7e452c80..e8568f4a93c65c6ac1f7b102ac800724531d9d05 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/FastExtendedPostdominanceHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/FastExtendedPostdominanceHelper.java
 @@ -14,9 +14,9 @@ public class FastExtendedPostdominanceHelper {
@@ -264,7 +264,7 @@ index 71ef24b..e8568f4 100644
  
      return res;
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
-index 9fa5812..691d613 100644
+index 9fa58125289555ee7a4c565574acf74afcc413d0..691d613050f89cce24136dc957a38b65cc51fc4c 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
 @@ -177,15 +177,15 @@ public class ConstExprent extends Exprent {
@@ -327,7 +327,7 @@ index 9fa5812..691d613 100644
    public boolean isNull() {
      return CodeConstants.TYPE_NULL == constType.type;
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
-index cc1f537..0994d94 100644
+index cc1f537e71af0748b7b97d7d8489198e2a677cc9..0994d9466eda95b46d3f234bf977e8e9aa0e0899 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
 @@ -15,7 +15,10 @@ import org.jetbrains.java.decompiler.struct.match.MatchEngine;
@@ -381,7 +381,7 @@ index cc1f537..0994d94 100644
    // IMatchable implementation
    // *****************************************************************************
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java
-index 29e7030..6efce5e 100644
+index 29e7030a24be3d75161885ae1adf38cf5a94a001..6efce5e4b043b2dcb58b4dc21f85da9ac9081a7a 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java
 @@ -22,6 +22,7 @@ import org.jetbrains.java.decompiler.util.SFormsFastMapDirect;
@@ -402,7 +402,7 @@ index 29e7030..6efce5e 100644
        setInit.add(i);
      }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java
-index 4edec05..f5719d1 100644
+index 4edec05872a22da324cb24961825b9d66811a5e2..f5719d1a14fc0fd41393e44fe84e0d3c9370d323 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java
 @@ -71,7 +71,7 @@ public class SSAUConstructorSparseEx {
@@ -415,7 +415,7 @@ index 4edec05..f5719d1 100644
        setInit.add(i);
      }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/GeneralStatement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/GeneralStatement.java
-index 0891a47..c098f3b 100644
+index 0891a4758e43affe4c8f7df991a79bd9475cafc8..c098f3be7e2b67de21ea499ca5e12f120b47572e 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/GeneralStatement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/GeneralStatement.java
 @@ -5,7 +5,8 @@ import org.jetbrains.java.decompiler.main.collectors.BytecodeMappingTracer;
@@ -438,7 +438,7 @@ index 0891a47..c098f3b 100644
  
      for (Statement st : set) {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
-index ab48ecc..e146481 100644
+index ab48eccfcad8e5b0f58ad6bb401587b1d71bab2d..e14648190ba6e309992149b9a60105a53caacf9f 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
 @@ -63,7 +63,15 @@ public class SwitchStatement extends Statement {
@@ -459,7 +459,7 @@ index ab48ecc..e146481 100644
      }
    }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java
-index adbb6fd..c211d68 100644
+index adbb6fd39f8dca8e6ef97916354e3cb4e59340c9..c211d680fe9d488b302c92e0ad1ba37f233675ec 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java
 @@ -215,7 +215,10 @@ public class VarVersionsProcessor {
@@ -475,7 +475,7 @@ index adbb6fd..c211d68 100644
        if (pair.version >= 0) {
          int newIndex = pair.version == 1 ? pair.var : counters.getCounterAndIncrement(CounterContainer.VAR_COUNTER);
 diff --git a/testData/results/MoreAnnotations.dec b/testData/results/MoreAnnotations.dec
-index 37302cc..069c033 100644
+index 37302cc3db53fe0bbcfdab2e7a9653812a320235..069c0334a1df23c17159f8f199045438559b7687 100644
 --- a/testData/results/MoreAnnotations.dec
 +++ b/testData/results/MoreAnnotations.dec
 @@ -34,8 +34,8 @@ public @interface MoreAnnotations {
@@ -532,7 +532,7 @@ index 37302cc..069c033 100644
  }
  
 diff --git a/testData/results/TestAnonymousClass.dec b/testData/results/TestAnonymousClass.dec
-index 924b764..14c92f9 100644
+index 924b7641e3454daf3ce738de750dfcfa587fa18d..14c92f960012ea63747096f9237fca7ee5e70ced 100644
 --- a/testData/results/TestAnonymousClass.dec
 +++ b/testData/results/TestAnonymousClass.dec
 @@ -67,15 +67,8 @@ public abstract class TestAnonymousClass {
@@ -636,7 +636,7 @@ index 924b764..14c92f9 100644
  18
  104
 diff --git a/testData/results/TestAnonymousClassConstructor.dec b/testData/results/TestAnonymousClassConstructor.dec
-index 66960ce..63abd4a 100644
+index 66960ce40f72703d3577549847d033f011007834..63abd4acbe8cf73eb9628724b632af1a9ca231a3 100644
 --- a/testData/results/TestAnonymousClassConstructor.dec
 +++ b/testData/results/TestAnonymousClassConstructor.dec
 @@ -65,16 +65,16 @@ class TestAnonymousClassConstructor {
@@ -780,7 +780,7 @@ index 66960ce..63abd4a 100644
  57
  63
 diff --git a/testData/results/TestClassSimpleBytecodeMapping.dec b/testData/results/TestClassSimpleBytecodeMapping.dec
-index 8883fab..d5f7070 100644
+index 8883fab6ffd4b5f8b8b656b96e9a5c45d0e1bfb9..d5f7070f5b6618b11ea075941af29d4278059b59 100644
 --- a/testData/results/TestClassSimpleBytecodeMapping.dec
 +++ b/testData/results/TestClassSimpleBytecodeMapping.dec
 @@ -33,17 +33,17 @@ public class TestClassSimpleBytecodeMapping {
@@ -842,7 +842,7 @@ index 8883fab..d5f7070 100644
  Not mapped:
  39
 diff --git a/testData/results/TestConstants.dec b/testData/results/TestConstants.dec
-index 28df2c2..1170f1a 100644
+index 28df2c294ca1c0818ffad43052919c61c262c16a..1170f1a5876121e55bc5c58a2d10afeac8d1527f 100644
 --- a/testData/results/TestConstants.dec
 +++ b/testData/results/TestConstants.dec
 @@ -16,14 +16,14 @@ public class TestConstants {
@@ -867,7 +867,7 @@ index 28df2c2..1170f1a 100644
     static final double DMax = 1.7976931348623157E308D;
  
 diff --git a/testData/results/TestExtendingSubclass.dec b/testData/results/TestExtendingSubclass.dec
-index 5e13985..2caf740 100644
+index 5e13985808328287c750d776eee29041bec8e3fe..2caf74011a7beee7fd2a9fdebe1873be625a8f1a 100644
 --- a/testData/results/TestExtendingSubclass.dec
 +++ b/testData/results/TestExtendingSubclass.dec
 @@ -1,35 +1,35 @@
@@ -920,7 +920,7 @@ index 5e13985..2caf740 100644
  8
  13
 diff --git a/testData/results/TestInnerLocal.dec b/testData/results/TestInnerLocal.dec
-index af4fb30..f728ad7 100644
+index af4fb30496706a46dcc578948b4c66ef90b6d65e..f728ad7e3493b296f88d919a028b646096f733c7 100644
 --- a/testData/results/TestInnerLocal.dec
 +++ b/testData/results/TestInnerLocal.dec
 @@ -30,6 +30,14 @@ public class TestInnerLocal {
@@ -1032,7 +1032,7 @@ index af4fb30..f728ad7 100644
  7
  19
 diff --git a/testData/results/TestInnerSignature.dec b/testData/results/TestInnerSignature.dec
-index b2e4d0f..8aab3c2 100644
+index b2e4d0f757e55cd9ab6bd77aa9ed0afb33989e7d..8aab3c2b9f56368f1350f1ac98262c761bf6ed19 100644
 --- a/testData/results/TestInnerSignature.dec
 +++ b/testData/results/TestInnerSignature.dec
 @@ -11,18 +11,6 @@ public class TestInnerSignature<A, B, C> {
@@ -1136,7 +1136,7 @@ index b2e4d0f..8aab3c2 100644
  8
  19
 diff --git a/testData/results/TestMethodParameters.dec b/testData/results/TestMethodParameters.dec
-index 21f0f12..af7ce86 100644
+index 21f0f129d1bc260e2dbc7ce77f07ece57711bf75..af7ce865f5d946980010ee02c3e5be384a041064 100644
 --- a/testData/results/TestMethodParameters.dec
 +++ b/testData/results/TestMethodParameters.dec
 @@ -21,6 +21,14 @@ public class TestMethodParameters {
@@ -1225,7 +1225,7 @@ index 21f0f12..af7ce86 100644
  37 <-> 19
  39 <-> 22
 diff --git a/testData/results/TestSwitchOnEnum.dec b/testData/results/TestSwitchOnEnum.dec
-index b6984c3..3406481 100644
+index b6984c399ceff5434ddf72837649389341a00ea5..34064819cc6a520a13bc3fd718a046861414ae4c 100644
 --- a/testData/results/TestSwitchOnEnum.dec
 +++ b/testData/results/TestSwitchOnEnum.dec
 @@ -36,15 +36,15 @@ public class TestSwitchOnEnum {
@@ -1249,6 +1249,3 @@ index b6984c3..3406481 100644
     }
  }
  
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0006-Convert-Exprent.bytecode-to-a-BitMap.patch
+++ b/FernFlower-Patches/0006-Convert-Exprent.bytecode-to-a-BitMap.patch
@@ -1,15 +1,12 @@
-From c1a8e1becde30b672d737f5103966bf258692fc2 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Wed, 12 Apr 2017 15:18:38 -0700
-Subject: [PATCH] Convert Exprent.bytecode to a BitMap, as it gives better
- speed and functionality. Added method to gather bytecode markers for every
- expression. Allows us to get the bytecode offsets for an entire block of
- code. Also more aggressively capture bytecode ranges to better understand how
- much of the code we are processing/outputting
+Subject: [PATCH] Convert Exprent.bytecode to a BitMap.
 
+It gives better speed and functionality. Added method to gather bytecode markers for every expression. Allows us to get the bytecode offsets for an entire block of code. Also more aggressively capture bytecode ranges to better understand how much of the code we are processing/outputting
 
 diff --git a/src/org/jetbrains/java/decompiler/code/Instruction.java b/src/org/jetbrains/java/decompiler/code/Instruction.java
-index 1a260f2..6d2463f 100644
+index 1a260f2bbd2c593351eb45f345b334045c93ad4c..6d2463f7a97aca61bf0642c9bb4930645a6b96a1 100644
 --- a/src/org/jetbrains/java/decompiler/code/Instruction.java
 +++ b/src/org/jetbrains/java/decompiler/code/Instruction.java
 @@ -2,20 +2,21 @@
@@ -68,7 +65,7 @@ index 1a260f2..6d2463f 100644
 \ No newline at end of file
 +}
 diff --git a/src/org/jetbrains/java/decompiler/code/JumpInstruction.java b/src/org/jetbrains/java/decompiler/code/JumpInstruction.java
-index 129df62..1597df0 100644
+index 129df62e7295cbd4145880d2c215d5c1e717ffe6..1597df01326479fd8992af4b6e754dd6223a50e6 100644
 --- a/src/org/jetbrains/java/decompiler/code/JumpInstruction.java
 +++ b/src/org/jetbrains/java/decompiler/code/JumpInstruction.java
 @@ -4,8 +4,8 @@ package org.jetbrains.java.decompiler.code;
@@ -83,7 +80,7 @@ index 129df62..1597df0 100644
  
    @Override
 diff --git a/src/org/jetbrains/java/decompiler/code/SwitchInstruction.java b/src/org/jetbrains/java/decompiler/code/SwitchInstruction.java
-index 61810d9..6379cca 100644
+index 61810d96bea8e35006df80630e9caf029b33b41c..6379ccadaf4d0b7bf2a4001481b408dd33b3f7bd 100644
 --- a/src/org/jetbrains/java/decompiler/code/SwitchInstruction.java
 +++ b/src/org/jetbrains/java/decompiler/code/SwitchInstruction.java
 @@ -6,8 +6,8 @@ public class SwitchInstruction extends Instruction {
@@ -105,7 +102,7 @@ index 61810d9..6379cca 100644
 \ No newline at end of file
 +}
 diff --git a/src/org/jetbrains/java/decompiler/code/cfg/BasicBlock.java b/src/org/jetbrains/java/decompiler/code/cfg/BasicBlock.java
-index 265ffca..e89d9e4 100644
+index 265ffca9a139bd0cb7a4a2e1e68a8f3032939b9a..e89d9e45ac59e28e49a82c1838f24d57f029406b 100644
 --- a/src/org/jetbrains/java/decompiler/code/cfg/BasicBlock.java
 +++ b/src/org/jetbrains/java/decompiler/code/cfg/BasicBlock.java
 @@ -190,4 +190,19 @@ public class BasicBlock implements IGraphNode {
@@ -130,7 +127,7 @@ index 265ffca..e89d9e4 100644
  }
 \ No newline at end of file
 diff --git a/src/org/jetbrains/java/decompiler/main/collectors/BytecodeMappingTracer.java b/src/org/jetbrains/java/decompiler/main/collectors/BytecodeMappingTracer.java
-index c6a23b3..32ca965 100644
+index c6a23b3277c3a93be621d6686b1554d51be01c9b..32ca965883f26cd8944bfb5e838d5cf584142f68 100644
 --- a/src/org/jetbrains/java/decompiler/main/collectors/BytecodeMappingTracer.java
 +++ b/src/org/jetbrains/java/decompiler/main/collectors/BytecodeMappingTracer.java
 @@ -31,10 +31,10 @@ public class BytecodeMappingTracer {
@@ -148,7 +145,7 @@ index c6a23b3..32ca965 100644
      }
    }
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-index 3625c48..5606e91 100644
+index 3625c482744fe98f41fda3736355c50b7ed514e6..5606e91f5ea92b921d73ea9d85360a8d924c14fc 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 @@ -532,7 +532,7 @@ public class NestedClassProcessor {
@@ -170,7 +167,7 @@ index 3625c48..5606e91 100644
              }
  
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/ConcatenationHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/ConcatenationHelper.java
-index 7d5c207..5290152 100644
+index 7d5c207d5e58028c214db07093a1d16d76fb70a1..5290152d9aefe9d1aa8674325876a9b3fc4b445d 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/ConcatenationHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ConcatenationHelper.java
 @@ -10,8 +10,8 @@ import org.jetbrains.java.decompiler.struct.gen.VarType;
@@ -193,7 +190,7 @@ index 7d5c207..5290152 100644
      Exprent func = lstOperands.get(0);
  
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
-index 010566b..6aa0616 100644
+index 010566ba18cc005e72ddcbf7eea17f0f533a87d9..6aa061689f525158f31aee3fdcc114ac89f11ae5 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 @@ -282,7 +282,15 @@ public class ExprProcessor implements CodeConstants {
@@ -276,7 +273,7 @@ index 010566b..6aa0616 100644
 \ No newline at end of file
 +}
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java
-index bcd6a6c..c3e3732 100644
+index bcd6a6c52620e19cf9f7cba7679dfe493ee54528..c3e37329d651b983484736154c6fccbe8b851218 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java
 @@ -318,6 +318,7 @@ public class FinallyProcessor {
@@ -328,7 +325,7 @@ index bcd6a6c..c3e3732 100644
 \ No newline at end of file
 +}
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/MergeHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/MergeHelper.java
-index ed9f368..3f351c1 100644
+index ed9f368b5913a7b0316cddd0e40c88d499510fe6..3f351c1c9c1d646854e4dff428c1f065296b1291 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/MergeHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/MergeHelper.java
 @@ -89,6 +89,12 @@ public class MergeHelper {
@@ -392,7 +389,7 @@ index ed9f368..3f351c1 100644
  
      if (lastData.getExprents().isEmpty()) {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
-index 72c845f..26f82b9 100644
+index 72c845f20473ef66ad68ed0a30dbefd8597a6bb6..26f82b92d1b4a972032c05203e8bb642aaba493e 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
 @@ -638,7 +638,7 @@ public class SimplifyExprentsHelper {
@@ -405,7 +402,7 @@ index 72c845f..26f82b9 100644
        if (statement.iftype == IfStatement.IFTYPE_IFELSE) {
          Statement ifStatement = statement.getIfstat();
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/deobfuscator/ExceptionDeobfuscator.java b/src/org/jetbrains/java/decompiler/modules/decompiler/deobfuscator/ExceptionDeobfuscator.java
-index 810291d..26d7839 100644
+index 810291db635243e735195cebd131738904b33de5..26d78392196bdf3033d633d5e9f9a7f45211ffcb 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/deobfuscator/ExceptionDeobfuscator.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/deobfuscator/ExceptionDeobfuscator.java
 @@ -409,8 +409,8 @@ public class ExceptionDeobfuscator {
@@ -420,7 +417,7 @@ index 810291d..26d7839 100644
          BasicBlock dummyBlock = new BasicBlock(++graph.last_id);
          dummyBlock.setSeq(seq);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AnnotationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AnnotationExprent.java
-index c1d7551..a6601ee 100644
+index c1d755183f276c66f087e86b0cf8b0aa4c198f75..a6601eee39bde738f840f01806a13b907583af50 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AnnotationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AnnotationExprent.java
 @@ -9,6 +9,7 @@ import org.jetbrains.java.decompiler.modules.decompiler.ExprProcessor;
@@ -444,7 +441,7 @@ index c1d7551..a6601ee 100644
  }
 \ No newline at end of file
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ArrayExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ArrayExprent.java
-index 753a0a6..bf5ff14 100644
+index 753a0a60059ba84b3cb42edf782ab312a18791ca..bf5ff14382c3d5e655778298c87fbe6a8b6592c3 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ArrayExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ArrayExprent.java
 @@ -9,15 +9,15 @@ import org.jetbrains.java.decompiler.util.InterpreterUtil;
@@ -479,7 +476,7 @@ index 753a0a6..bf5ff14 100644
  }
 \ No newline at end of file
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssertExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssertExprent.java
-index 0dcb63d..097c10a 100644
+index 0dcb63d34c036a9cd21e21d77c2ea01f6f5b9266..097c10a32ed819368c48efa51866420c01584395 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssertExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssertExprent.java
 @@ -6,6 +6,7 @@ package org.jetbrains.java.decompiler.modules.decompiler.exps;
@@ -502,7 +499,7 @@ index 0dcb63d..097c10a 100644
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssignmentExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssignmentExprent.java
-index c590ac5..e2768f5 100644
+index c590ac5a15ba65b7dfc90cac27e1b34e5d1ffefd..e2768f5f53f670e2189454970d66524b4446021a 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssignmentExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssignmentExprent.java
 @@ -15,8 +15,8 @@ import org.jetbrains.java.decompiler.util.InterpreterUtil;
@@ -539,7 +536,7 @@ index c590ac5..e2768f5 100644
    // getter and setter methods
    // *****************************************************************************
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
-index 691d613..e97be6c 100644
+index 691d613050f89cce24136dc957a38b65cc51fc4c..e97be6c82f048e553b0e24b9311169ea5626e263 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
 @@ -36,15 +36,15 @@ public class ConstExprent extends Exprent {
@@ -574,7 +571,7 @@ index 691d613..e97be6c 100644
    // IMatchable implementation
    // *****************************************************************************
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ExitExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ExitExprent.java
-index b3cc07d..61b29a8 100644
+index b3cc07de2a2ef613de320e120e2f0957aed4cbbd..61b29a83579f85aaba32dd0e432de825a106457d 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ExitExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ExitExprent.java
 @@ -17,8 +17,8 @@ import org.jetbrains.java.decompiler.util.InterpreterUtil;
@@ -611,7 +608,7 @@ index b3cc07d..61b29a8 100644
    // IMatchable implementation
    // *****************************************************************************
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
-index 0994d94..7183241 100644
+index 0994d9466eda95b46d3f234bf977e8e9aa0e0899..7183241d331031e66f1afca8bce8feffa985e7a2 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
 @@ -16,7 +16,7 @@ import org.jetbrains.java.decompiler.struct.match.MatchNode;
@@ -680,7 +677,7 @@ index 0994d94..7183241 100644
    }
  
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
-index c79f1a6..45b9f87 100644
+index c79f1a6fc6d13c3e61d877624c18b117a5567ce6..45b9f87924ca6d651fb2ab0a4671eb95cdb696fd 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
 @@ -22,8 +22,8 @@ import org.jetbrains.java.decompiler.util.TextBuffer;
@@ -726,7 +723,7 @@ index c79f1a6..45b9f87 100644
    // IMatchable implementation
    // *****************************************************************************
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
-index 6bdd8db..53b7403 100644
+index 6bdd8dbe64e8fc562952e63f424b562d9bbc17b0..53b7403a24707b5719aeec34bfba8391c664b502 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
 @@ -186,7 +186,7 @@ public class FunctionExprent extends Exprent {
@@ -770,7 +767,7 @@ index 6bdd8db..53b7403 100644
    // IMatchable implementation
    // *****************************************************************************
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/IfExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/IfExprent.java
-index 32dd0ba..f9177d5 100644
+index 32dd0ba62d28eb445ccae63f8d688b6a3d41404f..f9177d5f5f7991637bb793cdf479b6af63dcf414 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/IfExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/IfExprent.java
 @@ -10,6 +10,7 @@ import org.jetbrains.java.decompiler.util.ListStack;
@@ -813,7 +810,7 @@ index 32dd0ba..f9177d5 100644
 +  }
 +}
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 3fe26b3..87522af 100644
+index 3fe26b38b93b72d776e506b6158cb7968270d7c2..87522af363670f27a69bf5dee95a954ae14ed594 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -65,7 +65,7 @@ public class InvocationExprent extends Exprent {
@@ -840,7 +837,7 @@ index 3fe26b3..87522af 100644
    // IMatchable implementation
    // *****************************************************************************
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/MonitorExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/MonitorExprent.java
-index 4172874..380f47a 100644
+index 4172874fff5ab1323bb477bbf3cdd5710a197945..380f47a9de0e1b9d342d5c8557175d7e5a6b1e8a 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/MonitorExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/MonitorExprent.java
 @@ -8,8 +8,8 @@ import org.jetbrains.java.decompiler.util.InterpreterUtil;
@@ -874,7 +871,7 @@ index 4172874..380f47a 100644
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
-index e946c9a..7914279 100644
+index e946c9a285276d946475add0803bfa789ccdd155..7914279296b8aaa495f85bed6439676c15963411 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
 @@ -20,8 +20,9 @@ import org.jetbrains.java.decompiler.util.ListStack;
@@ -918,7 +915,7 @@ index e946c9a..7914279 100644
      return constructor;
    }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/SwitchExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/SwitchExprent.java
-index 3a97175..81f7546 100644
+index 3a97175bf6ff44f745e9d4738a34aae2b4d05437..81f7546312493c244636b50fa972c0a3817b9aed 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/SwitchExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/SwitchExprent.java
 @@ -10,15 +10,15 @@ import org.jetbrains.java.decompiler.util.InterpreterUtil;
@@ -963,7 +960,7 @@ index 3a97175..81f7546 100644
      return value;
    }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
-index f30082e..e3b253c 100644
+index f30082ee0cfb054456d81f57658e8cc73ce206f1..e3b253c9526436c1dab974cac21680a571998f43 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
 @@ -27,6 +27,7 @@ import org.jetbrains.java.decompiler.util.TextBuffer;
@@ -1038,7 +1035,7 @@ index f30082e..e3b253c 100644
      return index;
    }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/BasicBlockStatement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/BasicBlockStatement.java
-index 262a01f..cf79818 100644
+index 262a01f7e3d64235423a7b2e5ed915ff057c9355..cf79818c542c47c6c1e128197dce3061002dcdb8 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/BasicBlockStatement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/BasicBlockStatement.java
 @@ -10,6 +10,7 @@ import org.jetbrains.java.decompiler.main.collectors.BytecodeMappingTracer;
@@ -1064,7 +1061,7 @@ index 262a01f..cf79818 100644
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DummyExitStatement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DummyExitStatement.java
-index c1d4530..5fc00b4 100644
+index c1d4530d9264e3ab97563ab0541d9d674c7c130d..5fc00b45371c373f2a60cff44e04e9e2b789981d 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DummyExitStatement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DummyExitStatement.java
 @@ -1,25 +1,21 @@
@@ -1099,7 +1096,7 @@ index c1d4530..5fc00b4 100644
    }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/IfStatement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/IfStatement.java
-index bf18c51..3b5d0d2 100644
+index bf18c51ae7be623619ecf734fc70d870232c8f74..3b5d0d254e7325eaed110434744f29201c6229b6 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/IfStatement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/IfStatement.java
 @@ -11,6 +11,7 @@ import org.jetbrains.java.decompiler.struct.match.IMatchable;
@@ -1125,7 +1122,7 @@ index bf18c51..3b5d0d2 100644
    // IMatchable implementation
    // *****************************************************************************
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/RootStatement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/RootStatement.java
-index 61eca33..8649444 100644
+index 61eca33c037cb575b1b6df2addd1ffcdf2aa671b..8649444b62e0d98aa08ecc1276fc8602ea42dcdc 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/RootStatement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/RootStatement.java
 @@ -4,6 +4,7 @@ package org.jetbrains.java.decompiler.modules.decompiler.stats;
@@ -1149,7 +1146,7 @@ index 61eca33..8649444 100644
 +  }
 +}
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java
-index b905da5..74f44c0 100644
+index b905da55c9b3bd7dc48123559809a1d7ed9eaf9c..74f44c077c0985fa23145f39d617976f94571f55 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java
 @@ -16,6 +16,7 @@ import org.jetbrains.java.decompiler.struct.match.IMatchable;
@@ -1202,7 +1199,7 @@ index b905da5..74f44c0 100644
    // IMatchable implementation
    // *****************************************************************************
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
-index e146481..0f12b13 100644
+index e14648190ba6e309992149b9a60105a53caacf9f..0f12b13c14272a923540ff71f59b41b1b1295f07 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/SwitchStatement.java
 @@ -16,6 +16,7 @@ import org.jetbrains.java.decompiler.modules.decompiler.exps.FieldExprent;
@@ -1232,7 +1229,7 @@ index e146481..0f12b13 100644
    // private methods
    // *****************************************************************************
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructMethod.java b/src/org/jetbrains/java/decompiler/struct/StructMethod.java
-index 859805c..dbfcc2c 100644
+index 859805c20928564c3388e2593b80ac233599d8b3..dbfcc2cd5cb3cf326612bbc0f6496b83d5992de2 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructMethod.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructMethod.java
 @@ -313,11 +313,11 @@ public class StructMethod extends StructMember {
@@ -1259,7 +1256,7 @@ index 859805c..dbfcc2c 100644
 +}
 diff --git a/src/org/jetbrains/java/decompiler/util/StartEndPair.java b/src/org/jetbrains/java/decompiler/util/StartEndPair.java
 new file mode 100644
-index 0000000..ded36aa
+index 0000000000000000000000000000000000000000..ded36aadd72242ba74e3392e0891c6c82ac6b920
 --- /dev/null
 +++ b/src/org/jetbrains/java/decompiler/util/StartEndPair.java
 @@ -0,0 +1,51 @@
@@ -1315,7 +1312,7 @@ index 0000000..ded36aa
 +  }
 +}
 diff --git a/testData/results/InvalidMethodSignature.dec b/testData/results/InvalidMethodSignature.dec
-index e4b567c..ce8afab 100644
+index e4b567c433b4a80e0c01119a8f115611dffe93be..ce8afaba80cd2197e1831af1af6be13da86962cb 100644
 --- a/testData/results/InvalidMethodSignature.dec
 +++ b/testData/results/InvalidMethodSignature.dec
 @@ -26,19 +26,51 @@ class i implements bg {
@@ -1371,7 +1368,7 @@ index e4b567c..ce8afab 100644
     }
  
 diff --git a/testData/results/TestAbstractMethods.dec b/testData/results/TestAbstractMethods.dec
-index 781cbfc..c0e60eb 100644
+index 781cbfcf0bf85491e31f60dc3087d3106436ed1b..c0e60eb5262ee228d5eb57719bd4caddc8c90651 100644
 --- a/testData/results/TestAbstractMethods.dec
 +++ b/testData/results/TestAbstractMethods.dec
 @@ -16,12 +16,18 @@ public abstract class TestAbstractMethods {
@@ -1394,7 +1391,7 @@ index 781cbfc..c0e60eb 100644
     }
  }
 diff --git a/testData/results/TestAccessReplace.dec b/testData/results/TestAccessReplace.dec
-index f365126..83d1eb2 100644
+index f365126e79b21d9cc1d59591a00f219bf0755424..83d1eb2fac3378e5d556aeeebc70bb83a4e5cba8 100644
 --- a/testData/results/TestAccessReplace.dec
 +++ b/testData/results/TestAccessReplace.dec
 @@ -15,7 +15,7 @@ public class TestAccessReplace {
@@ -1447,7 +1444,7 @@ index f365126..83d1eb2 100644
 -25
 +26
 diff --git a/testData/results/TestAmbiguousCall.dec b/testData/results/TestAmbiguousCall.dec
-index a48730d..dec7ba0 100644
+index a48730dcfb207c76a0959c5c34d59c5d3d503897..dec7ba0f20eecdc5a3c7d0774a0fdd4f3b68e6f6 100644
 --- a/testData/results/TestAmbiguousCall.dec
 +++ b/testData/results/TestAmbiguousCall.dec
 @@ -28,16 +28,38 @@ class 'pkg/TestAmbiguousCall' {
@@ -1490,7 +1487,7 @@ index a48730d..dec7ba0 100644
     }
  }
 diff --git a/testData/results/TestAmbiguousCallWithDebugInfo.dec b/testData/results/TestAmbiguousCallWithDebugInfo.dec
-index b697e79..e873e7e 100644
+index b697e795761f0f254e341663f4934e06ae3af8ef..e873e7e3cc488b036a46c332bd724e3fac30f720 100644
 --- a/testData/results/TestAmbiguousCallWithDebugInfo.dec
 +++ b/testData/results/TestAmbiguousCallWithDebugInfo.dec
 @@ -28,16 +28,38 @@ class 'pkg/TestAmbiguousCall' {
@@ -1533,7 +1530,7 @@ index b697e79..e873e7e 100644
     }
  }
 diff --git a/testData/results/TestAnonymousClass.dec b/testData/results/TestAnonymousClass.dec
-index 14c92f9..b86b5fd 100644
+index 14c92f960012ea63747096f9237fca7ee5e70ced..b86b5fdcf18f733f846dd2cb4d5796d8046cf965 100644
 --- a/testData/results/TestAnonymousClass.dec
 +++ b/testData/results/TestAnonymousClass.dec
 @@ -46,12 +46,12 @@ public abstract class TestAnonymousClass {
@@ -1593,7 +1590,7 @@ index 14c92f9..b86b5fd 100644
  14 <-> 52
  15 <-> 53
 diff --git a/testData/results/TestAnonymousClassConstructor.dec b/testData/results/TestAnonymousClassConstructor.dec
-index 63abd4a..e0ab2c8 100644
+index 63abd4acbe8cf73eb9628724b632af1a9ca231a3..e0ab2c8e78b4489495c36623c734ca58c68fccd4 100644
 --- a/testData/results/TestAnonymousClassConstructor.dec
 +++ b/testData/results/TestAnonymousClassConstructor.dec
 @@ -117,139 +117,207 @@ class TestAnonymousClassConstructor {
@@ -1805,7 +1802,7 @@ index 63abd4a..e0ab2c8 100644
     }
  }
 diff --git a/testData/results/TestAnonymousParams.dec b/testData/results/TestAnonymousParams.dec
-index c487941..b963eff 100644
+index c48794179eeaa512f49f552cdc691ee62c61adec..b963effed064e192a69c16c927a234a6708f68b2 100644
 --- a/testData/results/TestAnonymousParams.dec
 +++ b/testData/results/TestAnonymousParams.dec
 @@ -6,31 +6,38 @@ import java.io.InputStream;
@@ -1852,7 +1849,7 @@ index c487941..b963eff 100644
  30 <-> 14
  31 <-> 15
 diff --git a/testData/results/TestAnonymousSignature.dec b/testData/results/TestAnonymousSignature.dec
-index 95ad203..0c183ba 100644
+index 95ad203e3412f03b51eb06a9f926586f653042de..0c183ba28589c504aafed9631bea09e6524ae19d 100644
 --- a/testData/results/TestAnonymousSignature.dec
 +++ b/testData/results/TestAnonymousSignature.dec
 @@ -21,6 +21,8 @@ public class TestAnonymousSignature {
@@ -1883,7 +1880,7 @@ index 95ad203..0c183ba 100644
     }
  }
 diff --git a/testData/results/TestAsserts.dec b/testData/results/TestAsserts.dec
-index f260d9e..c9e51a5 100644
+index f260d9efcbc1332056ce9b534d56a3305fbd4bf1..c9e51a54a63c5615a5e6b03ef1e256b8067233e9 100644
 --- a/testData/results/TestAsserts.dec
 +++ b/testData/results/TestAsserts.dec
 @@ -16,10 +16,13 @@ class 'pkg/TestAsserts' {
@@ -1901,7 +1898,7 @@ index f260d9e..c9e51a5 100644
        22      8
        2d      10
 diff --git a/testData/results/TestClashName.dec b/testData/results/TestClashName.dec
-index 43348ea..1424265 100644
+index 43348ea674adf840021a807e16fd231a51939c1d..14242655cc785caa4ba0773580f4795b410c2ef9 100644
 --- a/testData/results/TestClashName.dec
 +++ b/testData/results/TestClashName.dec
 @@ -32,17 +32,37 @@ public class TestClashName extends ext.TestClashNameParent implements TestClashN
@@ -1943,7 +1940,7 @@ index 43348ea..1424265 100644
        20      25
     }
 diff --git a/testData/results/TestClassCast.dec b/testData/results/TestClassCast.dec
-index e807294..f602eea 100644
+index e807294b770fefe3a7ea25c77e7b962b65e345f9..f602eea1b4bd4eb097a41992cd3271020a15c2c5 100644
 --- a/testData/results/TestClassCast.dec
 +++ b/testData/results/TestClassCast.dec
 @@ -16,14 +16,29 @@ public class TestClassCast {
@@ -1977,7 +1974,7 @@ index e807294..f602eea 100644
     }
  }
 diff --git a/testData/results/TestClassFields.dec b/testData/results/TestClassFields.dec
-index 852ae47..1547551 100644
+index 852ae473bdfa591e28aa9b132f9f358ee1fc6eeb..1547551e536084420a529a7cb7c5d621159938b3 100644
 --- a/testData/results/TestClassFields.dec
 +++ b/testData/results/TestClassFields.dec
 @@ -17,8 +17,12 @@ public class TestClassFields {
@@ -1994,7 +1991,7 @@ index 852ae47..1547551 100644
     }
  }
 diff --git a/testData/results/TestClassLambda.dec b/testData/results/TestClassLambda.dec
-index cae1518..9bb7d48 100644
+index cae1518889f1af8977a574de616e37574b3b2c16..9bb7d48e1531f3ac1e467ba8eac25de08b4da3da 100644
 --- a/testData/results/TestClassLambda.dec
 +++ b/testData/results/TestClassLambda.dec
 @@ -22,12 +22,12 @@ public class TestClassLambda {
@@ -2472,7 +2469,7 @@ index cae1518..9bb7d48 100644
 +89 <-> 87
 +90 <-> 88
 diff --git a/testData/results/TestClassLoop.dec b/testData/results/TestClassLoop.dec
-index 55e369b..82e549f 100644
+index 55e369b4cb9d39272293f42d72f62fb60dea4f35..82e549f8076ccb6adf4989e71127c70b223922cc 100644
 --- a/testData/results/TestClassLoop.dec
 +++ b/testData/results/TestClassLoop.dec
 @@ -78,41 +78,68 @@ public class TestClassLoop {
@@ -2604,7 +2601,7 @@ index 55e369b..82e549f 100644
     }
  }
 diff --git a/testData/results/TestClassNestedInitializer.dec b/testData/results/TestClassNestedInitializer.dec
-index 0576e74..f2617df 100644
+index 0576e74a1d8f22a9dee2d72ba7dc984e269abe9d..f2617df3c17a6b9caa908148f7d612a498ed9eee 100644
 --- a/testData/results/TestClassNestedInitializer.dec
 +++ b/testData/results/TestClassNestedInitializer.dec
 @@ -4,34 +4,45 @@ public class TestClassNestedInitializer {
@@ -2658,7 +2655,7 @@ index 0576e74..f2617df 100644
  23 <-> 12
  24 <-> 13
 diff --git a/testData/results/TestClassSimpleBytecodeMapping.dec b/testData/results/TestClassSimpleBytecodeMapping.dec
-index d5f7070..c033983 100644
+index d5f7070f5b6618b11ea075941af29d4278059b59..c033983370f38dda5935716026b9d339e9eac24a 100644
 --- a/testData/results/TestClassSimpleBytecodeMapping.dec
 +++ b/testData/results/TestClassSimpleBytecodeMapping.dec
 @@ -49,8 +49,13 @@ public class TestClassSimpleBytecodeMapping {
@@ -2782,7 +2779,7 @@ index d5f7070..c033983 100644
     }
  }
 diff --git a/testData/results/TestClassSwitch.dec b/testData/results/TestClassSwitch.dec
-index d8cb724..a42bfc8 100644
+index d8cb7242db570634da4bf4dfde39371dbd0676f3..a42bfc86fd3fa9948233d709ba8358f1b8ec7908 100644
 --- a/testData/results/TestClassSwitch.dec
 +++ b/testData/results/TestClassSwitch.dec
 @@ -15,12 +15,20 @@ public class TestClassSwitch {
@@ -2807,7 +2804,7 @@ index d8cb724..a42bfc8 100644
        29      6
        2c      8
 diff --git a/testData/results/TestClassTypes.dec b/testData/results/TestClassTypes.dec
-index 1b76bbb..cc61ae7 100644
+index 1b76bbb2e89b84dd33fbda862787f8a9d68ef8c0..cc61ae7e238d542e26bde5062a31523003d1b313 100644
 --- a/testData/results/TestClassTypes.dec
 +++ b/testData/results/TestClassTypes.dec
 @@ -53,29 +53,41 @@ class 'pkg/TestClassTypes' {
@@ -2913,7 +2910,7 @@ index 1b76bbb..cc61ae7 100644
     }
  }
 diff --git a/testData/results/TestClassVar.dec b/testData/results/TestClassVar.dec
-index 14e8b9e..a1c44f7 100644
+index 14e8b9e377dae1246dad22afec036b2e410c3dd9..a1c44f7954ab14e9caa6c85d098fc6d83c70ba82 100644
 --- a/testData/results/TestClassVar.dec
 +++ b/testData/results/TestClassVar.dec
 @@ -42,20 +42,32 @@ class 'pkg/TestClassVar' {
@@ -2984,7 +2981,7 @@ index 14e8b9e..a1c44f7 100644
  }
  
 diff --git a/testData/results/TestCodeConstructs.dec b/testData/results/TestCodeConstructs.dec
-index fefd421..2e422b8 100644
+index fefd4212a729bcafc87860b0ed02969149e019f7..2e422b84f097ceb4f923d2cafe9a0c84c1302881 100644
 --- a/testData/results/TestCodeConstructs.dec
 +++ b/testData/results/TestCodeConstructs.dec
 @@ -15,11 +15,16 @@ class TestCodeConstructs {
@@ -3005,7 +3002,7 @@ index fefd421..2e422b8 100644
        12      10
     }
 diff --git a/testData/results/TestDebugSymbols.dec b/testData/results/TestDebugSymbols.dec
-index e96eb33..1300ffd 100644
+index e96eb3328706553b4bd8c131f5c1708a348531c1..1300ffd36f0d85b2334ff9b30d0dc824b0215caa 100644
 --- a/testData/results/TestDebugSymbols.dec
 +++ b/testData/results/TestDebugSymbols.dec
 @@ -13,22 +13,44 @@ class TestDebugSymbols {
@@ -3054,7 +3051,7 @@ index e96eb33..1300ffd 100644
     }
  }
 diff --git a/testData/results/TestEnum.dec b/testData/results/TestEnum.dec
-index 6fabfae..069e4ef 100644
+index 6fabfaebda76ddd7136b9d8a9f8c354a398e9a0a..069e4efe131ecd59c97e979a3ab4f1fcb8170cfc 100644
 --- a/testData/results/TestEnum.dec
 +++ b/testData/results/TestEnum.dec
 @@ -50,13 +50,20 @@ class 'pkg/TestEnum' {
@@ -3079,7 +3076,7 @@ index 6fabfae..069e4ef 100644
     }
  }
 diff --git a/testData/results/TestExtendingSubclass.dec b/testData/results/TestExtendingSubclass.dec
-index 2caf740..20f4057 100644
+index 2caf74011a7beee7fd2a9fdebe1873be625a8f1a..20f40571d8d00eee74650de2bf483f9ce2a1a1a5 100644
 --- a/testData/results/TestExtendingSubclass.dec
 +++ b/testData/results/TestExtendingSubclass.dec
 @@ -21,7 +21,10 @@ class 'pkg/TestExtendingSubclass$Subclass1' {
@@ -3094,7 +3091,7 @@ index 2caf740..20f4057 100644
     }
  }
 diff --git a/testData/results/TestIffSimplification.dec b/testData/results/TestIffSimplification.dec
-index 595c4cb..f9e97f1 100644
+index 595c4cb3560eb0e2892ad78d4d1e09624972288f..f9e97f1441516c6c91781d0481182641c468eb2a 100644
 --- a/testData/results/TestIffSimplification.dec
 +++ b/testData/results/TestIffSimplification.dec
 @@ -32,54 +32,91 @@ public class TestIffSimplification {
@@ -3190,7 +3187,7 @@ index 595c4cb..f9e97f1 100644
        43      27
        46      27
 diff --git a/testData/results/TestIllegalVarName.dec b/testData/results/TestIllegalVarName.dec
-index 3eb1ea5..5178d84 100644
+index 3eb1ea54a6080827d3022ea409fdbdc84febf881..5178d8421eb80d2f354cf156bb0ada67c8093d19 100644
 --- a/testData/results/TestIllegalVarName.dec
 +++ b/testData/results/TestIllegalVarName.dec
 @@ -21,10 +21,19 @@ public final class TestIllegalVarName {
@@ -3214,7 +3211,7 @@ index 3eb1ea5..5178d84 100644
     }
  }
 diff --git a/testData/results/TestInnerClassConstructor.dec b/testData/results/TestInnerClassConstructor.dec
-index f15701a..2c64a27 100644
+index f15701a8cc1a757ed8689f40ab375bc52e094be1..2c64a2779e6178a1059af45478e8b15d11ada2aa 100644
 --- a/testData/results/TestInnerClassConstructor.dec
 +++ b/testData/results/TestInnerClassConstructor.dec
 @@ -29,6 +29,7 @@ class TestInnerClassConstructor {
@@ -3272,7 +3269,7 @@ index f15701a..2c64a27 100644
     }
  }
 diff --git a/testData/results/TestInnerLocal.dec b/testData/results/TestInnerLocal.dec
-index f728ad7..5873a12 100644
+index f728ad7e3493b296f88d919a028b646096f733c7..5873a128dea3f646318c14f11822d08005c8673e 100644
 --- a/testData/results/TestInnerLocal.dec
 +++ b/testData/results/TestInnerLocal.dec
 @@ -57,52 +57,79 @@ public class TestInnerLocal {
@@ -3371,7 +3368,7 @@ index f728ad7..5873a12 100644
     }
  }
 diff --git a/testData/results/TestInnerSignature.dec b/testData/results/TestInnerSignature.dec
-index 8aab3c2..37b2169 100644
+index 8aab3c2b9f56368f1350f1ac98262c761bf6ed19..37b216917552fc933ebc5fa3239002fa2b52d575 100644
 --- a/testData/results/TestInnerSignature.dec
 +++ b/testData/results/TestInnerSignature.dec
 @@ -38,27 +38,64 @@ public class TestInnerSignature<A, B, C> {
@@ -3444,7 +3441,7 @@ index 8aab3c2..37b2169 100644
     }
  }
 diff --git a/testData/results/TestJava9StringConcat.dec b/testData/results/TestJava9StringConcat.dec
-index 389bb85..29890ed 100644
+index 389bb85905dd216819edf881e0f7fd187a703d64..29890ed8d641519f957d34981fc41e678a7caf2f 100644
 --- a/testData/results/TestJava9StringConcat.dec
 +++ b/testData/results/TestJava9StringConcat.dec
 @@ -12,12 +12,25 @@ public class TestJava9StringConcat {
@@ -3474,7 +3471,7 @@ index 389bb85..29890ed 100644
     }
  }
 diff --git a/testData/results/TestKotlinConstructorKt.dec b/testData/results/TestKotlinConstructorKt.dec
-index d1e3f7b..0e94145 100644
+index d1e3f7b3570c456d37db7afb8bb2c9ae8096c9d6..0e941450d0dabcbec609f869f674d9cc5bdace33 100644
 --- a/testData/results/TestKotlinConstructorKt.dec
 +++ b/testData/results/TestKotlinConstructorKt.dec
 @@ -16,12 +16,12 @@ import kotlin.collections.CollectionsKt;
@@ -3598,7 +3595,7 @@ index d1e3f7b..0e94145 100644
 +12 <-> 32
  13 <-> 35
 diff --git a/testData/results/TestLocalsNames.dec b/testData/results/TestLocalsNames.dec
-index fe6fe79..59563dd 100644
+index fe6fe796965768533ba3cde2a2a79ddc37ee7b3e..59563ddeb1c2cb82405b31d9f0073a1df450c9e8 100644
 --- a/testData/results/TestLocalsNames.dec
 +++ b/testData/results/TestLocalsNames.dec
 @@ -26,40 +26,104 @@ public class TestLocalsNames {
@@ -3707,7 +3704,7 @@ index fe6fe79..59563dd 100644
        bc      23
     }
 diff --git a/testData/results/TestLocalsSignature.dec b/testData/results/TestLocalsSignature.dec
-index 2948bfd..3da716b 100644
+index 2948bfdb98eaac6f172a7abf518ef795304bc56a..3da716bb86c538148347d67c29354a66dc416c17 100644
 --- a/testData/results/TestLocalsSignature.dec
 +++ b/testData/results/TestLocalsSignature.dec
 @@ -13,8 +13,14 @@ public class TestLocalsSignature {
@@ -3726,7 +3723,7 @@ index 2948bfd..3da716b 100644
     }
  }
 diff --git a/testData/results/TestMemberAnnotations.dec b/testData/results/TestMemberAnnotations.dec
-index 1e3a41c..72d29af 100644
+index 1e3a41c0f8acf669d79049228dc72f63fc387528..72d29afee0f95f9b75898720f39cb0519a48863f 100644
 --- a/testData/results/TestMemberAnnotations.dec
 +++ b/testData/results/TestMemberAnnotations.dec
 @@ -22,9 +22,14 @@ class TestMemberAnnotations {
@@ -3745,7 +3742,7 @@ index 1e3a41c..72d29af 100644
        9      13
     }
 diff --git a/testData/results/TestMethodReferenceSameName.dec b/testData/results/TestMethodReferenceSameName.dec
-index 2592d18..beaf26e 100644
+index 2592d18d569d40e672ddbeee8d07b498a3596626..beaf26ef7981bb1d125430c4e3c41c10511d81e2 100644
 --- a/testData/results/TestMethodReferenceSameName.dec
 +++ b/testData/results/TestMethodReferenceSameName.dec
 @@ -14,9 +14,19 @@ public class TestMethodReferenceSameName {
@@ -3771,7 +3768,7 @@ index 2592d18..beaf26e 100644
  }
  
 diff --git a/testData/results/TestPrimitives.dec b/testData/results/TestPrimitives.dec
-index bc930a5..a7d1557 100644
+index bc930a51035d6d89803c5c618fb2f2934c45eb63..a7d1557e6814e071df65c610fbdae860c8ff93bc 100644
 --- a/testData/results/TestPrimitives.dec
 +++ b/testData/results/TestPrimitives.dec
 @@ -172,143 +172,178 @@ public class TestPrimitives {
@@ -4091,7 +4088,7 @@ index bc930a5..a7d1557 100644
  
     method '<init> (ZBSIJFDC)V' {
 diff --git a/testData/results/TestStaticNameClash.dec b/testData/results/TestStaticNameClash.dec
-index 1c0f21a..f36d336 100644
+index 1c0f21a81b83a0ca7e8a43ba1d86f7f0f6fe7b8d..f36d336afcae4bd24201a7e0818d10362d098c90 100644
 --- a/testData/results/TestStaticNameClash.dec
 +++ b/testData/results/TestStaticNameClash.dec
 @@ -10,7 +10,10 @@ public class TestStaticNameClash {
@@ -4106,7 +4103,7 @@ index 1c0f21a..f36d336 100644
     }
  }
 diff --git a/testData/results/TestStringConcat.dec b/testData/results/TestStringConcat.dec
-index b3fc995..951a761 100644
+index b3fc99579d32896fffb309beba1d89a9f14b84ce..951a761c030b7d6e62e309019b361722ebdd40d9 100644
 --- a/testData/results/TestStringConcat.dec
 +++ b/testData/results/TestStringConcat.dec
 @@ -12,16 +12,29 @@ public class TestStringConcat {
@@ -4140,7 +4137,7 @@ index b3fc995..951a761 100644
     }
  }
 diff --git a/testData/results/TestStringLiterals.dec b/testData/results/TestStringLiterals.dec
-index c5afe18..644701c 100644
+index c5afe1865540afe457073567009b4b96132d0a07..644701c21beb2a80ed07fc6ed7b2873f13d4e2db 100644
 --- a/testData/results/TestStringLiterals.dec
 +++ b/testData/results/TestStringLiterals.dec
 @@ -12,20 +12,39 @@ public class TestStringLiterals {
@@ -4184,7 +4181,7 @@ index c5afe18..644701c 100644
     }
  }
 diff --git a/testData/results/TestSwitchOnEnum.dec b/testData/results/TestSwitchOnEnum.dec
-index 3406481..5afdee0 100644
+index 34064819cc6a520a13bc3fd718a046861414ae4c..5afdee0f6dc9f35169315b838d25991b0dd8dd20 100644
 --- a/testData/results/TestSwitchOnEnum.dec
 +++ b/testData/results/TestSwitchOnEnum.dec
 @@ -50,6 +50,7 @@ public class TestSwitchOnEnum {
@@ -4196,7 +4193,7 @@ index 3406481..5afdee0 100644
        24      10
        25      10
 diff --git a/testData/results/TestSynchronizedMapping.dec b/testData/results/TestSynchronizedMapping.dec
-index 84ad48a..6778aa1 100644
+index 84ad48a1e66013579286702e7fee9e562a8369e8..6778aa19b6d347f20cac678bd6414c2e1eac369d 100644
 --- a/testData/results/TestSynchronizedMapping.dec
 +++ b/testData/results/TestSynchronizedMapping.dec
 @@ -16,16 +16,26 @@ public class TestSynchronizedMapping {
@@ -4227,7 +4224,7 @@ index 84ad48a..6778aa1 100644
     }
  }
 diff --git a/testData/results/TestSyntheticAccess.dec b/testData/results/TestSyntheticAccess.dec
-index d5016a2..290e7a3 100644
+index d5016a28f9ecd2cd30317c4c595b8c30b21b63ea..290e7a3cd313d5b54036e0ce2b5eaed572524cb6 100644
 --- a/testData/results/TestSyntheticAccess.dec
 +++ b/testData/results/TestSyntheticAccess.dec
 @@ -39,43 +39,66 @@ class TestSyntheticAccess {
@@ -4301,7 +4298,7 @@ index d5016a2..290e7a3 100644
     }
  }
 diff --git a/testData/results/TestThrowException.dec b/testData/results/TestThrowException.dec
-index 7c52234..1344ac4 100644
+index 7c52234203a98704f4631c8e7d3b6edd27f18c4f..1344ac4d312e381ad98e3c1ef2a33a36d6f6952e 100644
 --- a/testData/results/TestThrowException.dec
 +++ b/testData/results/TestThrowException.dec
 @@ -26,10 +26,15 @@ class 'pkg/TestThrowException$1' {
@@ -4321,7 +4318,7 @@ index 7c52234..1344ac4 100644
     }
  }
 diff --git a/testData/results/TestTryCatchFinally.dec b/testData/results/TestTryCatchFinally.dec
-index 2af717c..20e9afb 100644
+index 2af717c0764a39b168d490d00d0933185ad11fde..20e9afb72b2d2dabc76d29f6bb1f4ef2bfbc5a20 100644
 --- a/testData/results/TestTryCatchFinally.dec
 +++ b/testData/results/TestTryCatchFinally.dec
 @@ -42,42 +42,74 @@ public class TestTryCatchFinally {
@@ -4424,7 +4421,7 @@ index 2af717c..20e9afb 100644
  }
  
 diff --git a/testData/results/TestVarArgCalls.dec b/testData/results/TestVarArgCalls.dec
-index 6cdcd8f..db4cb49 100644
+index 6cdcd8fc638ceeec823172b2859ee8f970f61327..db4cb49cc7816f05dd2e3d82a6b79a7405001e4d 100644
 --- a/testData/results/TestVarArgCalls.dec
 +++ b/testData/results/TestVarArgCalls.dec
 @@ -27,58 +27,135 @@ public class TestVarArgCalls {
@@ -4564,7 +4561,7 @@ index 6cdcd8f..db4cb49 100644
     }
  }
 diff --git a/testData/results/TypeAnnotations.dec b/testData/results/TypeAnnotations.dec
-index 590d894..f743fc8 100644
+index 590d89477cde2bc61395393b10827c7b5b180e7d..f743fc88a30f344f033bbde656589afee1e49bf7 100644
 --- a/testData/results/TypeAnnotations.dec
 +++ b/testData/results/TypeAnnotations.dec
 @@ -31,6 +31,7 @@ class TypeAnnotations {
@@ -4575,6 +4572,3 @@ index 590d894..f743fc8 100644
        2      13
     }
  
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0007-Enhance-switch-on-enum-output.patch
+++ b/FernFlower-Patches/0007-Enhance-switch-on-enum-output.patch
@@ -1,11 +1,11 @@
-From 24cd3bf51d4dbe070edca1fcf35d78d9d81c6825 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Sat, 15 Apr 2017 17:32:28 -0700
 Subject: [PATCH] Enhance switch on enum output
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-index 5606e91..983298e 100644
+index 5606e91f5ea92b921d73ea9d85360a8d924c14fc..983298ea03a14f6b1911b5e43be3538d7e768ddc 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 @@ -2,6 +2,7 @@
@@ -155,7 +155,7 @@ index 5606e91..983298e 100644
    private static void setLambdaVars(ClassNode parent, ClassNode child) {
      if (child.lambdaInformation.is_method_reference) { // method reference, no code and no parameters
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchHelper.java
-index b49bf39..23d28d7 100644
+index b49bf394176bd007bb7aa3571370ca281ea56024..23d28d7fe91ad5c8f5ca9f9ad5d247ae69fd7b93 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SwitchHelper.java
 @@ -8,7 +8,7 @@ import org.jetbrains.java.decompiler.main.extern.IFernflowerLogger;
@@ -338,7 +338,7 @@ zv~1o}$51x!tz$Hsm+A;+8*ra;_KTT}(9eDpL5$P!1+WU8T5QhnF5<-Ag%w;R9VGh%
 RF}#on(r=%hghG)*{{<v4Oc4M8
 
 diff --git a/testData/results/TestEnum.dec b/testData/results/TestEnum.dec
-index 069e4ef..ce2511c 100644
+index 069e4efe131ecd59c97e979a3ab4f1fcb8170cfc..ce2511cc9f80e7162f6d7d3e8d061757a38ba125 100644
 --- a/testData/results/TestEnum.dec
 +++ b/testData/results/TestEnum.dec
 @@ -21,10 +21,32 @@ public enum TestEnum {
@@ -460,7 +460,7 @@ index 069e4ef..ce2511c 100644
 +57 <-> 45
 +59 <-> 48
 diff --git a/testData/src/pkg/TestEnum.java b/testData/src/pkg/TestEnum.java
-index e474d34..974898e 100644
+index e474d341d406981b924706ac065121f2a9603ed4..974898e766f59086aa471ea2ca48352478bece3a 100644
 --- a/testData/src/pkg/TestEnum.java
 +++ b/testData/src/pkg/TestEnum.java
 @@ -35,4 +35,26 @@ public enum TestEnum {
@@ -490,6 +490,3 @@ index e474d34..974898e 100644
 +    }
 +  }
  }
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0008-Reintroduce-DotExporter-for-debugging-purposes.patch
+++ b/FernFlower-Patches/0008-Reintroduce-DotExporter-for-debugging-purposes.patch
@@ -1,11 +1,11 @@
-From 52836026a01ad1ae4d4bac835b1e5a2066a754bf Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Wed, 12 Apr 2017 18:37:18 -0700
 Subject: [PATCH] Reintroduce DotExporter for debugging purposes
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-index 983298e..5c7be12 100644
+index 983298ea03a14f6b1911b5e43be3538d7e768ddc..5c7be12a1097a6464fe674cf62823418d2644e99 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 @@ -27,6 +27,7 @@ import org.jetbrains.java.decompiler.struct.attr.StructEnclosingMethodAttribute;
@@ -25,7 +25,7 @@ index 983298e..5c7be12 100644
              List<Exprent> lst = exprent.getAllExprents(true);
              lst.add(exprent);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java
-index 6efce5e..8e57cd7 100644
+index 6efce5e4b043b2dcb58b4dc21f85da9ac9081a7a..8e57cd727302fe608f178c51ba4a7fb4c8971448 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java
 @@ -14,6 +14,7 @@ import org.jetbrains.java.decompiler.modules.decompiler.stats.Statement;
@@ -73,7 +73,7 @@ index 6efce5e..8e57cd7 100644
      for (DirectNode node : dgraph.nodes) {
  
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java
-index f5719d1..3607a8d 100644
+index f5719d1a14fc0fd41393e44fe84e0d3c9370d323..3607a8dc6483775f12aa23420ffe447ec9e993bd 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java
 @@ -11,6 +11,7 @@ import org.jetbrains.java.decompiler.modules.decompiler.vars.VarVersionPair;
@@ -126,7 +126,7 @@ index f5719d1..3607a8d 100644
      for (DirectNode node : dgraph.nodes) {
  
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java
-index c211d68..eca0d0f 100644
+index c211d680fe9d488b302c92e0ad1ba37f233675ec..eca0d0fb9ef15db26e9de38ebda2bf9ee19857df 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java
 @@ -14,6 +14,7 @@ import org.jetbrains.java.decompiler.modules.decompiler.stats.RootStatement;
@@ -148,7 +148,7 @@ index c211d68..eca0d0f 100644
      typeProcessor.calculateVarTypes(root, graph);
 diff --git a/src/org/jetbrains/java/decompiler/util/DotExporter.java b/src/org/jetbrains/java/decompiler/util/DotExporter.java
 new file mode 100644
-index 0000000..d3c6f92
+index 0000000000000000000000000000000000000000..d3c6f92fbe0e8304f4f3e8d110dbee77eb04fe56
 --- /dev/null
 +++ b/src/org/jetbrains/java/decompiler/util/DotExporter.java
 @@ -0,0 +1,238 @@
@@ -391,6 +391,3 @@ index 0000000..d3c6f92
 +  }
 +}
 \ No newline at end of file
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0009-LVT-Fixes-and-Support-for-Enhanced-For-loop-detectio.patch
+++ b/FernFlower-Patches/0009-LVT-Fixes-and-Support-for-Enhanced-For-loop-detectio.patch
@@ -1,11 +1,11 @@
-From a9be4697c9357fc04432fb0e9c82165a75721fc4 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Tue, 11 Apr 2017 22:54:20 -0700
 Subject: [PATCH] LVT Fixes and Support for Enhanced For loop detection.
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java b/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
-index ca63ad5..fa79617 100644
+index ca63ad5131641e1ce917afabf84700cd9121d987..fa7961777d41bc0845f741689c33143851eabf63 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
 @@ -8,7 +8,6 @@ import org.jetbrains.java.decompiler.main.collectors.VarNamesCollector;
@@ -44,7 +44,7 @@ index ca63ad5..fa79617 100644
          }
        }
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
-index 726d747..447780c 100644
+index 726d7474416cfea5c21483e06d3e8ac19f500c20..447780c1ed1316d6f30cd35150061b7946233315 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
 @@ -11,7 +11,13 @@ import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
@@ -143,7 +143,7 @@ index 726d747..447780c 100644
  }
 \ No newline at end of file
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-index 5c7be12..fb9c7a9 100644
+index 5c7be12a1097a6464fe674cf62823418d2644e99..fb9c7a961ec3cfc1f50c3fd902c299e097988997 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 @@ -25,6 +25,7 @@ import org.jetbrains.java.decompiler.struct.StructField;
@@ -404,7 +404,7 @@ index 5c7be12..fb9c7a9 100644
 +  }
 +}
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java
-index bc3cb33..63b4b35 100644
+index bc3cb3311e6b132f46025ed498a6fc7e6d583d02..63b4b35ab95a3ba989109c19aaec494290b4bcd9 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java
 @@ -9,6 +9,8 @@ import org.jetbrains.java.decompiler.main.extern.IFernflowerLogger;
@@ -438,7 +438,7 @@ index bc3cb33..63b4b35 100644
  
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/EliminateLoopsHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/EliminateLoopsHelper.java
 new file mode 100644
-index 0000000..adc7839
+index 0000000000000000000000000000000000000000..adc78392c4a82692b32a603e7c0aa90db86a800a
 --- /dev/null
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/EliminateLoopsHelper.java
 @@ -0,0 +1,199 @@
@@ -642,7 +642,7 @@ index 0000000..adc7839
 +  }
 +}
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/ExitHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/ExitHelper.java
-index 3b9847f..3d458f9 100644
+index 3b9847f569e2f820e2fe3d9648ba0cbff7f9cb30..3d458f93edaa8351fcad19f8453be6699c6f9ab0 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExitHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExitHelper.java
 @@ -171,7 +171,7 @@ public class ExitHelper {
@@ -655,7 +655,7 @@ index 3b9847f..3d458f9 100644
  
        if (data != null && data.size() == 1) {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
-index 6aa0616..f19e321 100644
+index 6aa061689f525158f31aee3fdcc114ac89f11ae5..f19e321da5e392eff9c87da6018aa1407411332d 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 @@ -330,7 +330,9 @@ public class ExprProcessor implements CodeConstants {
@@ -690,7 +690,7 @@ index 6aa0616..f19e321 100644
              instr.operand(1) < 0 ? FunctionExprent.FUNCTION_SUB : FunctionExprent.FUNCTION_ADD, Arrays
              .asList(vevar.copy(), new ConstExprent(VarType.VARTYPE_INT, Math.abs(instr.operand(1)), null)),
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/InlineSingleBlockHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/InlineSingleBlockHelper.java
-index f6ee600..b7fa59c 100644
+index f6ee600ab9fde26b8849bb081cd04b68ed95faa7..b7fa59c05e7e403287d65d8ee3918fdf427eadf5 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/InlineSingleBlockHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/InlineSingleBlockHelper.java
 @@ -118,6 +118,9 @@ public class InlineSingleBlockHelper {
@@ -704,7 +704,7 @@ index f6ee600..b7fa59c 100644
            for (int i = index; i < seq.getStats().size(); i++) {
              if (!noExitLabels(seq.getStats().get(i), seq)) {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/LoopExtractHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/LoopExtractHelper.java
-index 8229127..545f687 100644
+index 822912795072fc94b32ffd368b8c5ebe61403e3f..545f687a7f7ac501f1447357f60c98ff12a326bb 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/LoopExtractHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/LoopExtractHelper.java
 @@ -8,6 +8,7 @@ import org.jetbrains.java.decompiler.modules.decompiler.stats.Statement;
@@ -797,7 +797,7 @@ index 8229127..545f687 100644
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/LowBreakHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/LowBreakHelper.java
 new file mode 100644
-index 0000000..c62c74d
+index 0000000000000000000000000000000000000000..c62c74da3925db6820facb219ee93163610ea737
 --- /dev/null
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/LowBreakHelper.java
 @@ -0,0 +1,194 @@
@@ -997,7 +997,7 @@ index 0000000..c62c74d
 +}
 \ No newline at end of file
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/MergeHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/MergeHelper.java
-index 3f351c1..0bbd0a5 100644
+index 3f351c1c9c1d646854e4dff428c1f065296b1291..0bbd0a5a5337a6a377f005be79347c7e9f71d34a 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/MergeHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/MergeHelper.java
 @@ -4,8 +4,13 @@ package org.jetbrains.java.decompiler.modules.decompiler;
@@ -1434,7 +1434,7 @@ index 3f351c1..0bbd0a5 100644
 +  }
 +}
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/PPandMMHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/PPandMMHelper.java
-index d73535f..94dc0a3 100644
+index d73535f1374e3ec59079fddf06ecea6480925467..94dc0a33d7eaec052c6f3ce10fbbb93eb5395025 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/PPandMMHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/PPandMMHelper.java
 @@ -5,19 +5,31 @@ import org.jetbrains.java.decompiler.modules.decompiler.exps.AssignmentExprent;
@@ -1548,7 +1548,7 @@ index d73535f..94dc0a3 100644
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/StatEdge.java b/src/org/jetbrains/java/decompiler/modules/decompiler/StatEdge.java
-index c481c0a..cdbcb70 100644
+index c481c0a343d8ca7825989cfe289fc7d2dd793aa7..cdbcb7090acf9afb536ca003c9a685e5c209d265 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/StatEdge.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/StatEdge.java
 @@ -35,6 +35,8 @@ public class StatEdge {
@@ -1561,7 +1561,7 @@ index c481c0a..cdbcb70 100644
      this(type, source, destination);
      this.closure = closure;
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 87522af..9803a21 100644
+index 87522af363670f27a69bf5dee95a954ae14ed594..9803a215b8c5bc40658c8210c10e61644b519231 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -458,7 +458,7 @@ public class InvocationExprent extends Exprent {
@@ -1581,7 +1581,7 @@ index 87522af..9803a21 100644
 \ No newline at end of file
 +}
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
-index e3b253c..8e3dbf6 100644
+index e3b253c9526436c1dab974cac21680a571998f43..8e3dbf6eb41b9fd14754ab5406eb9a4f1e3288f7 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
 @@ -9,12 +9,15 @@ import org.jetbrains.java.decompiler.main.collectors.BytecodeMappingTracer;
@@ -1784,7 +1784,7 @@ index e3b253c..8e3dbf6 100644
    // IMatchable implementation
    // *****************************************************************************
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/DirectGraph.java b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/DirectGraph.java
-index aa2fae8..fc6fc93 100644
+index aa2fae88906858a3c8bd05508db963edbaf0de07..fc6fc93f29c8e8c9e4319d3c6777562ba3e7dc9f 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/DirectGraph.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/DirectGraph.java
 @@ -113,6 +113,21 @@ public class DirectGraph {
@@ -1810,7 +1810,7 @@ index aa2fae8..fc6fc93 100644
      // 0 - success, do nothing
      // 1 - cancel iteration
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/FlattenStatementsHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/FlattenStatementsHelper.java
-index b9abd11..23713c9 100644
+index b9abd119f2e49cb5c87f8cb9c530e49a760fcbbb..23713c94c72373f76284bc7a8615f74419531651 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/FlattenStatementsHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/FlattenStatementsHelper.java
 @@ -201,6 +201,7 @@ public class FlattenStatementsHelper {
@@ -1833,7 +1833,7 @@ index b9abd11..23713c9 100644
  
                  DirectNode nodeinc = new DirectNode(DirectNode.NODE_INCREMENT, stat, stat.id + "_inc");
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/CatchAllStatement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/CatchAllStatement.java
-index 376abe5..3cb030a 100644
+index 376abe530eac85cf1aaed38835afb19724262ed9..3cb030a94b2ad4c4928ecb7a7a58a32e618c7f36 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/CatchAllStatement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/CatchAllStatement.java
 @@ -2,6 +2,7 @@
@@ -1854,7 +1854,7 @@ index 376abe5..3cb030a 100644
                              new VarType(CodeConstants.TYPE_OBJECT, 0, "java/lang/Throwable"),
                              DecompilerContext.getVarProcessor()));
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/CatchStatement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/CatchStatement.java
-index 652931a..5582b37 100644
+index 652931af32774c5cf7f63e50443c4096254ae6c5..5582b3781f6ff71684d6802c11d4d361899c196e 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/CatchStatement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/CatchStatement.java
 @@ -41,7 +41,7 @@ public class CatchStatement extends Statement {
@@ -1867,7 +1867,7 @@ index 652931a..5582b37 100644
                                  new VarType(CodeConstants.TYPE_OBJECT, 0, edge.getExceptions().get(0)),
                                  // FIXME: for now simply the first type. Should get the first common superclass when possible.
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DoStatement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DoStatement.java
-index f9a149f..d4ccb5e 100644
+index f9a149f3be6ac414781a988f9cc57d97ad685199..d4ccb5ecd7c9cfa2d76d9364a907f374bc1f5ba7 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DoStatement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DoStatement.java
 @@ -17,6 +17,7 @@ public class DoStatement extends Statement {
@@ -1904,7 +1904,7 @@ index f9a149f..d4ccb5e 100644
  
      lst.add(first);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java
-index 74f44c0..b2455f2 100644
+index 74f44c077c0985fa23145f39d617976f94571f55..b2455f278256688815f05a3b1a835726329202a8 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java
 @@ -807,6 +807,14 @@ public class Statement implements IMatchable {
@@ -1932,7 +1932,7 @@ index 74f44c0..b2455f2 100644
  
    //TODO: Cleanup/cache?
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
-index 0402097..fa326a4 100644
+index 0402097b50b89cd8092915db381abfb61be7f495..fa326a4a190012b9e121baa61880c172836e22db 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
 @@ -4,16 +4,26 @@ package org.jetbrains.java.decompiler.modules.decompiler.vars;
@@ -2788,7 +2788,7 @@ index 0402097..fa326a4 100644
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarProcessor.java
-index 9999b50..ec60c00 100644
+index 9999b50b14518caeb2ab042c0826c6049885fe40..ec60c001a0c56aadf71b7badf0284ed656121153 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarProcessor.java
 @@ -2,21 +2,26 @@
@@ -2949,7 +2949,7 @@ index 9999b50..ec60c00 100644
  }
 \ No newline at end of file
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarTypeProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarTypeProcessor.java
-index c31cfad..78b5302 100644
+index c31cfad036b4b2de11449c54ded7864e394d5f91..78b5302cba6fc90f7f32520f637a740d21ed7fab 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarTypeProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarTypeProcessor.java
 @@ -96,7 +96,12 @@ public class VarTypeProcessor {
@@ -2967,7 +2967,7 @@ index c31cfad..78b5302 100644
          else if (expr.type == Exprent.EXPRENT_CONST) {
            ConstExprent constExpr = (ConstExprent)expr;
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java
-index eca0d0f..47e7e0c 100644
+index eca0d0fb9ef15db26e9de38ebda2bf9ee19857df..47e7e0c04f6114a9d64b1d86c1e2643052ad5023 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java
 @@ -22,7 +22,7 @@ import java.util.Map.Entry;
@@ -3038,7 +3038,7 @@ index eca0d0f..47e7e0c 100644
  }
 \ No newline at end of file
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructContext.java b/src/org/jetbrains/java/decompiler/struct/StructContext.java
-index 6d07096..aea1b21 100644
+index 6d070968a661a1fc36c4b7fe348e20e5997009a0..aea1b21ae67cc410fa514aeb079f5f58b6d0ae1a 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructContext.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructContext.java
 @@ -160,4 +160,30 @@ public class StructContext {
@@ -3074,7 +3074,7 @@ index 6d07096..aea1b21 100644
  }
 \ No newline at end of file
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructMember.java b/src/org/jetbrains/java/decompiler/struct/StructMember.java
-index a5b87f1..7ead7d6 100644
+index a5b87f1f1d3d9eaf5646ab8a6d31efda2b9e426e..7ead7d6f93a0a60d41e1c1276bfcde7b75e9ab5f 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructMember.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructMember.java
 @@ -12,6 +12,8 @@ import java.io.IOException;
@@ -3103,7 +3103,7 @@ index a5b87f1..7ead7d6 100644
 \ No newline at end of file
 +}
 diff --git a/src/org/jetbrains/java/decompiler/struct/attr/StructLocalVariableTableAttribute.java b/src/org/jetbrains/java/decompiler/struct/attr/StructLocalVariableTableAttribute.java
-index 15fb317..c72d18a 100644
+index 15fb317f2693e2edc8164519af3c25e2df3e59b4..c72d18adf8c923674331178c8832f02359850700 100644
 --- a/src/org/jetbrains/java/decompiler/struct/attr/StructLocalVariableTableAttribute.java
 +++ b/src/org/jetbrains/java/decompiler/struct/attr/StructLocalVariableTableAttribute.java
 @@ -1,7 +1,10 @@
@@ -3267,7 +3267,7 @@ index 15fb317..c72d18a 100644
    }
  }
 diff --git a/src/org/jetbrains/java/decompiler/struct/attr/StructLocalVariableTypeTableAttribute.java b/src/org/jetbrains/java/decompiler/struct/attr/StructLocalVariableTypeTableAttribute.java
-index 829c78e..cfdda0f 100644
+index 829c78e8a1361bb88cb700696c22af4f7d36349d..cfdda0f2830307d34dfcc3c0a0714f6e0693f3eb 100644
 --- a/src/org/jetbrains/java/decompiler/struct/attr/StructLocalVariableTypeTableAttribute.java
 +++ b/src/org/jetbrains/java/decompiler/struct/attr/StructLocalVariableTypeTableAttribute.java
 @@ -17,7 +17,7 @@ import java.io.IOException;
@@ -3281,7 +3281,7 @@ index 829c78e..cfdda0f 100644
    public void initContent(DataInputFullStream data, ConstantPool pool) throws IOException {
 diff --git a/src/org/jetbrains/java/decompiler/util/DebugPrinter.java b/src/org/jetbrains/java/decompiler/util/DebugPrinter.java
 new file mode 100644
-index 0000000..71d69ef
+index 0000000000000000000000000000000000000000..71d69efb6418e111b0a7e59e0eb4389eca207f5d
 --- /dev/null
 +++ b/src/org/jetbrains/java/decompiler/util/DebugPrinter.java
 @@ -0,0 +1,94 @@
@@ -3381,7 +3381,7 @@ index 0000000..71d69ef
 +}
 diff --git a/test/org/jetbrains/java/decompiler/LVTTest.java b/test/org/jetbrains/java/decompiler/LVTTest.java
 new file mode 100644
-index 0000000..71d689d
+index 0000000000000000000000000000000000000000..71d689df60a4377103777be6a408ed4f8651377c
 --- /dev/null
 +++ b/test/org/jetbrains/java/decompiler/LVTTest.java
 @@ -0,0 +1,48 @@
@@ -3434,7 +3434,7 @@ index 0000000..71d689d
 +  @Test public void testLoopMerging() { doTest("pkg/TestLoopMerging"); }
 +}
 diff --git a/test/org/jetbrains/java/decompiler/SingleClassesTest.java b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
-index 2b60ca1..d86b673 100644
+index 2b60ca149c39b5dbe8a6191be44d1d607b9cbe18..d86b673db5f202a362063aba622c48d7dbfd6895 100644
 --- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
 +++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
 @@ -17,6 +17,7 @@ public class SingleClassesTest extends SingleClassesTestBase {
@@ -3446,7 +3446,7 @@ index 2b60ca1..d86b673 100644
    @Test public void testClassFields() { doTest("pkg/TestClassFields"); }
    @Test public void testInterfaceFields() { doTest("pkg/TestInterfaceFields"); }
 diff --git a/testData/bulk/pkg/res/Loader.java b/testData/bulk/pkg/res/Loader.java
-index cdb1db5..5e4c220 100644
+index cdb1db5b9d381f4766555df788d5e6fefc09d059..5e4c220660b40e5ba8a7f13b5516b01724c9d2d6 100644
 --- a/testData/bulk/pkg/res/Loader.java
 +++ b/testData/bulk/pkg/res/Loader.java
 @@ -17,8 +17,8 @@ public class Loader {
@@ -3651,7 +3651,7 @@ literal 0
 HcmV?d00001
 
 diff --git a/testData/results/TestAmbiguousCallWithDebugInfo.dec b/testData/results/TestAmbiguousCallWithDebugInfo.dec
-index e873e7e..18beb9a 100644
+index e873e7e3cc488b036a46c332bd724e3fac30f720..18beb9a51b1010c58bf8058c999c1a5dc5457f57 100644
 --- a/testData/results/TestAmbiguousCallWithDebugInfo.dec
 +++ b/testData/results/TestAmbiguousCallWithDebugInfo.dec
 @@ -12,7 +12,7 @@ class TestAmbiguousCall {
@@ -3665,7 +3665,7 @@ index e873e7e..18beb9a 100644
  }
 diff --git a/testData/results/TestEnhancedForLoops.dec b/testData/results/TestEnhancedForLoops.dec
 new file mode 100644
-index 0000000..a83751c
+index 0000000000000000000000000000000000000000..a83751cd36645d1c820183d0892972544d015dbe
 --- /dev/null
 +++ b/testData/results/TestEnhancedForLoops.dec
 @@ -0,0 +1,127 @@
@@ -3797,7 +3797,7 @@ index 0000000..a83751c
 +37
 +40
 diff --git a/testData/results/TestKotlinConstructorKt.dec b/testData/results/TestKotlinConstructorKt.dec
-index 0e94145..e57e91a 100644
+index 0e941450d0dabcbec609f869f674d9cc5bdace33..e57e91a4d0f967a12d306f22b295608a08a872f1 100644
 --- a/testData/results/TestKotlinConstructorKt.dec
 +++ b/testData/results/TestKotlinConstructorKt.dec
 @@ -1,6 +1,5 @@
@@ -3986,7 +3986,7 @@ index 0e94145..e57e91a 100644
 +13 <-> 31
 diff --git a/testData/results/TestLVT.dec b/testData/results/TestLVT.dec
 new file mode 100644
-index 0000000..a78cf6e
+index 0000000000000000000000000000000000000000..a78cf6ee711a1115ed42c227a630086dd8bcff8b
 --- /dev/null
 +++ b/testData/results/TestLVT.dec
 @@ -0,0 +1,39 @@
@@ -4031,7 +4031,7 @@ index 0000000..a78cf6e
 +}
 diff --git a/testData/results/TestLVTComplex.dec b/testData/results/TestLVTComplex.dec
 new file mode 100644
-index 0000000..7d492ca
+index 0000000000000000000000000000000000000000..7d492ca4a8dcba8dae51f5d2d8f4a086022aef2a
 --- /dev/null
 +++ b/testData/results/TestLVTComplex.dec
 @@ -0,0 +1,84 @@
@@ -4121,7 +4121,7 @@ index 0000000..7d492ca
 +}
 diff --git a/testData/results/TestLVTScoping.dec b/testData/results/TestLVTScoping.dec
 new file mode 100644
-index 0000000..74941fb
+index 0000000000000000000000000000000000000000..74941fbba151492665389134b3d925e57f4801a7
 --- /dev/null
 +++ b/testData/results/TestLVTScoping.dec
 @@ -0,0 +1,35 @@
@@ -4161,7 +4161,7 @@ index 0000000..74941fb
 +   }
 +}
 diff --git a/testData/results/TestLocalsNames.dec b/testData/results/TestLocalsNames.dec
-index 59563dd..1041a54 100644
+index 59563ddeb1c2cb82405b31d9f0073a1df450c9e8..1041a5490d33ee05ccb669d924c3fac80f6e134f 100644
 --- a/testData/results/TestLocalsNames.dec
 +++ b/testData/results/TestLocalsNames.dec
 @@ -7,21 +7,18 @@ public class TestLocalsNames {
@@ -4373,7 +4373,7 @@ index 59563dd..1041a54 100644
 +34 <-> 20
 diff --git a/testData/results/TestLoopMerging.dec b/testData/results/TestLoopMerging.dec
 new file mode 100644
-index 0000000..703203a
+index 0000000000000000000000000000000000000000..703203a5dad69c818eac940996013864c2167da5
 --- /dev/null
 +++ b/testData/results/TestLoopMerging.dec
 @@ -0,0 +1,82 @@
@@ -4460,7 +4460,7 @@ index 0000000..703203a
 +   }
 +}
 diff --git a/testData/results/TestTryCatchFinally.dec b/testData/results/TestTryCatchFinally.dec
-index 20e9afb..0caaede 100644
+index 20e9afb72b2d2dabc76d29f6bb1f4ef2bfbc5a20..0caaede304ce41149b60846857bba24468c99675 100644
 --- a/testData/results/TestTryCatchFinally.dec
 +++ b/testData/results/TestTryCatchFinally.dec
 @@ -4,7 +4,7 @@ public class TestTryCatchFinally {
@@ -4474,7 +4474,7 @@ index 20e9afb..0caaede 100644
           } catch (Exception var8) {// 28
 diff --git a/testData/results/TestVarType.dec b/testData/results/TestVarType.dec
 new file mode 100644
-index 0000000..56fb422
+index 0000000000000000000000000000000000000000..56fb422828fe9a4985f892122d46051d3cd1f73b
 --- /dev/null
 +++ b/testData/results/TestVarType.dec
 @@ -0,0 +1,9 @@
@@ -4489,7 +4489,7 @@ index 0000000..56fb422
 +}
 diff --git a/testData/src/pkg/TestEnhancedForLoops.java b/testData/src/pkg/TestEnhancedForLoops.java
 new file mode 100644
-index 0000000..d808218
+index 0000000000000000000000000000000000000000..d808218357900a716e43edca3b7146f1a01add13
 --- /dev/null
 +++ b/testData/src/pkg/TestEnhancedForLoops.java
 @@ -0,0 +1,42 @@
@@ -4537,7 +4537,7 @@ index 0000000..d808218
 +}
 diff --git a/testData/src/pkg/TestLVT.java b/testData/src/pkg/TestLVT.java
 new file mode 100644
-index 0000000..b9eed0d
+index 0000000000000000000000000000000000000000..b9eed0dc1287fbabc4a400444b32b087831ffc66
 --- /dev/null
 +++ b/testData/src/pkg/TestLVT.java
 @@ -0,0 +1,36 @@
@@ -4579,7 +4579,7 @@ index 0000000..b9eed0d
 +}
 diff --git a/testData/src/pkg/TestLVTComplex.java b/testData/src/pkg/TestLVTComplex.java
 new file mode 100644
-index 0000000..548b9fd
+index 0000000000000000000000000000000000000000..548b9fd5883d6c9d2f706e8f97c93e42ace808f1
 --- /dev/null
 +++ b/testData/src/pkg/TestLVTComplex.java
 @@ -0,0 +1,64 @@
@@ -4649,7 +4649,7 @@ index 0000000..548b9fd
 +}
 diff --git a/testData/src/pkg/TestLVTScoping.java b/testData/src/pkg/TestLVTScoping.java
 new file mode 100644
-index 0000000..ab57832
+index 0000000000000000000000000000000000000000..ab57832c2f3df13a4ae9da2af193c2d6a79067ab
 --- /dev/null
 +++ b/testData/src/pkg/TestLVTScoping.java
 @@ -0,0 +1,34 @@
@@ -4689,7 +4689,7 @@ index 0000000..ab57832
 +}
 diff --git a/testData/src/pkg/TestLoopMerging.java b/testData/src/pkg/TestLoopMerging.java
 new file mode 100644
-index 0000000..1643c81
+index 0000000000000000000000000000000000000000..1643c8137282657c42f090481a16d0ed5b34e93f
 --- /dev/null
 +++ b/testData/src/pkg/TestLoopMerging.java
 @@ -0,0 +1,47 @@
@@ -4742,7 +4742,7 @@ index 0000000..1643c81
 +}
 diff --git a/testData/src/pkg/TestVarType.java b/testData/src/pkg/TestVarType.java
 new file mode 100644
-index 0000000..15e2171
+index 0000000000000000000000000000000000000000..15e2171a235562128cdb80c64f1acdacaa05c387
 --- /dev/null
 +++ b/testData/src/pkg/TestVarType.java
 @@ -0,0 +1,24 @@
@@ -4770,6 +4770,3 @@ index 0000000..15e2171
 +    i+=500;
 +  }
 +}
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0010-Rework-of-Generics-system-for-better-output.patch
+++ b/FernFlower-Patches/0010-Rework-of-Generics-system-for-better-output.patch
@@ -1,4 +1,4 @@
-From 7a29bc103392b7744e13878449205b83d85daeb5 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Fri, 14 Apr 2017 17:09:41 -0700
 Subject: [PATCH] Rework of Generics system for better output
@@ -6,7 +6,7 @@ Subject: [PATCH] Rework of Generics system for better output
 
 diff --git a/java9/org/jetbrains/java/decompiler/util/ClasspathScanner.java b/java9/org/jetbrains/java/decompiler/util/ClasspathScanner.java
 new file mode 100644
-index 0000000..ad9f8c2
+index 0000000000000000000000000000000000000000..ad9f8c22d02565f22720a4fa8819511124598dac
 --- /dev/null
 +++ b/java9/org/jetbrains/java/decompiler/util/ClasspathScanner.java
 @@ -0,0 +1,81 @@
@@ -92,7 +92,7 @@ index 0000000..ad9f8c2
 +    }
 +}
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassReference14Processor.java b/src/org/jetbrains/java/decompiler/main/ClassReference14Processor.java
-index 41b5a9a..bce7835 100644
+index 41b5a9ac58d639397b6204540eb957fdc0eb2ec5..bce783516cc17ef1bf2ddcf91d4ae94f4bfb8acc 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassReference14Processor.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassReference14Processor.java
 @@ -34,7 +34,7 @@ public class ClassReference14Processor {
@@ -121,7 +121,7 @@ index 41b5a9a..bce7835 100644
 \ No newline at end of file
 +}
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 1182bd1..2fcabdc 100644
+index 1182bd193cb0aef1ebacbcd8d6427dd79af9715f..2fcabdcd9ce1130a778754b318bf874922f02e12 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -320,7 +320,7 @@ public class ClassWriter {
@@ -366,7 +366,7 @@ index 1182bd1..2fcabdc 100644
 \ No newline at end of file
 +}
 diff --git a/src/org/jetbrains/java/decompiler/main/DecompilerContext.java b/src/org/jetbrains/java/decompiler/main/DecompilerContext.java
-index e293635..bf0fe47 100644
+index e2936358fa03746e00e23d30f47351c28124e09f..bf0fe47e7d48b21acd758449b67612e250f19554 100644
 --- a/src/org/jetbrains/java/decompiler/main/DecompilerContext.java
 +++ b/src/org/jetbrains/java/decompiler/main/DecompilerContext.java
 @@ -18,6 +18,7 @@ public class DecompilerContext {
@@ -385,7 +385,7 @@ index e293635..bf0fe47 100644
 \ No newline at end of file
 +}
 diff --git a/src/org/jetbrains/java/decompiler/main/Fernflower.java b/src/org/jetbrains/java/decompiler/main/Fernflower.java
-index 692c1b6..f8c413c 100644
+index 692c1b622ef7e065c9c970cf0a5289f9ca8869f5..f8c413c7b7302b201a739310677d0103e2878d3e 100644
 --- a/src/org/jetbrains/java/decompiler/main/Fernflower.java
 +++ b/src/org/jetbrains/java/decompiler/main/Fernflower.java
 @@ -11,6 +11,7 @@ import org.jetbrains.java.decompiler.struct.StructClass;
@@ -413,7 +413,7 @@ index 692c1b6..f8c413c 100644
  
    private static IIdentifierRenamer loadHelper(String className, IFernflowerLogger logger) {
 diff --git a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
-index 5448e79..bdd34f0 100644
+index 5448e7900953da79b2bc01f99fd7e8f3080148e7..bdd34f0382b06687ef7fb3237bbc96ac322bdd5c 100644
 --- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
 +++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
 @@ -35,6 +35,8 @@ public interface IFernflowerPreferences {
@@ -435,7 +435,7 @@ index 5448e79..bdd34f0 100644
      defaults.put(MAX_PROCESSING_METHOD, "0");
      defaults.put(RENAME_ENTITIES, "0");
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java b/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
-index fa79617..3ebc650 100644
+index fa7961777d41bc0845f741689c33143851eabf63..3ebc65082b733a0153e665e346cea5c44eb9042b 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
 @@ -2,6 +2,7 @@
@@ -463,7 +463,7 @@ index fa79617..3ebc650 100644
 \ No newline at end of file
 +}
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
-index f19e321..03a59cb 100644
+index f19e321da5e392eff9c87da6018aa1407411332d..03a59cb999d3d05d647128c96007e9743938a0ea 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 @@ -25,6 +25,8 @@ import org.jetbrains.java.decompiler.struct.consts.PrimitiveConstant;
@@ -517,7 +517,7 @@ index f19e321..03a59cb 100644
      boolean cast =
        castAlways ||
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
-index 26f82b9..986a8a7 100644
+index 26f82b92d1b4a972032c05203e8bb642aaba493e..986a8a72ec138ea637d3446ed2e823f6100c31cc 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
 @@ -719,7 +719,7 @@ public class SimplifyExprentsHelper {
@@ -537,7 +537,7 @@ index 26f82b9..986a8a7 100644
 \ No newline at end of file
 +}
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssignmentExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssignmentExprent.java
-index e2768f5..0f5411b 100644
+index e2768f5f53f670e2189454970d66524b4446021a..0f5411be3e790faa5a9f28d1eab3152851944e48 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssignmentExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssignmentExprent.java
 @@ -53,6 +53,11 @@ public class AssignmentExprent extends Exprent {
@@ -581,7 +581,7 @@ index e2768f5..0f5411b 100644
  
      buffer.append(condType == CONDITION_NONE ? " = " : OPERATORS[condType]).append(res);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ExitExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ExitExprent.java
-index 61b29a8..996eb3c 100644
+index 61b29a83579f85aaba32dd0e432de825a106457d..996eb3c3fe5388f7fde11df8937a09d01843f89d 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ExitExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ExitExprent.java
 @@ -10,6 +10,7 @@ import org.jetbrains.java.decompiler.modules.decompiler.ExprProcessor;
@@ -642,7 +642,7 @@ index 61b29a8..996eb3c 100644
    public void getBytecodeRange(BitSet values) {
      measureBytecode(values, value);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
-index 7183241..4aeda0e 100644
+index 7183241d331031e66f1afca8bce8feffa985e7a2..4aeda0e0c459d4956971b3298b8a4cd6f9424e0c 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
 @@ -3,13 +3,21 @@
@@ -813,7 +813,7 @@ index 7183241..4aeda0e 100644
    // IMatchable implementation
    // *****************************************************************************
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
-index 45b9f87..880a5d2 100644
+index 45b9f87924ca6d651fb2ab0a4671eb95cdb696fd..880a5d29d0b8c8d92ea7bd8918268742c7efcde5 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
 @@ -10,6 +10,8 @@ import org.jetbrains.java.decompiler.main.collectors.BytecodeMappingTracer;
@@ -870,7 +870,7 @@ index 45b9f87..880a5d2 100644
 \ No newline at end of file
 +}
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
-index 53b7403..161f55c 100644
+index 53b7403a24707b5719aeec34bfba8391c664b502..161f55c45a3f2c199fcc24b9fdd1bd269bafbfb8 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
 @@ -4,6 +4,8 @@
@@ -948,7 +948,7 @@ index 53b7403..161f55c 100644
        case FUNCTION_ARRAY_LENGTH:
          Exprent arr = lstOperands.get(0);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 9803a21..d72870e 100644
+index 9803a215b8c5bc40658c8210c10e61644b519231..d72870ee498d9da075a08dc6e2afef906ba44ad2 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -18,6 +18,8 @@ import org.jetbrains.java.decompiler.struct.consts.LinkConstant;
@@ -1154,7 +1154,7 @@ index 9803a21..d72870e 100644
            ambiguous.set(i);
            break;
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
-index 7914279..f99fdc4 100644
+index 7914279296b8aaa495f85bed6439676c15963411..f99fdc492e9ca76a1f14695e832ea193b920c1e1 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
 @@ -14,7 +14,6 @@ import org.jetbrains.java.decompiler.modules.decompiler.vars.VarVersionPair;
@@ -1236,7 +1236,7 @@ index 7914279..f99fdc4 100644
  
            boolean firstParam = true;
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
-index 8e3dbf6..b681b11 100644
+index 8e3dbf6eb41b9fd14754ab5406eb9a4f1e3288f7..b681b11cad3899d90c5f04df50b2ae021bea3021 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
 @@ -22,6 +22,7 @@ import org.jetbrains.java.decompiler.struct.attr.StructLocalVariableTypeTableAtt
@@ -1289,7 +1289,7 @@ index 8e3dbf6..b681b11 100644
                  }
                }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DoStatement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DoStatement.java
-index d4ccb5e..e35051b 100644
+index d4ccb5ecd7c9cfa2d76d9364a907f374bc1f5ba7..e35051b07919366db7fb532fd5e0eaba1121a2ae 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DoStatement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DoStatement.java
 @@ -126,6 +126,7 @@ public class DoStatement extends Statement {
@@ -1301,7 +1301,7 @@ index d4ccb5e..e35051b 100644
          tracer.incrementCurrentSourceLine();
          buf.append(ExprProcessor.jmpWrapper(first, indent + 1, true, tracer));
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
-index fa326a4..89f1c97 100644
+index fa326a4a190012b9e121baa61880c172836e22db..89f1c9709d9002701c3ec8b4563d345337995dac 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
 @@ -991,7 +991,7 @@ public class VarDefinitionHelper {
@@ -1314,7 +1314,7 @@ index fa326a4..89f1c97 100644
          this.cast = ExprProcessor.getCastTypeName(lvt.getVarType(), false);
        else if (type != null)
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructClass.java b/src/org/jetbrains/java/decompiler/struct/StructClass.java
-index 0bb370c..c9bfe7b 100644
+index 0bb370cbf9542a9bebb7978a4d9c4dab5c96a247..c9bfe7bea082a4acc673acf821ef20a3659065a5 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructClass.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructClass.java
 @@ -2,14 +2,28 @@
@@ -1472,7 +1472,7 @@ index 0bb370c..c9bfe7b 100644
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructContext.java b/src/org/jetbrains/java/decompiler/struct/StructContext.java
-index aea1b21..87afc93 100644
+index aea1b21ae67cc410fa514aeb079f5f58b6d0ae1a..87afc93ad6361ba6c8a45fa082bcf8d59db11f0d 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructContext.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructContext.java
 @@ -157,6 +157,19 @@ public class StructContext {
@@ -1496,7 +1496,7 @@ index aea1b21..87afc93 100644
      return classes;
    }
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructField.java b/src/org/jetbrains/java/decompiler/struct/StructField.java
-index 6c85ca4..3b1e5cc 100644
+index 6c85ca46b50be7aa7cbf782f5c8aad4bd4564b80..3b1e5cce6c2483db98d49b66d66ecc892c92bab9 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructField.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructField.java
 @@ -1,7 +1,13 @@
@@ -1542,7 +1542,7 @@ index 6c85ca4..3b1e5cc 100644
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructMethod.java b/src/org/jetbrains/java/decompiler/struct/StructMethod.java
-index dbfcc2c..cd9ac7e 100644
+index dbfcc2cd5cb3cf326612bbc0f6496b83d5992de2..cd9ac7edea0f4c840527cc526712a8f67f2c8a95 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructMethod.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructMethod.java
 @@ -2,9 +2,14 @@
@@ -1595,7 +1595,7 @@ index dbfcc2c..cd9ac7e 100644
 +}
 \ No newline at end of file
 diff --git a/src/org/jetbrains/java/decompiler/struct/gen/MethodDescriptor.java b/src/org/jetbrains/java/decompiler/struct/gen/MethodDescriptor.java
-index 102393c..49bb8c8 100644
+index 102393c8c7da549f2432e591406a2aceed778778..49bb8c809a273cfd4f268b5e01badc468f895f75 100644
 --- a/src/org/jetbrains/java/decompiler/struct/gen/MethodDescriptor.java
 +++ b/src/org/jetbrains/java/decompiler/struct/gen/MethodDescriptor.java
 @@ -2,14 +2,24 @@
@@ -1669,7 +1669,7 @@ index 102393c..49bb8c8 100644
 \ No newline at end of file
 +}
 diff --git a/src/org/jetbrains/java/decompiler/struct/gen/VarType.java b/src/org/jetbrains/java/decompiler/struct/gen/VarType.java
-index 4362f38..af6b899 100644
+index 4362f38e086b4ccd996145132135da895ea2d951..af6b8995f8396efdcaa82fae195dd8c3d107b5a7 100644
 --- a/src/org/jetbrains/java/decompiler/struct/gen/VarType.java
 +++ b/src/org/jetbrains/java/decompiler/struct/gen/VarType.java
 @@ -1,7 +1,10 @@
@@ -1743,7 +1743,7 @@ index 4362f38..af6b899 100644
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericClassDescriptor.java b/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericClassDescriptor.java
-index ad623a2..ae2a3dd 100644
+index ad623a2ab64debaf17974ae0a0757986f4cfbadf..ae2a3dd9085efea75979bbac66b1af29c52aa138 100644
 --- a/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericClassDescriptor.java
 +++ b/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericClassDescriptor.java
 @@ -4,13 +4,17 @@ package org.jetbrains.java.decompiler.struct.gen.generics;
@@ -1768,7 +1768,7 @@ index ad623a2..ae2a3dd 100644
 +  public final List<List<VarType>> fbounds = new ArrayList<>();
  }
 diff --git a/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericFieldDescriptor.java b/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericFieldDescriptor.java
-index a651817..2b0fdf1 100644
+index a65181762765bfdc9d2ee5695f3ffa68b7768b74..2b0fdf1dad01ec62f3e21f372297c124d859e8ff 100644
 --- a/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericFieldDescriptor.java
 +++ b/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericFieldDescriptor.java
 @@ -1,10 +1,12 @@
@@ -1788,7 +1788,7 @@ index a651817..2b0fdf1 100644
  }
 \ No newline at end of file
 diff --git a/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericMain.java b/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericMain.java
-index 3e4e1f1..1631617 100644
+index 3e4e1f14553927f521e79154d9ad97414d08813d..16316179dd5d277fc1722d5cc8695b6e62475216 100644
 --- a/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericMain.java
 +++ b/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericMain.java
 @@ -5,6 +5,7 @@ import org.jetbrains.java.decompiler.code.CodeConstants;
@@ -1978,7 +1978,7 @@ index 3e4e1f1..1631617 100644
 -  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericMethodDescriptor.java b/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericMethodDescriptor.java
-index eb80491..a93d250 100644
+index eb8049193e952f7476a99188838b6c8907f49f8d..a93d250e2400a9680d7561d73cc1a69f7c0f8d79 100644
 --- a/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericMethodDescriptor.java
 +++ b/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericMethodDescriptor.java
 @@ -4,18 +4,20 @@ package org.jetbrains.java.decompiler.struct.gen.generics;
@@ -2011,7 +2011,7 @@ index eb80491..a93d250 100644
      this.typeParameterBounds = substitute(typeParameterBounds);
      this.parameterTypes = substitute(parameterTypes);
 diff --git a/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericType.java b/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericType.java
-index 60bffdb..13cca79 100644
+index 60bffdb70108c9e035109d77dca48262fa216b32..13cca7906fb5810a0bf70b4b6ce184087e1c99e0 100644
 --- a/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericType.java
 +++ b/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericType.java
 @@ -2,43 +2,43 @@
@@ -2343,7 +2343,7 @@ index 60bffdb..13cca79 100644
    }
  }
 diff --git a/src/org/jetbrains/java/decompiler/struct/lazy/LazyLoader.java b/src/org/jetbrains/java/decompiler/struct/lazy/LazyLoader.java
-index 63c0f8e..b3dbda9 100644
+index 63c0f8ef5da6a25541129b5019a02427d0a9938c..b3dbda9d1c91ca75f316230102c54adde37cb452 100644
 --- a/src/org/jetbrains/java/decompiler/struct/lazy/LazyLoader.java
 +++ b/src/org/jetbrains/java/decompiler/struct/lazy/LazyLoader.java
 @@ -118,7 +118,7 @@ public class LazyLoader {
@@ -2375,7 +2375,7 @@ index 63c0f8e..b3dbda9 100644
 \ No newline at end of file
 diff --git a/src/org/jetbrains/java/decompiler/util/ClasspathScanner.java b/src/org/jetbrains/java/decompiler/util/ClasspathScanner.java
 new file mode 100644
-index 0000000..a76571c
+index 0000000000000000000000000000000000000000..a76571c1359c904bdb1e374bbc1e4969850b8087
 --- /dev/null
 +++ b/src/org/jetbrains/java/decompiler/util/ClasspathScanner.java
 @@ -0,0 +1,35 @@
@@ -2415,7 +2415,7 @@ index 0000000..a76571c
 +    }
 +}
 diff --git a/test/org/jetbrains/java/decompiler/SingleClassesTest.java b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
-index d86b673..f8ba124 100644
+index d86b673db5f202a362063aba622c48d7dbfd6895..f8ba12410a1b3d20dadf0780cae14ff8a3631446 100644
 --- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
 +++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
 @@ -14,9 +14,11 @@ public class SingleClassesTest extends SingleClassesTestBase {
@@ -2486,7 +2486,7 @@ literal 0
 HcmV?d00001
 
 diff --git a/testData/results/TestAmbiguousCall.dec b/testData/results/TestAmbiguousCall.dec
-index dec7ba0..acf1120 100644
+index dec7ba0f20eecdc5a3c7d0774a0fdd4f3b68e6f6..acf1120655937c0e227ab11a1f472c444b2857b9 100644
 --- a/testData/results/TestAmbiguousCall.dec
 +++ b/testData/results/TestAmbiguousCall.dec
 @@ -13,7 +13,7 @@ class TestAmbiguousCall {
@@ -2499,7 +2499,7 @@ index dec7ba0..acf1120 100644
  }
  
 diff --git a/testData/results/TestClassSwitch.dec b/testData/results/TestClassSwitch.dec
-index a42bfc8..8d59b04 100644
+index a42bfc86fd3fa9948233d709ba8358f1b8ec7908..8d59b04318021a2188c429be5b4055fe10efa0b8 100644
 --- a/testData/results/TestClassSwitch.dec
 +++ b/testData/results/TestClassSwitch.dec
 @@ -4,11 +4,11 @@ public class TestClassSwitch {
@@ -2517,7 +2517,7 @@ index a42bfc8..8d59b04 100644
     }// 25
  }
 diff --git a/testData/results/TestExtendsList.dec b/testData/results/TestExtendsList.dec
-index 6f116db..3f3dbea 100644
+index 6f116dbad41c3ce71fd5c79ee639ddbff3f1b39f..3f3dbea1836b9acaa8626c029bfe40dc0ee3c751 100644
 --- a/testData/results/TestExtendsList.dec
 +++ b/testData/results/TestExtendsList.dec
 @@ -2,11 +2,11 @@ package pkg;
@@ -2536,7 +2536,7 @@ index 6f116db..3f3dbea 100644
  
 diff --git a/testData/results/TestGenerics.dec b/testData/results/TestGenerics.dec
 new file mode 100644
-index 0000000..da090b3
+index 0000000000000000000000000000000000000000..da090b301d5537352bad9fb01068cc37fa156cc0
 --- /dev/null
 +++ b/testData/results/TestGenerics.dec
 @@ -0,0 +1,218 @@
@@ -2759,7 +2759,7 @@ index 0000000..da090b3
 +56
 +63
 diff --git a/testData/results/TestKotlinConstructorKt.dec b/testData/results/TestKotlinConstructorKt.dec
-index e57e91a..624026a 100644
+index e57e91a4d0f967a12d306f22b295608a08a872f1..624026a45ae5dd4b613fb8079a0ea0743281c9cc 100644
 --- a/testData/results/TestKotlinConstructorKt.dec
 +++ b/testData/results/TestKotlinConstructorKt.dec
 @@ -14,8 +14,8 @@ import kotlin.collections.CollectionsKt;
@@ -2789,7 +2789,7 @@ index e57e91a..624026a 100644
  }
  
 diff --git a/testData/results/TestLocalsSignature.dec b/testData/results/TestLocalsSignature.dec
-index 3da716b..3bd9c84 100644
+index 3da716bb86c538148347d67c29354a66dc416c17..3bd9c84810baa9f0cec8a62492ddccf80747d2d2 100644
 --- a/testData/results/TestLocalsSignature.dec
 +++ b/testData/results/TestLocalsSignature.dec
 @@ -5,7 +5,7 @@ import java.util.List;
@@ -2802,7 +2802,7 @@ index 3da716b..3bd9c84 100644
     }// 26
  }
 diff --git a/testData/results/TestVarArgCalls.dec b/testData/results/TestVarArgCalls.dec
-index db4cb49..89cfc19 100644
+index db4cb49cc7816f05dd2e3d82a6b79a7405001e4d..89cfc1980d0ff576c6f7676da8cb8c876db2c6ae 100644
 --- a/testData/results/TestVarArgCalls.dec
 +++ b/testData/results/TestVarArgCalls.dec
 @@ -13,15 +13,15 @@ public class TestVarArgCalls {
@@ -2826,7 +2826,7 @@ index db4cb49..89cfc19 100644
  
 diff --git a/testData/src/pkg/TestGenerics.java b/testData/src/pkg/TestGenerics.java
 new file mode 100644
-index 0000000..c45ac50
+index 0000000000000000000000000000000000000000..c45ac50962a7ebbf590404070a9fbd6a6a22aa6d
 --- /dev/null
 +++ b/testData/src/pkg/TestGenerics.java
 @@ -0,0 +1,71 @@
@@ -2901,6 +2901,3 @@ index 0000000..c45ac50
 +    }
 +  }
 +}
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0011-Improvements-to-var-and-var.patch
+++ b/FernFlower-Patches/0011-Improvements-to-var-and-var.patch
@@ -1,11 +1,11 @@
-From bc4c7596f58963f24df59be9dffcaf681be0351c Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Fri, 14 Apr 2017 10:13:01 -0700
 Subject: [PATCH] Improvements to var++ and var--
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-index fb9c7a9..58bf515 100644
+index fb9c7a961ec3cfc1f50c3fd902c299e097988997..58bf5152299a7ca6f4d22a2e1f8b95b6393e6242 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 @@ -1048,7 +1048,7 @@ public class NestedClassProcessor {
@@ -18,7 +18,7 @@ index fb9c7a9..58bf515 100644
            break;
          case Exprent.EXPRENT_VAR:
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/PPandMMHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/PPandMMHelper.java
-index 94dc0a3..806bec5 100644
+index 94dc0a33d7eaec052c6f3ce10fbbb93eb5395025..806bec52c8e2c3ea5d8416f3edd6f0e6aa79aeff 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/PPandMMHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/PPandMMHelper.java
 @@ -13,7 +13,6 @@ import org.jetbrains.java.decompiler.modules.decompiler.stats.RootStatement;
@@ -111,7 +111,7 @@ index 94dc0a3..806bec5 100644
            }
          }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
-index e97be6c..71f2ad8 100644
+index e97be6c82f048e553b0e24b9311169ea5626e263..71f2ad8417d51eaa564a1813fbd34e1de8b50f94 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
 @@ -407,7 +407,12 @@ public class ConstExprent extends Exprent {
@@ -129,7 +129,7 @@ index e97be6c..71f2ad8 100644
    // IMatchable implementation
    // *****************************************************************************
 diff --git a/test/org/jetbrains/java/decompiler/LVTTest.java b/test/org/jetbrains/java/decompiler/LVTTest.java
-index 71d689d..76e4064 100644
+index 71d689df60a4377103777be6a408ed4f8651377c..76e406446e524ad1df39881ab5178c09c1e5b421 100644
 --- a/test/org/jetbrains/java/decompiler/LVTTest.java
 +++ b/test/org/jetbrains/java/decompiler/LVTTest.java
 @@ -45,4 +45,5 @@ public class LVTTest extends SingleClassesTestBase {
@@ -160,7 +160,7 @@ HcmV?d00001
 
 diff --git a/testData/results/TestPPMM.dec b/testData/results/TestPPMM.dec
 new file mode 100644
-index 0000000..ba3a5fc
+index 0000000000000000000000000000000000000000..ba3a5fc1b4a29798078399358a7e560326aa2044
 --- /dev/null
 +++ b/testData/results/TestPPMM.dec
 @@ -0,0 +1,70 @@
@@ -236,7 +236,7 @@ index 0000000..ba3a5fc
 +}
 diff --git a/testData/src/pkg/TestPPMM.java b/testData/src/pkg/TestPPMM.java
 new file mode 100644
-index 0000000..0a062be
+index 0000000000000000000000000000000000000000..0a062be8c8cc93d9f398e786671223ac9a591492
 --- /dev/null
 +++ b/testData/src/pkg/TestPPMM.java
 @@ -0,0 +1,81 @@
@@ -322,6 +322,3 @@ index 0000000..0a062be
 +   }
 +}
 \ No newline at end of file
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0012-JAD-Style-variable-naming.patch
+++ b/FernFlower-Patches/0012-JAD-Style-variable-naming.patch
@@ -1,11 +1,11 @@
-From 2e58f4ec3e52394fb6d0b215e6aca449ebb22a35 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Tue, 11 Apr 2017 22:37:40 -0700
 Subject: [PATCH] JAD Style variable naming
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 2fcabdc..4817f05 100644
+index 2fcabdcd9ce1130a778754b318bf874922f02e12..4817f055906bfa4bfa4f7bfa9b590f88e984c3a1 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -701,6 +701,11 @@ public class ClassWriter {
@@ -21,7 +21,7 @@ index 2fcabdc..4817f05 100644
  
              paramCount++;
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
-index a347589..6b6e38f 100644
+index a34758940dbce0c5bac8dff269386af752c63d91..6b6e38f72a51e3f426b812060511e71142860263 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 @@ -11,6 +11,7 @@ import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
@@ -57,7 +57,7 @@ index a347589..6b6e38f 100644
 \ No newline at end of file
 +}
 diff --git a/src/org/jetbrains/java/decompiler/main/DecompilerContext.java b/src/org/jetbrains/java/decompiler/main/DecompilerContext.java
-index bf0fe47..95baa7d 100644
+index bf0fe47e7d48b21acd758449b67612e250f19554..95baa7dfec5a9c8dcde30a288499aa127aeffa4b 100644
 --- a/src/org/jetbrains/java/decompiler/main/DecompilerContext.java
 +++ b/src/org/jetbrains/java/decompiler/main/DecompilerContext.java
 @@ -7,6 +7,7 @@ import org.jetbrains.java.decompiler.main.collectors.ImportCollector;
@@ -113,7 +113,7 @@ index bf0fe47..95baa7d 100644
      return getCurrentContext().importCollector;
    }
 diff --git a/src/org/jetbrains/java/decompiler/main/Fernflower.java b/src/org/jetbrains/java/decompiler/main/Fernflower.java
-index f8c413c..ab8c1a6 100644
+index f8c413c7b7302b201a739310677d0103e2878d3e..ab8c1a60acfdef8c6ffb3082efbfbc1315d2c0bc 100644
 --- a/src/org/jetbrains/java/decompiler/main/Fernflower.java
 +++ b/src/org/jetbrains/java/decompiler/main/Fernflower.java
 @@ -10,6 +10,7 @@ import org.jetbrains.java.decompiler.struct.IDecompiledData;
@@ -152,7 +152,7 @@ index f8c413c..ab8c1a6 100644
      String vendor = System.getProperty("java.vendor", "missing vendor");
 diff --git a/src/org/jetbrains/java/decompiler/main/IdentityRenamerFactory.java b/src/org/jetbrains/java/decompiler/main/IdentityRenamerFactory.java
 new file mode 100644
-index 0000000..4b62af8
+index 0000000000000000000000000000000000000000..4b62af8a0587083fedc44fc7fd5032ee32513700
 --- /dev/null
 +++ b/src/org/jetbrains/java/decompiler/main/IdentityRenamerFactory.java
 @@ -0,0 +1,44 @@
@@ -201,7 +201,7 @@ index 0000000..4b62af8
 +  }
 +}
 diff --git a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
-index bdd34f0..206f627 100644
+index bdd34f0382b06687ef7fb3237bbc96ac322bdd5c..206f62766c52572b6d5583c7822da22a25130adc 100644
 --- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
 +++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
 @@ -51,6 +51,8 @@ public interface IFernflowerPreferences {
@@ -226,7 +226,7 @@ index bdd34f0..206f627 100644
 +}
 diff --git a/src/org/jetbrains/java/decompiler/main/extern/IVariableNameProvider.java b/src/org/jetbrains/java/decompiler/main/extern/IVariableNameProvider.java
 new file mode 100644
-index 0000000..8e6ab2b
+index 0000000000000000000000000000000000000000..8e6ab2bfc651c25b095f16f9eabc4a81ef10d605
 --- /dev/null
 +++ b/src/org/jetbrains/java/decompiler/main/extern/IVariableNameProvider.java
 @@ -0,0 +1,26 @@
@@ -258,7 +258,7 @@ index 0000000..8e6ab2b
 +}
 diff --git a/src/org/jetbrains/java/decompiler/main/extern/IVariableNamingFactory.java b/src/org/jetbrains/java/decompiler/main/extern/IVariableNamingFactory.java
 new file mode 100644
-index 0000000..fc1d7d6
+index 0000000000000000000000000000000000000000..fc1d7d67864ab12e894fcdf0ed8e1297ce057bee
 --- /dev/null
 +++ b/src/org/jetbrains/java/decompiler/main/extern/IVariableNamingFactory.java
 @@ -0,0 +1,22 @@
@@ -285,7 +285,7 @@ index 0000000..fc1d7d6
 +  public IVariableNameProvider createFactory(StructMethod structMethod);
 +}
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-index 58bf515..9942e12 100644
+index 58bf5152299a7ca6f4d22a2e1f8b95b6393e6242..9942e125766f6162506ff6418f00e8bcbe6d8072 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 @@ -545,7 +545,11 @@ public class NestedClassProcessor {
@@ -302,7 +302,7 @@ index 58bf515..9942e12 100644
            int index = 0, varIndex = 1;
            MethodDescriptor md = MethodDescriptor.parseDescriptor(method.methodStruct.getDescriptor());
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
-index 89f1c97..06d6cba 100644
+index 89f1c9709d9002701c3ec8b4563d345337995dac..06d6cbad98176e0b86eaa464e799620ca51fd25c 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
 @@ -2,6 +2,7 @@
@@ -403,7 +403,7 @@ index 89f1c97..06d6cba 100644
          this.cast = ExprProcessor.getCastTypeName(lvt.getVarType(), false);
        else if (type != null)
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructMethod.java b/src/org/jetbrains/java/decompiler/struct/StructMethod.java
-index cd9ac7e..195e8d5 100644
+index cd9ac7edea0f4c840527cc526712a8f67f2c8a95..195e8d55b6c32bb1be7acadb76dc13ba1a33e44c 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructMethod.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructMethod.java
 @@ -4,6 +4,7 @@ package org.jetbrains.java.decompiler.struct;
@@ -442,7 +442,7 @@ index cd9ac7e..195e8d5 100644
    }
 diff --git a/src/org/jetbrains/java/decompiler/util/JADNameProvider.java b/src/org/jetbrains/java/decompiler/util/JADNameProvider.java
 new file mode 100644
-index 0000000..b29e693
+index 0000000000000000000000000000000000000000..b29e693b22abb9c296a1b36fd3e050f41044f24c
 --- /dev/null
 +++ b/src/org/jetbrains/java/decompiler/util/JADNameProvider.java
 @@ -0,0 +1,212 @@
@@ -660,7 +660,7 @@ index 0000000..b29e693
 +}
 diff --git a/src/org/jetbrains/java/decompiler/util/StatementIterator.java b/src/org/jetbrains/java/decompiler/util/StatementIterator.java
 new file mode 100644
-index 0000000..a41c910
+index 0000000000000000000000000000000000000000..a41c910e58c3c0e16e6b13a90fe9f34acea09662
 --- /dev/null
 +++ b/src/org/jetbrains/java/decompiler/util/StatementIterator.java
 @@ -0,0 +1,58 @@
@@ -724,7 +724,7 @@ index 0000000..a41c910
 +}
 diff --git a/test/org/jetbrains/java/decompiler/JADTest.java b/test/org/jetbrains/java/decompiler/JADTest.java
 new file mode 100644
-index 0000000..176b850
+index 0000000000000000000000000000000000000000..176b850d338fbfbbd65eab8405c46f35de662c7d
 --- /dev/null
 +++ b/test/org/jetbrains/java/decompiler/JADTest.java
 @@ -0,0 +1,34 @@
@@ -779,7 +779,7 @@ HcmV?d00001
 
 diff --git a/testData/results/TestJADNaming.dec b/testData/results/TestJADNaming.dec
 new file mode 100644
-index 0000000..b5d7ed5
+index 0000000000000000000000000000000000000000..b5d7ed54d77cc30c25688e1989a5a63eafaf863f
 --- /dev/null
 +++ b/testData/results/TestJADNaming.dec
 @@ -0,0 +1,81 @@
@@ -866,7 +866,7 @@ index 0000000..b5d7ed5
 +11 <-> 21
 diff --git a/testData/src/pkg/TestJADNaming.java b/testData/src/pkg/TestJADNaming.java
 new file mode 100644
-index 0000000..87e1c03
+index 0000000000000000000000000000000000000000..87e1c035ea3a6fd049bb95ba09935cc674afacd4
 --- /dev/null
 +++ b/testData/src/pkg/TestJADNaming.java
 @@ -0,0 +1,12 @@
@@ -883,6 +883,3 @@ index 0000000..87e1c03
 +    }
 +}
 \ No newline at end of file
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0013-Fix-primitive-un-boxing-issues.patch
+++ b/FernFlower-Patches/0013-Fix-primitive-un-boxing-issues.patch
@@ -1,11 +1,11 @@
-From d2f6207885de9b82c2d37d87a7ee26328efb6aa1 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Thu, 11 May 2017 03:24:33 -0700
 Subject: [PATCH] Fix primitive un/boxing issues.
 
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
-index 03a59cb..474ffda 100644
+index 03a59cb999d3d05d647128c96007e9743938a0ea..474ffda1b9d610968bd12160f2153713b37f2db9 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 @@ -876,12 +876,14 @@ public class ExprProcessor implements CodeConstants {
@@ -30,7 +30,7 @@ index 03a59cb..474ffda 100644
        }
      }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
-index 161f55c..068e44b 100644
+index 161f55c45a3f2c199fcc24b9fdd1bd269bafbfb8..068e44b80f9972be77bfd9fe095a5549edf40a2f 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
 @@ -566,6 +566,19 @@ public class FunctionExprent extends Exprent {
@@ -54,7 +54,7 @@ index 161f55c..068e44b 100644
          TYPES[funcType - FUNCTION_I2L]) + ")");
      }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index d72870e..1c822f3 100644
+index d72870ee498d9da075a08dc6e2afef906ba44ad2..1c822f357c117f4bc8af4ced1842421d2224af18 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -59,6 +59,8 @@ public class InvocationExprent extends Exprent {
@@ -308,7 +308,7 @@ index d72870e..1c822f3 100644
          GenericMethodDescriptor gen = mtt.getSignature(); //TODO: Find synthetic flags for params, as Enum generic signatures do no contain the String,int params
          if (gen != null && gen.parameterTypes.size() > i && gen.parameterTypes.get(i).isGeneric()) {
 diff --git a/testData/results/TestPrimitives.dec b/testData/results/TestPrimitives.dec
-index a7d1557..07e818e 100644
+index a7d1557e6814e071df65c610fbdae860c8ff93bc..07e818e12a3a4371d3cb76ab613b119837332525 100644
 --- a/testData/results/TestPrimitives.dec
 +++ b/testData/results/TestPrimitives.dec
 @@ -3,6 +3,26 @@ package pkg;
@@ -1007,7 +1007,7 @@ index a7d1557..07e818e 100644
  
     method '<init> (ZBSIJFDC)V' {
 diff --git a/testData/src/pkg/TestPrimitives.java b/testData/src/pkg/TestPrimitives.java
-index 3630252..acfe886 100644
+index 36302524a2ecfae64e25098eff1318b8b7d11d51..acfe886bf4578fe0cd0b1a58bf4073eb97436025 100644
 --- a/testData/src/pkg/TestPrimitives.java
 +++ b/testData/src/pkg/TestPrimitives.java
 @@ -3,6 +3,19 @@ package pkg;
@@ -1030,6 +1030,3 @@ index 3630252..acfe886 100644
  
    public void printAll() {
      printBoolean(true);
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0014-Add-Minecraft-test-framework.patch
+++ b/FernFlower-Patches/0014-Add-Minecraft-test-framework.patch
@@ -1,4 +1,4 @@
-From 88936c514f503ca5ff902c5f57e8a6e6474f4431 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Wed, 19 Apr 2017 01:59:28 -0700
 Subject: [PATCH] Add Minecraft test framework
@@ -6,7 +6,7 @@ Subject: [PATCH] Add Minecraft test framework
 
 diff --git a/test/org/jetbrains/java/decompiler/MinecraftTest.java b/test/org/jetbrains/java/decompiler/MinecraftTest.java
 new file mode 100644
-index 0000000..8ec8c36
+index 0000000000000000000000000000000000000000..8ec8c36234a30e76b7f75d54220f771afe58e264
 --- /dev/null
 +++ b/test/org/jetbrains/java/decompiler/MinecraftTest.java
 @@ -0,0 +1,140 @@
@@ -150,6 +150,3 @@ index 0000000..8ec8c36
 +  @Test public void testWoodlandMansionPieces() { doTest("net/minecraft/world/gen/structure/WoodlandMansionPieces"); }
 +  @Test public void testEntityPlayer() { doTest("net/minecraft/command/impl/SeedCommand"); }
 +}
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0015-Support-for-Java-9-Module-and-Package-constant-pool-.patch
+++ b/FernFlower-Patches/0015-Support-for-Java-9-Module-and-Package-constant-pool-.patch
@@ -1,4 +1,4 @@
-From 5ca4ca36ce3e41a4a4f8d74692af36ebe1268acb Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Mon, 25 Sep 2017 13:46:14 -0700
 Subject: [PATCH] Support for Java 9 Module and Package constant pool entries.
@@ -6,7 +6,7 @@ Subject: [PATCH] Support for Java 9 Module and Package constant pool entries.
 
 
 diff --git a/src/org/jetbrains/java/decompiler/code/CodeConstants.java b/src/org/jetbrains/java/decompiler/code/CodeConstants.java
-index 720d2a7..240a3e9 100644
+index 720d2a7e9522f42af750a1b40a21628b8817ba4d..240a3e9790f37f679ad711b8d2aab92ad1947982 100644
 --- a/src/org/jetbrains/java/decompiler/code/CodeConstants.java
 +++ b/src/org/jetbrains/java/decompiler/code/CodeConstants.java
 @@ -75,6 +75,7 @@ public interface CodeConstants {
@@ -27,7 +27,7 @@ index 720d2a7..240a3e9 100644
    // ----------------------------------------------------------------------
    // MethodHandle reference_kind values
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructContext.java b/src/org/jetbrains/java/decompiler/struct/StructContext.java
-index 87afc93..6840263 100644
+index 87afc93ad6361ba6c8a45fa082bcf8d59db11f0d..684026371c3a8314055a30ae6dafbd02f2c79240 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructContext.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructContext.java
 @@ -3,6 +3,7 @@ package org.jetbrains.java.decompiler.struct;
@@ -55,7 +55,7 @@ index 87afc93..6840263 100644
              classes.put(cl.qualifiedName, cl);
              unit.addClass(cl, name);
 diff --git a/src/org/jetbrains/java/decompiler/struct/consts/ConstantPool.java b/src/org/jetbrains/java/decompiler/struct/consts/ConstantPool.java
-index 0ea6e01..ba5342e 100644
+index 0ea6e01531bfef6949a3b8c9dc60f98dc13b9437..ba5342ee2fe2213c36ede0e6ff6e2f8ed17e6d91 100644
 --- a/src/org/jetbrains/java/decompiler/struct/consts/ConstantPool.java
 +++ b/src/org/jetbrains/java/decompiler/struct/consts/ConstantPool.java
 @@ -64,6 +64,8 @@ public class ConstantPool implements NewClassNameBuilder {
@@ -105,6 +105,3 @@ index 0ea6e01..ba5342e 100644
        }
      }
    }
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0016-Add-new-command-line-argument-sef-SkipExtraFiles-To-.patch
+++ b/FernFlower-Patches/0016-Add-new-command-line-argument-sef-SkipExtraFiles-To-.patch
@@ -1,4 +1,4 @@
-From 518b5a5d78cf5daa944333b6e748474b9e31e700 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Tue, 12 Dec 2017 00:18:19 -0800
 Subject: [PATCH] Add new command line argument -sef SkipExtraFiles: To skip
@@ -6,7 +6,7 @@ Subject: [PATCH] Add new command line argument -sef SkipExtraFiles: To skip
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
-index 206f627..d91d9fa 100644
+index 206f62766c52572b6d5583c7822da22a25130adc..d91d9faebf718192a679c436792a54c24bed8c63 100644
 --- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
 +++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
 @@ -53,6 +53,8 @@ public interface IFernflowerPreferences {
@@ -27,7 +27,7 @@ index 206f627..d91d9fa 100644
      return Collections.unmodifiableMap(defaults);
    }
 diff --git a/src/org/jetbrains/java/decompiler/struct/ContextUnit.java b/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
-index f9cd2af..f7b253b 100644
+index f9cd2af9307678da1214a3553a8790018a8699f6..f7b253bc942cd00f64505ce1424c6d5e8d0225d8 100644
 --- a/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
 +++ b/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
 @@ -54,6 +54,8 @@ public class ContextUnit {
@@ -46,6 +46,3 @@ index f9cd2af..f7b253b 100644
 -}
 \ No newline at end of file
 +}
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0017-Bugfix-Fix-invalid-logic-in-ExprUtils.-https-github..patch
+++ b/FernFlower-Patches/0017-Bugfix-Fix-invalid-logic-in-ExprUtils.-https-github..patch
@@ -1,4 +1,4 @@
-From 3aca192efe8d8cd79c5cdfeb9a5f8536121c4495 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Wed, 21 Feb 2018 18:27:17 -0800
 Subject: [PATCH] Bugfix: Fix invalid logic in ExprUtils.
@@ -16,7 +16,7 @@ public interface Test {
 }
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ExprUtil.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ExprUtil.java
-index 302d62f..195d365 100644
+index 302d62fd14906a1ba75dcb8a044e7f909054ccc3..195d3655eff47fa3dcb57f131ca2aa9a148a0cce 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ExprUtil.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ExprUtil.java
 @@ -8,6 +8,9 @@ import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
@@ -59,6 +59,3 @@ index 302d62f..195d365 100644
 +    return false;
 +  }
 +}
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0018-Enhance-Generic-Invocations-Temporarily.patch
+++ b/FernFlower-Patches/0018-Enhance-Generic-Invocations-Temporarily.patch
@@ -1,4 +1,4 @@
-From a05f3907b40a0e9deb19f31882a0b5e944e30b8d Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Fri, 16 Feb 2018 22:04:00 -0800
 Subject: [PATCH] Enhance Generic Invocations Temporarily.
@@ -6,7 +6,7 @@ Subject: [PATCH] Enhance Generic Invocations Temporarily.
 This is a temp separate patch until I get some time to merge it to patch 10/13.
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
-index 4aeda0e..58c3471 100644
+index 4aeda0e0c459d4956971b3298b8a4cd6f9424e0c..58c3471ff26529c091a44670828d272755e75f7d 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
 @@ -266,11 +266,11 @@ public abstract class Exprent implements IMatchable {
@@ -24,7 +24,7 @@ index 4aeda0e..58c3471 100644
          left = left.resizeArrayDim(0);
          right = right.resizeArrayDim(0);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
-index 068e44b..8f69e43 100644
+index 068e44b80f9972be77bfd9fe095a5549edf40a2f..8f69e433dce5541e5f42693c67fbb9f8610821d2 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
 @@ -7,6 +7,8 @@ import org.jetbrains.java.decompiler.code.CodeConstants;
@@ -92,7 +92,7 @@ index 068e44b..8f69e43 100644
 \ No newline at end of file
 +}
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 1c822f3..a16aa29 100644
+index 1c822f357c117f4bc8af4ced1842421d2224af18..a16aa2923136edd2ee5c4a4c45203bdab6e652b6 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -406,6 +406,7 @@ public class InvocationExprent extends Exprent {
@@ -254,7 +254,7 @@ index 1c822f3..a16aa29 100644
      StructClass cl = DecompilerContext.getStructContext().getClass(classname);
      if (cl == null || matches.size() == 1) {
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructClass.java b/src/org/jetbrains/java/decompiler/struct/StructClass.java
-index c9bfe7b..6729ac6 100644
+index c9bfe7bea082a4acc673acf821ef20a3659065a5..6729ac6feb7d822c3786b1864dc12cf779c3d30d 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructClass.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructClass.java
 @@ -130,6 +130,35 @@ public class StructClass extends StructMember {
@@ -293,6 +293,3 @@ index c9bfe7b..6729ac6 100644
    public String getInterface(int i) {
      return interfaceNames[i];
    }
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0019-Add-cfg-argument-Used-to-specify-a-text-file-with-ad.patch
+++ b/FernFlower-Patches/0019-Add-cfg-argument-Used-to-specify-a-text-file-with-ad.patch
@@ -1,14 +1,13 @@
-From a58bdcfc4022f1461df6b5c43861c8ac4e6849d6 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Fri, 6 Apr 2018 20:45:33 -0700
 Subject: [PATCH] Add -cfg argument Used to specify a text file with additional
- command line arguments. Our use case is specifying a ton of external
- libraries. It will read a text file and replace the -cfg entry with those
- lines.
+ command line arguments.
 
+Our use case is specifying a ton of external libraries. It will read a text file and replace the -cfg entry with those lines.
 
 diff --git a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
-index 75d4d09..06e3629 100644
+index 75d4d0937f1e39fe630b1318a4ad531de7fbd644..06e362987a3917976627fc1f0b6aad302c4ea650 100644
 --- a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
 +++ b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
 @@ -10,9 +10,13 @@ import org.jetbrains.java.decompiler.util.InterpreterUtil;
@@ -72,7 +71,7 @@ index 75d4d09..06e3629 100644
 \ No newline at end of file
 +}
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructContext.java b/src/org/jetbrains/java/decompiler/struct/StructContext.java
-index 6840263..cc4e357 100644
+index 684026371c3a8314055a30ae6dafbd02f2c79240..cc4e357fb8b7adeeb76858813f5ee329d17497d5 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructContext.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructContext.java
 @@ -94,6 +94,7 @@ public class StructContext {
@@ -98,6 +97,3 @@ index 6840263..cc4e357 100644
 -}
 \ No newline at end of file
 +}
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0020-Add-support-for-destination-to-be-a-zip-file-if-ther.patch
+++ b/FernFlower-Patches/0020-Add-support-for-destination-to-be-a-zip-file-if-ther.patch
@@ -1,4 +1,4 @@
-From d93c3e1d8d933ec25b7bac0b22c131703553976b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Thu, 19 Jul 2018 22:57:52 -0700
 Subject: [PATCH] Add support for destination to be a zip file if there is only
@@ -6,7 +6,7 @@ Subject: [PATCH] Add support for destination to be a zip file if there is only
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
-index 06e3629..5393dde 100644
+index 06e362987a3917976627fc1f0b6aad302c4ea650..5393ddec202efa7e1f6bb3f7740fa83a70ea48fd 100644
 --- a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
 +++ b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
 @@ -100,7 +100,7 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
@@ -29,7 +29,7 @@ index 06e3629..5393dde 100644
    public void addSource(File source) {
 diff --git a/src/org/jetbrains/java/decompiler/main/decompiler/SingleFileSaver.java b/src/org/jetbrains/java/decompiler/main/decompiler/SingleFileSaver.java
 new file mode 100644
-index 0000000..8775e47
+index 0000000000000000000000000000000000000000..8775e47858f45abaac925543be718bf3cc97a1bf
 --- /dev/null
 +++ b/src/org/jetbrains/java/decompiler/main/decompiler/SingleFileSaver.java
 @@ -0,0 +1,118 @@
@@ -151,6 +151,3 @@ index 0000000..8775e47
 +    return added;
 +  }
 +}
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0021-Add-a-metadata-file-named-fernflower_abstract_parame.patch
+++ b/FernFlower-Patches/0021-Add-a-metadata-file-named-fernflower_abstract_parame.patch
@@ -1,13 +1,13 @@
-From 602e1f5eca571d8a7faaf2b55c808da1392246ec Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Fri, 20 Jul 2018 01:37:36 -0700
 Subject: [PATCH] Add a metadata file named
  'fernflower_abstract_parameter_names.txt' to rename abstract parameters.
- Format: ClassName MethodName Descriptor Param1[ Param2...]
 
+Format: ClassName MethodName Descriptor Param1[ Param2...]
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 4817f05..615b7a3 100644
+index 4817f055906bfa4bfa4f7bfa9b590f88e984c3a1..615b7a37610e6498e04eb971768df0ea57284383 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -703,7 +703,9 @@ public class ClassWriter {
@@ -22,7 +22,7 @@ index 4817f05..615b7a3 100644
  
              buffer.append(parameterName == null ? "param" + index : parameterName); // null iff decompiled with errors
 diff --git a/src/org/jetbrains/java/decompiler/struct/ContextUnit.java b/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
-index f7b253b..fde5881 100644
+index f7b253bc942cd00f64505ce1424c6d5e8d0225d8..fde588174ace52b073d205bd0fa045632a725df5 100644
 --- a/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
 +++ b/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
 @@ -7,12 +7,16 @@ import org.jetbrains.java.decompiler.main.extern.IResultSaver;
@@ -68,7 +68,7 @@ index f7b253b..fde5881 100644
          return;
      otherEntries.add(new String[]{fullPath, entry});
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructContext.java b/src/org/jetbrains/java/decompiler/struct/StructContext.java
-index cc4e357..68cf259 100644
+index cc4e357fb8b7adeeb76858813f5ee329d17497d5..68cf259230cd82298c36b391e0ea91d111fca9ab 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructContext.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructContext.java
 @@ -4,14 +4,18 @@ package org.jetbrains.java.decompiler.struct;
@@ -123,6 +123,3 @@ index cc4e357..68cf259 100644
 +    return params != null && index < params.size() ? params.get(index) : _default;
 +  }
  }
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0022-Synthetic-getClass-cleanup.patch
+++ b/FernFlower-Patches/0022-Synthetic-getClass-cleanup.patch
@@ -1,11 +1,11 @@
-From 348a11626d2ef165fe51a9ceed8bc4ecaded8b29 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Justin <jrd2558@gmail.com>
 Date: Thu, 26 Jul 2018 13:28:40 -0700
 Subject: [PATCH] Synthetic getClass cleanup
 
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
-index 474ffda..4933b5c 100644
+index 474ffda1b9d610968bd12160f2153713b37f2db9..4933b5c1d375b7beacbb521bc8770cf295e7d98c 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 @@ -617,6 +617,20 @@ public class ExprProcessor implements CodeConstants {
@@ -30,7 +30,7 @@ index 474ffda..4933b5c 100644
          case opc_pop2:
            if (stack.getByOffset(-1).getExprType().stackSize == 1) {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
-index 986a8a7..767f6bd 100644
+index 986a8a72ec138ea637d3446ed2e823f6100c31cc..767f6bdb92ecf0ba0bc4a437b8bf8482fa47bdea 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
 @@ -71,6 +71,10 @@ public class SimplifyExprentsHelper {
@@ -94,7 +94,7 @@ index 986a8a7..767f6bd 100644
                String classname = newExpr.getNewType().value;
                ClassNode node = DecompilerContext.getClassProcessor().getMapRootClasses().get(classname);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index a16aa29..593a5be 100644
+index a16aa2923136edd2ee5c4a4c45203bdab6e652b6..593a5bec560f71215ff23207c79a8648f84c3c0d 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -61,6 +61,7 @@ public class InvocationExprent extends Exprent {
@@ -128,6 +128,3 @@ index a16aa29..593a5be 100644
    @Override
    public void getBytecodeRange(BitSet values) {
      measureBytecode(values, lstParameters);
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0023-Fix-shortname-imports-that-are-shadowed-by-super-cla.patch
+++ b/FernFlower-Patches/0023-Fix-shortname-imports-that-are-shadowed-by-super-cla.patch
@@ -1,4 +1,4 @@
-From dadd7a8d9acb144e59bf8e1d37959d159bab0939 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Justin <jrd2558@gmail.com>
 Date: Fri, 27 Jul 2018 14:02:27 -0700
 Subject: [PATCH] Fix shortname imports that are shadowed by super class inner
@@ -6,7 +6,7 @@ Subject: [PATCH] Fix shortname imports that are shadowed by super class inner
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/collectors/ImportCollector.java b/src/org/jetbrains/java/decompiler/main/collectors/ImportCollector.java
-index 7b8c3b4..4ddb755 100644
+index 7b8c3b45c374a15c22b35054ff4cc78c6bbfe182..4ddb75547417339f61426ed55810966a9fabbb7d 100644
 --- a/src/org/jetbrains/java/decompiler/main/collectors/ImportCollector.java
 +++ b/src/org/jetbrains/java/decompiler/main/collectors/ImportCollector.java
 @@ -20,7 +20,7 @@ public class ImportCollector {
@@ -137,6 +137,3 @@ index 7b8c3b4..4ddb755 100644
 +  }
  }
 \ No newline at end of file
--- 
-2.27.0
-

--- a/FernFlower-Patches/0024-Give-nicer-output-for-float-and-double-literals.patch
+++ b/FernFlower-Patches/0024-Give-nicer-output-for-float-and-double-literals.patch
@@ -1,11 +1,11 @@
-From b490b94145b6af4a68f3fbc92b59b0fd312c637a Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Pokechu22 <Pokechu022@gmail.com>
 Date: Fri, 3 Aug 2018 14:15:46 -0700
 Subject: [PATCH] Give nicer output for float and double literals
 
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
-index 71f2ad8..4bd94d9 100644
+index 71f2ad8417d51eaa564a1813fbd34e1de8b50f94..4bd94d9f47c9d15ef571412a28b97a0fbbfd45ef 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
 @@ -31,6 +31,67 @@ public class ConstExprent extends Exprent {
@@ -227,6 +227,3 @@ index 71f2ad8..4bd94d9 100644
    // Different JVM implementations/version display Floats and Doubles with different number of trailing zeros.
    // This trims them all down to only the necessary amount.
    private static String trimZeros(String value) {
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0025-Add-try-with-resource-support.patch
+++ b/FernFlower-Patches/0025-Add-try-with-resource-support.patch
@@ -1,11 +1,11 @@
-From dfd5ecd8afb1faafc6abd35500cb5c7f9be33e01 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Justin <jrd2558@gmail.com>
 Date: Mon, 6 Aug 2018 20:26:59 -0700
 Subject: [PATCH] Add try with resource support
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
-index 447780c..b77dfec 100644
+index 447780c1ed1316d6f30cd35150061b7946233315..b77dfec43d4b5b7e11528df9ecf52f32473629b4 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
 @@ -174,6 +174,10 @@ public class MethodProcessorRunnable implements Runnable {
@@ -21,7 +21,7 @@ index 447780c..b77dfec 100644
        }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/TryHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/TryHelper.java
 new file mode 100644
-index 0000000..6484ee0
+index 0000000000000000000000000000000000000000..6484ee0ba087cde20472fdd75247c4e515f15996
 --- /dev/null
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/TryHelper.java
 @@ -0,0 +1,263 @@
@@ -289,7 +289,7 @@ index 0000000..6484ee0
 +  }
 +}
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/FlattenStatementsHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/FlattenStatementsHelper.java
-index 23713c9..bdafd77 100644
+index 23713c94c72373f76284bc7a8615f74419531651..bdafd77466aacfeb3499eff76052054b4856df31 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/FlattenStatementsHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/FlattenStatementsHelper.java
 @@ -126,6 +126,13 @@ public class FlattenStatementsHelper {
@@ -307,7 +307,7 @@ index 23713c9..bdafd77 100644
              graph.nodes.putWithKey(firstnd, firstnd.id);
  
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/CatchStatement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/CatchStatement.java
-index 5582b37..5ca1605 100644
+index 5582b3781f6ff71684d6802c11d4d361899c196e..5ca160553acd8e5992f7cd676a34269ea982e81d 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/CatchStatement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/CatchStatement.java
 @@ -4,6 +4,8 @@ package org.jetbrains.java.decompiler.modules.decompiler.stats;
@@ -429,7 +429,7 @@ index 5582b37..5ca1605 100644
  }
 \ No newline at end of file
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
-index 06d6cba..8574fe2 100644
+index 06d6cbad98176e0b86eaa464e799620ca51fd25c..8574fe25782da90f36888186fb3d977c33eeaad1 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
 @@ -110,7 +110,11 @@ public class VarDefinitionHelper {
@@ -446,7 +446,7 @@ index 06d6cba..8574fe2 100644
  
        if (lstVars != null) {
 diff --git a/test/org/jetbrains/java/decompiler/SingleClassesTest.java b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
-index f8ba124..d9ac036 100644
+index f8ba12410a1b3d20dadf0780cae14ff8a3631446..d9ac0365a2fc8c7886feaf07674ad1640baf8a82 100644
 --- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
 +++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
 @@ -114,4 +114,5 @@ public class SingleClassesTest extends SingleClassesTestBase {
@@ -490,7 +490,7 @@ HcmV?d00001
 
 diff --git a/testData/results/TestTryWithResources.dec b/testData/results/TestTryWithResources.dec
 new file mode 100644
-index 0000000..419b0df
+index 0000000000000000000000000000000000000000..419b0df6fc1731027c783900f7b8e407826a6f5e
 --- /dev/null
 +++ b/testData/results/TestTryWithResources.dec
 @@ -0,0 +1,176 @@
@@ -672,7 +672,7 @@ index 0000000..419b0df
 +34
 diff --git a/testData/src/pkg/TestTryWithResources.java b/testData/src/pkg/TestTryWithResources.java
 new file mode 100644
-index 0000000..0c217fe
+index 0000000000000000000000000000000000000000..0c217fe0bc40af775d817bac86c68f26a11e7fb5
 --- /dev/null
 +++ b/testData/src/pkg/TestTryWithResources.java
 @@ -0,0 +1,37 @@
@@ -714,6 +714,3 @@ index 0000000..0c217fe
 +  }
 +}
 \ No newline at end of file
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0026-Fix-incorrect-decompilation-of-inverted-floating-poi.patch
+++ b/FernFlower-Patches/0026-Fix-incorrect-decompilation-of-inverted-floating-poi.patch
@@ -1,4 +1,4 @@
-From fff7a1bfc7b3e565831d858ae2a5ee965cfd4f12 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: malte0811 <malte0811@web.de>
 Date: Mon, 23 Jul 2018 15:53:01 +0200
 Subject: [PATCH] Fix incorrect decompilation of inverted floating point
@@ -6,7 +6,7 @@ Subject: [PATCH] Fix incorrect decompilation of inverted floating point
 
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/SecondaryFunctionsHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/SecondaryFunctionsHelper.java
-index a7c804b..859f2cb 100644
+index a7c804b9485791f60f7be4ed8d9278dba29c9633..859f2cb4f7f7ce538af5e481336b3a36b9d1aa59 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/SecondaryFunctionsHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SecondaryFunctionsHelper.java
 @@ -168,8 +168,18 @@ public class SecondaryFunctionsHelper {
@@ -65,7 +65,7 @@ index a7c804b..859f2cb 100644
          }
        }
 diff --git a/test/org/jetbrains/java/decompiler/SingleClassesTest.java b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
-index d9ac036..e57ff62 100644
+index d9ac0365a2fc8c7886feaf07674ad1640baf8a82..e57ff6220012555bedb01b6d325e98489dcdc765 100644
 --- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
 +++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
 @@ -115,4 +115,5 @@ public class SingleClassesTest extends SingleClassesTestBase {
@@ -96,7 +96,7 @@ HcmV?d00001
 
 diff --git a/testData/results/TestInvertedFloatComparison.dec b/testData/results/TestInvertedFloatComparison.dec
 new file mode 100644
-index 0000000..03d684a
+index 0000000000000000000000000000000000000000..03d684aaf4c89cbbd1bbe3369b8ea316c38ee41d
 --- /dev/null
 +++ b/testData/results/TestInvertedFloatComparison.dec
 @@ -0,0 +1,199 @@
@@ -301,7 +301,7 @@ index 0000000..03d684a
 +66 <-> 65
 diff --git a/testData/src/pkg/TestInvertedFloatComparison.java b/testData/src/pkg/TestInvertedFloatComparison.java
 new file mode 100644
-index 0000000..a660d33
+index 0000000000000000000000000000000000000000..a660d3309284037ecda581a223c107ee92459c9d
 --- /dev/null
 +++ b/testData/src/pkg/TestInvertedFloatComparison.java
 @@ -0,0 +1,68 @@
@@ -374,6 +374,3 @@ index 0000000..a660d33
 +  }
 +}
 \ No newline at end of file
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0027-Prioritize-self-and-enclosing-class-when-encounterin.patch
+++ b/FernFlower-Patches/0027-Prioritize-self-and-enclosing-class-when-encounterin.patch
@@ -1,15 +1,14 @@
-From 4229aec08eb43808b3df46be908ab1e9989f82f8 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Wed, 12 Sep 2018 03:01:05 -0700
 Subject: [PATCH] Prioritize self and enclosing class when encountering
- inconsistent InnerClass attributes. The compiler encodes all REFERENCED inner
- classes into the class. The first found used to win, but now ThisClass >
- EnclosingClass > Others AccessTransformers only edit the targeted class as it
- can't find all references. Fixes AccessTransformers.
+ inconsistent InnerClass attributes.
 
+The compiler encodes all REFERENCED inner classes into the class. The first found used to win, but now ThisClass > EnclosingClass > Others AccessTransformers only edit the targeted class as it can't find all references.
+Fixes AccessTransformers.
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 615b7a3..69b1dc4 100644
+index 615b7a37610e6498e04eb971768df0ea57284383..69b1dc49a54a4f114e04dee27c019d7b09028220 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -28,6 +28,7 @@ import org.jetbrains.java.decompiler.util.InterpreterUtil;
@@ -32,7 +31,7 @@ index 615b7a3..69b1dc4 100644
      buffer.append('<');
  
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
-index 6b6e38f..c5cfa74 100644
+index 6b6e38f72a51e3f426b812060511e71142860263..c5cfa74b683deb347d5733ba306628561e013cc3 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 @@ -41,10 +41,20 @@ public class ClassesProcessor implements CodeConstants {
@@ -78,6 +77,3 @@ index 6b6e38f..c5cfa74 100644
                  }
  
                  // reference to the nested class
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0028-Fix-ambiguous-lambdas.patch
+++ b/FernFlower-Patches/0028-Fix-ambiguous-lambdas.patch
@@ -1,11 +1,11 @@
-From 4d39e77afc4bfba7fd4df4370b7f5c8b1ccfc28e Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Justin <jrd2558@gmail.com>
 Date: Wed, 19 Sep 2018 22:51:00 -0700
 Subject: [PATCH] Fix ambiguous lambdas
 
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
-index 4933b5c..cc67f34 100644
+index 4933b5c1d375b7beacbb521bc8770cf295e7d98c..cc67f34aeede9a41bd78aeefdf6ac4a88d79348c 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 @@ -910,6 +910,9 @@ public class ExprProcessor implements CodeConstants {
@@ -41,7 +41,7 @@ index 4933b5c..cc67f34 100644
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 593a5be..43db4dc 100644
+index 593a5bec560f71215ff23207c79a8648f84c3c0d..43db4dcfe8e32f8809a2a8743eb04a49e6942f18 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -804,7 +804,8 @@ public class InvocationExprent extends Exprent {
@@ -95,7 +95,7 @@ index 593a5be..43db4dc 100644
  
          MethodDescriptor md = MethodDescriptor.parseDescriptor(mtt.getDescriptor());
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
-index f99fdc4..bf254b8 100644
+index f99fdc492e9ca76a1f14695e832ea193b920c1e1..bf254b8d843526d872092f4b0a000b13baef518a 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
 @@ -5,6 +5,8 @@ import org.jetbrains.java.decompiler.code.CodeConstants;
@@ -141,6 +141,3 @@ index f99fdc4..bf254b8 100644
 +    return "";
 +  }
  }
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0029-Improve-inferred-generic-types.patch
+++ b/FernFlower-Patches/0029-Improve-inferred-generic-types.patch
@@ -1,11 +1,11 @@
-From 8001cd51a44dd519547d593e1e2e79b5d1dcf7ab Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Justin <jrd2558@gmail.com>
 Date: Tue, 30 Apr 2019 10:34:56 -0700
 Subject: [PATCH] Improve inferred generic types
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
-index d91d9fa..01b9cef 100644
+index d91d9faebf718192a679c436792a54c24bed8c63..01b9cef3bb535025f816f18acab5951083e4ec55 100644
 --- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
 +++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
 @@ -36,6 +36,7 @@ public interface IFernflowerPreferences {
@@ -25,7 +25,7 @@ index d91d9fa..01b9cef 100644
      defaults.put(LOG_LEVEL, IFernflowerLogger.Severity.INFO.name());
      defaults.put(MAX_PROCESSING_METHOD, "0");
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ArrayExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ArrayExprent.java
-index bf5ff14..9fd3f05 100644
+index bf5ff14382c3d5e655778298c87fbe6a8b6592c3..9fd3f0547c17ca6c52cb725ebf1f90771c5ad456 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ArrayExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ArrayExprent.java
 @@ -42,6 +42,17 @@ public class ArrayExprent extends Exprent {
@@ -47,7 +47,7 @@ index bf5ff14..9fd3f05 100644
    public int getExprentUse() {
      return array.getExprentUse() & index.getExprentUse() & Exprent.MULTIPLE_USES;
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
-index 4bd94d9..6ed64f7 100644
+index 4bd94d9f47c9d15ef571412a28b97a0fbbfd45ef..6ed64f77930f44a9c6bd17d2eca51de97a6cbbcf 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
 @@ -3,6 +3,7 @@ package org.jetbrains.java.decompiler.modules.decompiler.exps;
@@ -72,7 +72,7 @@ index 4bd94d9..6ed64f7 100644
  
    private static VarType guessType(int val, boolean boolPermitted) {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
-index 58c3471..09cbfdc 100644
+index 58c3471ff26529c091a44670828d272755e75f7d..09cbfdc37b929ab03b99e16d47566331ade154a0 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
 @@ -54,6 +54,8 @@ public abstract class Exprent implements IMatchable {
@@ -181,7 +181,7 @@ index 58c3471..09cbfdc 100644
    // IMatchable implementation
    // *****************************************************************************
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
-index 880a5d2..5143f83 100644
+index 880a5d29d0b8c8d92ea7bd8918268742c7efcde5..5143f83d9e4e6fdb6d4e6b54acfaed13a8fdb328 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
 @@ -16,6 +16,7 @@ import org.jetbrains.java.decompiler.struct.attr.StructLocalVariableTableAttribu
@@ -231,7 +231,7 @@ index 880a5d2..5143f83 100644
  
      return getExprType();
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
-index 8f69e43..1f27ed6 100644
+index 8f69e433dce5541e5f42693c67fbb9f8610821d2..1f27ed6c5ab25460b0e67c728c7fdcaa23e6c268 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
 @@ -342,6 +342,11 @@ public class FunctionExprent extends Exprent {
@@ -264,7 +264,7 @@ index 8f69e43..1f27ed6 100644
    public void getBytecodeRange(BitSet values) {
      measureBytecode(values, lstOperands);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 43db4dc..25b88c3 100644
+index 43db4dcfe8e32f8809a2a8743eb04a49e6942f18..25b88c34b98821413c947cf597a46e1dfe16c762 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -52,6 +52,7 @@ public class InvocationExprent extends Exprent {
@@ -909,7 +909,7 @@ index 43db4dc..25b88c3 100644
    public void getBytecodeRange(BitSet values) {
      measureBytecode(values, lstParameters);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
-index bf254b8..9290b94 100644
+index bf254b8d843526d872092f4b0a000b13baef518a..9290b94f6590fa559b79b241a40da3e0f1253045 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
 @@ -5,7 +5,16 @@ import org.jetbrains.java.decompiler.code.CodeConstants;
@@ -1382,7 +1382,7 @@ index bf254b8..9290b94 100644
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
-index b681b11..e30acc8 100644
+index b681b11cad3899d90c5f04df50b2ae021bea3021..e30acc8a02cbfc5e95da42a7daf365a2974144a7 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
 @@ -14,6 +14,7 @@ import org.jetbrains.java.decompiler.modules.decompiler.vars.CheckTypesResult;
@@ -1419,7 +1419,7 @@ index b681b11..e30acc8 100644
  
      if (vt == null || (varType != null && varType.type != CodeConstants.TYPE_UNKNOWN)) {
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructClass.java b/src/org/jetbrains/java/decompiler/struct/StructClass.java
-index 6729ac6..868ccb5 100644
+index 6729ac6feb7d822c3786b1864dc12cf779c3d30d..868ccb525924c30ad17539d97b9a984c2f0c7ab8 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructClass.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructClass.java
 @@ -18,9 +18,11 @@ import org.jetbrains.java.decompiler.util.InterpreterUtil;
@@ -1464,7 +1464,7 @@ index 6729ac6..868ccb5 100644
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructContext.java b/src/org/jetbrains/java/decompiler/struct/StructContext.java
-index 68cf259..9226d9d 100644
+index 68cf259230cd82298c36b391e0ea91d111fca9ab..9226d9d8e8f34fcc5c43a67f914ff7683a6be50b 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructContext.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructContext.java
 @@ -210,6 +210,24 @@ public class StructContext {
@@ -1493,7 +1493,7 @@ index 68cf259..9226d9d 100644
      for (String line : string.split("\n")) {
        String[] pts = line.split(" ");
 diff --git a/src/org/jetbrains/java/decompiler/struct/gen/VarType.java b/src/org/jetbrains/java/decompiler/struct/gen/VarType.java
-index af6b899..88bf2ef 100644
+index af6b8995f8396efdcaa82fae195dd8c3d107b5a7..88bf2ef12b66bf190249ed8d3703c43be11c7c33 100644
 --- a/src/org/jetbrains/java/decompiler/struct/gen/VarType.java
 +++ b/src/org/jetbrains/java/decompiler/struct/gen/VarType.java
 @@ -423,8 +423,10 @@ public class VarType {  // TODO: optimize switch
@@ -1510,7 +1510,7 @@ index af6b899..88bf2ef 100644
      return this;
    }
 diff --git a/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericType.java b/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericType.java
-index 13cca79..34d03ea 100644
+index 13cca7906fb5810a0bf70b4b6ce184087e1c99e0..34d03ea99dad1f85220ac85b37f9cd849e4c3c64 100644
 --- a/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericType.java
 +++ b/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericType.java
 @@ -4,12 +4,16 @@ package org.jetbrains.java.decompiler.struct.gen.generics;
@@ -1842,6 +1842,3 @@ index 13cca79..34d03ea 100644
 +    return derivedType;
 +  }
  }
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0030-Improve-stack-var-processor-output.patch
+++ b/FernFlower-Patches/0030-Improve-stack-var-processor-output.patch
@@ -1,11 +1,11 @@
-From c41a9200ee52345805a1a51997d0a663966530f6 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Justin <jrd2558@gmail.com>
 Date: Sun, 25 Aug 2019 18:02:16 -0700
 Subject: [PATCH] Improve stack var processor output
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
-index b77dfec..75c6037 100644
+index b77dfec43d4b5b7e11528df9ecf52f32473629b4..75c6037aa532cc62df598fe682929db1d7e9a4ee 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
 @@ -167,11 +167,12 @@ public class MethodProcessorRunnable implements Runnable {
@@ -24,7 +24,7 @@ index b77dfec..75c6037 100644
  
        if (TryHelper.enhanceTryStats(root)) {
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-index 9942e12..7f80109 100644
+index 9942e125766f6162506ff6418f00e8bcbe6d8072..7f80109f80ec5686fd6934504022be5135c0863a 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 @@ -263,6 +263,9 @@ public class NestedClassProcessor {
@@ -38,7 +38,7 @@ index 9942e12..7f80109 100644
                }
                else {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
-index 767f6bd..261756b 100644
+index 767f6bdb92ecf0ba0bc4a437b8bf8482fa47bdea..261756b9e05f7e11d1c77e52e924cfefad988f45 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
 @@ -132,6 +132,11 @@ public class SimplifyExprentsHelper {
@@ -82,7 +82,7 @@ index 767f6bd..261756b 100644
      if (first.type == Exprent.EXPRENT_ASSIGNMENT) {
        AssignmentExprent asf = (AssignmentExprent)first;
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/StackVarsProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/StackVarsProcessor.java
-index 1232e64..500c5eb 100644
+index 1232e643fae990a7a3a9ee5f2e2ece46e607f934..500c5eb514de743bf133885f7d5f41ef1e377d24 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/StackVarsProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/StackVarsProcessor.java
 @@ -2,6 +2,8 @@
@@ -319,7 +319,7 @@ index 1232e64..500c5eb 100644
  }
 \ No newline at end of file
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 25b88c3..9bbdb53 100644
+index 25b88c34b98821413c947cf597a46e1dfe16c762..9bbdb537498de8dd02f0638760e24a37444e26e4 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -166,6 +166,11 @@ public class InvocationExprent extends Exprent {
@@ -335,7 +335,7 @@ index 25b88c3..9bbdb53 100644
  
    @Override
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
-index e30acc8..821062d 100644
+index e30acc8a02cbfc5e95da42a7daf365a2974144a7..821062d824197b9955bbadff1af0c643f15d3d41 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
 @@ -49,6 +49,7 @@ public class VarExprent extends Exprent {
@@ -370,7 +370,7 @@ index e30acc8..821062d 100644
      VarVersionPair pair = getVarVersionPair();
      if (lvt != null)
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java
-index 8e57cd7..db92712 100644
+index 8e57cd727302fe608f178c51ba4a7fb4c8971448..db927122415ad07666d51959debcb24d126c9545 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java
 @@ -238,7 +238,7 @@ public class SSAConstructorSparseEx {
@@ -402,7 +402,7 @@ index 8e57cd7..db92712 100644
    }
  
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java
-index 3607a8d..58169c2 100644
+index 3607a8dc6483775f12aa23420ffe447ec9e993bd..58169c235c1cf1d4862f3f515553bf0a9da132d5 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java
 @@ -67,6 +67,9 @@ public class SSAUConstructorSparseEx {
@@ -484,7 +484,7 @@ index 3607a8d..58169c2 100644
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
-index 8574fe2..1b1d911 100644
+index 8574fe25782da90f36888186fb3d977c33eeaad1..1b1d911df7b6767a56f543980b3adbb05f7cdb5d 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
 @@ -11,6 +11,7 @@ import org.jetbrains.java.decompiler.modules.decompiler.exps.ConstExprent;
@@ -584,7 +584,7 @@ index 8574fe2..1b1d911 100644
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionNode.java b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionNode.java
-index 914995e..17fa070 100644
+index 914995e6bb53b02680ae1c643185fcb85092944c..17fa070577c578161391a9544b478cbd8a52e4ac 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionNode.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionNode.java
 @@ -2,6 +2,7 @@
@@ -615,7 +615,7 @@ index 914995e..17fa070 100644
    public List<IGraphNode> getPredecessors() {
      List<IGraphNode> lst = new ArrayList<>(preds.size());
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsGraph.java b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsGraph.java
-index 58eda68..fc10e17 100644
+index 58eda687c83938c8b98fe59d54ca1a1972df8ed4..fc10e17c2db45ef9beb3ccd628a22bedc2467ceb 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsGraph.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsGraph.java
 @@ -4,6 +4,7 @@ package org.jetbrains.java.decompiler.modules.decompiler.vars;
@@ -640,6 +640,3 @@ index 58eda68..fc10e17 100644
      return node;
    }
  
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0031-Fix-finally-processor-instruction-comparison.patch
+++ b/FernFlower-Patches/0031-Fix-finally-processor-instruction-comparison.patch
@@ -1,11 +1,11 @@
-From ba2822e16daddb8e1340e18308a1d61aa09a8ce7 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Justin <jrd2558@gmail.com>
 Date: Sat, 11 Jan 2020 17:00:41 -0700
 Subject: [PATCH] Fix finally processor instruction comparison
 
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java
-index c3e3732..8641cbe 100644
+index c3e37329d651b983484736154c6fccbe8b851218..8641cbe298e1c7cbcae287bcf5c26b4f78a12266 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java
 @@ -859,13 +859,17 @@ public class FinallyProcessor {
@@ -27,6 +27,3 @@ index c3e3732..8641cbe 100644
  
            return false;
          }
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0032-Simple-lambda-syntax-support-isl-0-to-disable.patch
+++ b/FernFlower-Patches/0032-Simple-lambda-syntax-support-isl-0-to-disable.patch
@@ -1,11 +1,11 @@
-From 2c308e9733d2a666bdfa13e3ab7b53f9f6ab8eb0 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Justin <jrd2558@gmail.com>
 Date: Fri, 20 Dec 2019 08:35:30 -0700
 Subject: [PATCH] Simple lambda syntax support, --isl=0 to disable.
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 69b1dc4..58aaa9d 100644
+index 69b1dc49a54a4f114e04dee27c019d7b09028220..58aaa9d4dafc0b873fac77c6c9fa653ebf76d3cf 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -11,6 +11,7 @@ import org.jetbrains.java.decompiler.main.rels.MethodWrapper;
@@ -109,7 +109,7 @@ index 69b1dc4..58aaa9d 100644
      }
      finally {
 diff --git a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
-index 01b9cef..41f7389 100644
+index 01b9cef3bb535025f816f18acab5951083e4ec55..41f7389f3931a6a3c87647f7fde98f04c37af5c0 100644
 --- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
 +++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
 @@ -37,6 +37,7 @@ public interface IFernflowerPreferences {
@@ -128,6 +128,3 @@ index 01b9cef..41f7389 100644
  
      defaults.put(LOG_LEVEL, IFernflowerLogger.Severity.INFO.name());
      defaults.put(MAX_PROCESSING_METHOD, "0");
--- 
-2.27.0
-

--- a/FernFlower-Patches/0033-Add-explicit-cast-to-invocations-of-java-nio-Buffer-.patch
+++ b/FernFlower-Patches/0033-Add-explicit-cast-to-invocations-of-java-nio-Buffer-.patch
@@ -1,15 +1,13 @@
-From 9c65faa246edeb70c783f560388f0d0f3d92e587 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Tue, 14 Apr 2020 19:25:41 -0700
 Subject: [PATCH] Add explicit cast to invocations of java/nio/Buffer
- functions. Java 9+ added overrides to these functions to return the specific
- subclass, however, when there is a compiler "bug" that when targeting release
- * or below, it will still reference these new methods, causing exceptions at
- runtime on Java 8.
+ functions.
 
+Java 9+ added overrides to these functions to return the specific subclass, however, when there is a compiler "bug" that when targeting release * or below, it will still reference these new methods, causing exceptions at runtime on Java 8.
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 9bbdb53..7a3790f 100644
+index 9bbdb537498de8dd02f0638760e24a37444e26e4..7a3790fb7b4e33ca86ecf5e90f9eb4a8e30145db 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -46,6 +46,8 @@ public class InvocationExprent extends Exprent {
@@ -34,6 +32,3 @@ index 9bbdb53..7a3790f 100644
            else {
              buf.append(res);
            }
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0034-Revert-change-to-FieldExprent-getExprentUse.patch
+++ b/FernFlower-Patches/0034-Revert-change-to-FieldExprent-getExprentUse.patch
@@ -1,4 +1,4 @@
-From a96a23e7315d525175a511e61b82e243e3507d25 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: covers1624 <laughlan.cov@internode.on.net>
 Date: Sun, 7 Jun 2020 16:53:49 +0930
 Subject: [PATCH] Revert change to FieldExprent#getExprentUse
@@ -7,7 +7,7 @@ Revert part of a change introduced upstream. https://github.com/MinecraftForge/F
 This upstream change causes local variables to not be inlined in many cases, and makes decomp very messy for the reason of 'thread safety'.
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
-index 5143f83..fe98a67 100644
+index 5143f83d9e4e6fdb6d4e6b54acfaed13a8fdb328..fe98a67593856bc9358faf468afcd7bde986b520 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
 @@ -107,7 +107,13 @@ public class FieldExprent extends Exprent {
@@ -25,6 +25,3 @@ index 5143f83..fe98a67 100644
    }
  
    @Override
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0035-Add-only-argument-It-will-filter-what-classes-are-de.patch
+++ b/FernFlower-Patches/0035-Add-only-argument-It-will-filter-what-classes-are-de.patch
@@ -1,14 +1,14 @@
-From a66ecb7e8f5e2090fe1064a4e0c593fefe6dd936 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Wed, 10 Jun 2020 09:59:19 -0700
 Subject: [PATCH] Add -only argument It will filter what classes are decompiled
- from the target jar. Uses a prefix system, so -only=net/minecraft/block/ will
- decompile all classes in the block package and subpackages. Useful for
- debugging to limit scope/runtime.
+ from the target jar.
 
+Uses a prefix system, so -only=net/minecraft/block/ will decompile all classes in the block package and subpackages.
+Useful for debugging to limit scope/runtime.
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
-index c5cfa74..eafddcc 100644
+index c5cfa74b683deb347d5733ba306628561e013cc3..eafddccc870786ee6f68412420ddd52e1b5b6992 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 @@ -36,6 +36,7 @@ public class ClassesProcessor implements CodeConstants {
@@ -58,7 +58,7 @@ index c5cfa74..eafddcc 100644
      }
  
 diff --git a/src/org/jetbrains/java/decompiler/main/Fernflower.java b/src/org/jetbrains/java/decompiler/main/Fernflower.java
-index ab8c1a6..469b313 100644
+index ab8c1a60acfdef8c6ffb3082efbfbc1315d2c0bc..469b313a958cf8aca35fe98fc809880d12db671e 100644
 --- a/src/org/jetbrains/java/decompiler/main/Fernflower.java
 +++ b/src/org/jetbrains/java/decompiler/main/Fernflower.java
 @@ -115,6 +115,10 @@ public class Fernflower implements IDecompiledData {
@@ -82,7 +82,7 @@ index ab8c1a6..469b313 100644
      }
      else if (converter != null) {
 diff --git a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
-index 5393dde..2b6e9ed 100644
+index 5393ddec202efa7e1f6bb3f7740fa83a70ea48fd..2b6e9ed5d2cf8e3781c9b33b1489fee9447d8181 100644
 --- a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
 +++ b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
 @@ -66,6 +66,7 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
@@ -124,6 +124,3 @@ index 5393dde..2b6e9ed 100644
    public void decompileContext() {
      try {
        engine.decompileContext();
--- 
-2.27.0
-

--- a/FernFlower-Patches/0036-Fix-local-variables-incorrectly-merging.patch
+++ b/FernFlower-Patches/0036-Fix-local-variables-incorrectly-merging.patch
@@ -1,11 +1,11 @@
-From 7a7d32438ff61b53f582f66f063ebb51cb4f7d2b Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Mon, 15 Jun 2020 22:07:51 -0700
 Subject: [PATCH] Fix local variables incorrectly merging.
 
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/StackVarsProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/StackVarsProcessor.java
-index 500c5eb..66ba9d9 100644
+index 500c5eb514de743bf133885f7d5f41ef1e377d24..66ba9d916fe6c7df79d24d88b75204b5cf638d9c 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/StackVarsProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/StackVarsProcessor.java
 @@ -601,7 +601,7 @@ public class StackVarsProcessor {
@@ -34,6 +34,3 @@ index 500c5eb..66ba9d9 100644
            break;
          }
        }
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0037-Do-not-rebuild-variable-names-in-lambdas.patch
+++ b/FernFlower-Patches/0037-Do-not-rebuild-variable-names-in-lambdas.patch
@@ -1,12 +1,12 @@
-From 024157b96eede4558ab9feef2afced67db6e52ce Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Wed, 17 Jun 2020 11:07:09 -0700
-Subject: [PATCH] Do not rebuild variable names in lambdas. Breaks outer this
- references. Code existed before my time, no idea what it's intention is.
+Subject: [PATCH] Do not rebuild variable names in lambdas.
 
+Breaks outer this references. Code existed before my time, no idea what it's intention is.
 
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-index 7f80109..fe37266 100644
+index 7f80109f80ec5686fd6934504022be5135c0863a..fe372662be3fbd310f94831b47f21b92033a851c 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 @@ -285,7 +285,7 @@ public class NestedClassProcessor {
@@ -18,6 +18,3 @@ index 7f80109..fe37266 100644
      method.setOuterVarNames.addAll(setNewOuterNames);
  
      for (Entry<VarVersionPair, String> entry : mapNewNames.entrySet()) {
--- 
-2.27.0.windows.1
-

--- a/FernFlower-Patches/0038-Add-toString-to-MethodDescriptor.patch
+++ b/FernFlower-Patches/0038-Add-toString-to-MethodDescriptor.patch
@@ -1,11 +1,11 @@
-From 7b1e12d9f6b659bf671250d3e24b1314f0129428 Mon Sep 17 00:00:00 2001
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Wed, 17 Jun 2020 11:08:27 -0700
 Subject: [PATCH] Add toString to MethodDescriptor
 
 
 diff --git a/src/org/jetbrains/java/decompiler/struct/gen/MethodDescriptor.java b/src/org/jetbrains/java/decompiler/struct/gen/MethodDescriptor.java
-index 49bb8c8..4995d41 100644
+index 49bb8c809a273cfd4f268b5e01badc468f895f75..4995d41f7cca01876d8dc925fa7b02df2e24fcc2 100644
 --- a/src/org/jetbrains/java/decompiler/struct/gen/MethodDescriptor.java
 +++ b/src/org/jetbrains/java/decompiler/struct/gen/MethodDescriptor.java
 @@ -19,11 +19,13 @@ import java.util.Objects;
@@ -44,6 +44,3 @@ index 49bb8c8..4995d41 100644
    @Override
    public boolean equals(Object o) {
      if (o == this) return true;
--- 
-2.27.0.windows.1
-


### PR DESCRIPTION
Significantly cleans up redundant and continually changing data inside the patches.
Also fixes a few cases where commits had really long names.