### PR TITLE
Fix newline after abstract method

### DIFF
--- a/FernFlower-Patches/0021-Add-a-metadata-file-named-fernflower_abstract_parame.patch
+++ b/FernFlower-Patches/0021-Add-a-metadata-file-named-fernflower_abstract_parame.patch
@@ -68,7 +68,7 @@ index f7b253bc942cd00f64505ce1424c6d5e8d0225d8..fde588174ace52b073d205bd0fa04563
          return;
      otherEntries.add(new String[]{fullPath, entry});
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructContext.java b/src/org/jetbrains/java/decompiler/struct/StructContext.java
-index cc4e357fb8b7adeeb76858813f5ee329d17497d5..68cf259230cd82298c36b391e0ea91d111fca9ab 100644
+index cc4e357fb8b7adeeb76858813f5ee329d17497d5..d6d545b3cd24125c5c737756c28f82ccb3f2c2ef 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructContext.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructContext.java
 @@ -4,14 +4,18 @@ package org.jetbrains.java.decompiler.struct;
@@ -104,7 +104,7 @@ index cc4e357fb8b7adeeb76858813f5ee329d17497d5..68cf259230cd82298c36b391e0ea91d1
    }
 +
 +  public void loadAbstractMetadata(String string) {
-+    for (String line : string.split("\n")) {
++    for (String line : string.split(DecompilerContext.getNewLineSeparator())) {
 +      String[] pts = line.split(" ");
 +      if (pts.length < 4) //class method desc [args...]
 +        continue;

--- a/FernFlower-Patches/0029-Improve-inferred-generic-types.patch
+++ b/FernFlower-Patches/0029-Improve-inferred-generic-types.patch
@@ -1463,7 +1463,7 @@ index 6729ac6feb7d822c3786b1864dc12cf779c3d30d..868ccb525924c30ad17539d97b9a984c
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructContext.java b/src/org/jetbrains/java/decompiler/struct/StructContext.java
-index 68cf259230cd82298c36b391e0ea91d111fca9ab..9226d9d8e8f34fcc5c43a67f914ff7683a6be50b 100644
+index d6d545b3cd24125c5c737756c28f82ccb3f2c2ef..0d87d7ad97e2a8afff3abdee4abcf4cc45c9eb2d 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructContext.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructContext.java
 @@ -210,6 +210,24 @@ public class StructContext {
@@ -1489,7 +1489,7 @@ index 68cf259230cd82298c36b391e0ea91d111fca9ab..9226d9d8e8f34fcc5c43a67f914ff768
 +  }
 +
    public void loadAbstractMetadata(String string) {
-     for (String line : string.split("\n")) {
+     for (String line : string.split(DecompilerContext.getNewLineSeparator())) {
        String[] pts = line.split(" ");
 diff --git a/src/org/jetbrains/java/decompiler/struct/gen/VarType.java b/src/org/jetbrains/java/decompiler/struct/gen/VarType.java
 index af6b8995f8396efdcaa82fae195dd8c3d107b5a7..88bf2ef12b66bf190249ed8d3703c43be11c7c33 100644


### PR DESCRIPTION
If `fernflower_abstract_parameter_names.txt` separates lines with CRLF, the decompile output will have a newline after the abstract method just like below:
```java
public class EntityType<T extends Entity> implements EntityTypeTest<Entity, T> {
   // Omit some of the code
   public interface EntityFactory<T extends Entity> {
      T create(EntityType<T> entitytype, Level level
);
   }
}
```
The correct should be:
```java
public class EntityType<T extends Entity> implements EntityTypeTest<Entity, T> {
   // Omit some of the code
   public interface EntityFactory<T extends Entity> {
      T create(EntityType<T> entitytype, Level level);
   }
}
```

This PR replaces the hard coded LF to follow OS or configured line separator.