### PR TITLE
Fix jgit branch calculation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,15 +54,16 @@ def gitInfo(dir) {
         ]
     }
     def desc = git.describe().setLong(true).setTags(true).call().rsplit('-', 2)
-    def head = git.repository.resolve('HEAD')
-    
+    def head = git.repository.exactRef('HEAD')
+    def longBranch = head.symbolic ? head?.target?.name : null // matches Repository.getFullBranch() but returning null when on a detached HEAD
+
     def ret = [:]
     ret.tag = desc[0]
     ret.offset = desc[1]
     ret.hash = desc[2]
-    ret.branch = git.repository.branch
-    ret.commit = org.eclipse.jgit.lib.ObjectId.toString(head)
-    ret.abbreviatedId = head.abbreviate(8).name()
+    ret.branch = longBranch != null ? org.eclipse.jgit.lib.Repository.shortenRefName(longBranch) : null
+    ret.commit = org.eclipse.jgit.lib.ObjectId.toString(head.objectId)
+    ret.abbreviatedId = head.objectId.abbreviate(8).name()
     
     return ret
 }


### PR DESCRIPTION
seems there's a behaviour difference between grgit and jgit -- when grgit is on a detached head it returns `null` for a branch, while jgit will return the commit id

This resulted in published builds with versions like: https://files.minecraftforge.net/maven/net/minecraftforge/forgeflower/1.5.498.1-ab3565d50e8e8e293a0977878f0b825b828583ae/forgeflower-1.5.498.1-ab3565d50e8e8e293a0977878f0b825b828583ae.jar

Tested on detached head, `master` branch, and a non-`master` branch, and seems to produce the correct results.