### PR TITLE
Avoid NPE in primitive (un)boxing when libraries are not found on the classpath

### DIFF
--- a/FernFlower-Patches/0014-Fix-primitive-un-boxing-issues.patch
+++ b/FernFlower-Patches/0014-Fix-primitive-un-boxing-issues.patch
@@ -54,7 +54,7 @@ index 161f55c45a3f2c199fcc24b9fdd1bd269bafbfb8..068e44b80f9972be77bfd9fe095a5549
          TYPES[funcType - FUNCTION_I2L]) + ")");
      }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index d72870ee498d9da075a08dc6e2afef906ba44ad2..1c822f357c117f4bc8af4ced1842421d2224af18 100644
+index d72870ee498d9da075a08dc6e2afef906ba44ad2..a557614a3a59a270f2a6917b5eb0cf9046db98e8 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -59,6 +59,8 @@ public class InvocationExprent extends Exprent {
@@ -121,7 +121,7 @@ index d72870ee498d9da075a08dc6e2afef906ba44ad2..1c822f357c117f4bc8af4ced1842421d
  
            if (rightType.equals(VarType.VARTYPE_OBJECT) && !leftType.equals(rightType)) {
              buf.append("((").append(ExprProcessor.getCastTypeName(leftType)).append(")");
-@@ -417,8 +439,85 @@ public class InvocationExprent extends Exprent {
+@@ -417,8 +439,87 @@ public class InvocationExprent extends Exprent {
        }
      }
  
@@ -186,14 +186,16 @@ index d72870ee498d9da075a08dc6e2afef906ba44ad2..1c822f357c117f4bc8af4ced1842421d
 +        // types, and check unboxing as needed. Currently it causes some false forces
 +        else if (inv.isUnboxingCall() && !inv.shouldForceUnboxing()) {
 +          StructClass stClass = DecompilerContext.getStructContext().getClass(classname);
-+          for (StructMethod mt : stClass.getMethods()) {
-+            if (name.equals(mt.getName()) && !stringDescriptor.equals(mt.getDescriptor())) {
-+              MethodDescriptor md = MethodDescriptor.parseDescriptor(mt.getDescriptor());
-+              if (md.params.length == descriptor.params.length) {
-+                if (md.params[i].type == CodeConstants.TYPE_OBJECT) {
-+                  if (DecompilerContext.getStructContext().instanceOf(inv.getInstance().getExprType().value, md.params[i].value)) {
-+                    inv.forceUnboxing(true);
-+                    break;
++          if (stClass != null) {
++            for (StructMethod mt : stClass.getMethods()) {
++              if (name.equals(mt.getName()) && !stringDescriptor.equals(mt.getDescriptor())) {
++                MethodDescriptor md = MethodDescriptor.parseDescriptor(mt.getDescriptor());
++                if (md.params.length == descriptor.params.length) {
++                  if (md.params[i].type == CodeConstants.TYPE_OBJECT) {
++                    if (DecompilerContext.getStructContext().instanceOf(inv.getInstance().getExprType().value, md.params[i].value)) {
++                      inv.forceUnboxing(true);
++                      break;
++                    }
 +                  }
 +                }
 +              }
@@ -208,7 +210,7 @@ index d72870ee498d9da075a08dc6e2afef906ba44ad2..1c822f357c117f4bc8af4ced1842421d
      for (int i = start; i < lstParameters.size(); i++) {
        if (mask == null || mask.get(i) == null) {
          TextBuffer buff = new TextBuffer();
-@@ -453,7 +552,7 @@ public class InvocationExprent extends Exprent {
+@@ -453,7 +554,7 @@ public class InvocationExprent extends Exprent {
          */
  
          // 'byte' and 'short' literals need an explicit narrowing type cast when used as a parameter
@@ -217,7 +219,7 @@ index d72870ee498d9da075a08dc6e2afef906ba44ad2..1c822f357c117f4bc8af4ced1842421d
  
          // the last "new Object[0]" in the vararg call is not printed
          if (buff.length() > 0) {
-@@ -506,7 +605,7 @@ public class InvocationExprent extends Exprent {
+@@ -506,7 +607,7 @@ public class InvocationExprent extends Exprent {
          }
  
          if (paramType == CodeConstants.TYPE_BYTECHAR || paramType == CodeConstants.TYPE_SHORTCHAR) {
@@ -226,7 +228,7 @@ index d72870ee498d9da075a08dc6e2afef906ba44ad2..1c822f357c117f4bc8af4ced1842421d
              return true;
            }
          }
-@@ -565,6 +664,18 @@ public class InvocationExprent extends Exprent {
+@@ -565,6 +666,18 @@ public class InvocationExprent extends Exprent {
      return !isStatic && lstParameters.size() == 0 && classname.equals(UNBOXING_METHODS.get(name));
    }
  
@@ -245,7 +247,7 @@ index d72870ee498d9da075a08dc6e2afef906ba44ad2..1c822f357c117f4bc8af4ced1842421d
    private List<StructMethod> getMatchedDescriptors() {
      List<StructMethod> matches = new ArrayList<>();
      StructClass cl = DecompilerContext.getStructContext().getClass(classname);
-@@ -594,6 +705,8 @@ public class InvocationExprent extends Exprent {
+@@ -594,6 +707,8 @@ public class InvocationExprent extends Exprent {
        return EMPTY_BIT_SET;
      }
  
@@ -254,7 +256,7 @@ index d72870ee498d9da075a08dc6e2afef906ba44ad2..1c822f357c117f4bc8af4ced1842421d
      // check if a call is unambiguous
      StructMethod mt = cl.getMethod(InterpreterUtil.makeUniqueKey(name, stringDescriptor));
      if (mt != null) {
-@@ -603,18 +716,50 @@ public class InvocationExprent extends Exprent {
+@@ -603,18 +718,50 @@ public class InvocationExprent extends Exprent {
          for (int i = 0; i < md.params.length; i++) {
            if (!md.params[i].equals(lstParameters.get(i).getExprType())) {
              exact = false;

--- a/FernFlower-Patches/0019-Enhance-Generic-Invocations-Temporarily.patch
+++ b/FernFlower-Patches/0019-Enhance-Generic-Invocations-Temporarily.patch
@@ -92,7 +92,7 @@ index 068e44b80f9972be77bfd9fe095a5549edf40a2f..8f69e433dce5541e5f42693c67fbb9f8
 \ No newline at end of file
 +}
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 1c822f357c117f4bc8af4ced1842421d2224af18..4c68bdd8a434ecc0b4dfe2804c1c9c1e1c819626 100644
+index a557614a3a59a270f2a6917b5eb0cf9046db98e8..9d4eae94966f13ef56e710f53f67f84ef5a50cd3 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -406,6 +406,7 @@ public class InvocationExprent extends Exprent {
@@ -112,16 +112,16 @@ index 1c822f357c117f4bc8af4ced1842421d2224af18..4c68bdd8a434ecc0b4dfe2804c1c9c1e
                  MethodDescriptor md = MethodDescriptor.parseDescriptor(mt.getDescriptor());
                  if (md.params.length == descriptor.params.length) {
                    for (int x = 0; x < md.params.length; x++) {
-@@ -500,7 +501,7 @@ public class InvocationExprent extends Exprent {
-         else if (inv.isUnboxingCall() && !inv.shouldForceUnboxing()) {
+@@ -501,7 +502,7 @@ public class InvocationExprent extends Exprent {
            StructClass stClass = DecompilerContext.getStructContext().getClass(classname);
-           for (StructMethod mt : stClass.getMethods()) {
--            if (name.equals(mt.getName()) && !stringDescriptor.equals(mt.getDescriptor())) {
-+            if (name.equals(mt.getName()) && (currCls == null || canAccess(currCls.classStruct, mt)) && !stringDescriptor.equals(mt.getDescriptor())) {
-               MethodDescriptor md = MethodDescriptor.parseDescriptor(mt.getDescriptor());
-               if (md.params.length == descriptor.params.length) {
-                 if (md.params[i].type == CodeConstants.TYPE_OBJECT) {
-@@ -516,6 +517,22 @@ public class InvocationExprent extends Exprent {
+           if (stClass != null) {
+             for (StructMethod mt : stClass.getMethods()) {
+-              if (name.equals(mt.getName()) && !stringDescriptor.equals(mt.getDescriptor())) {
++              if (name.equals(mt.getName()) && (currCls == null || canAccess(currCls.classStruct, mt)) && !stringDescriptor.equals(mt.getDescriptor())) {
+                 MethodDescriptor md = MethodDescriptor.parseDescriptor(mt.getDescriptor());
+                 if (md.params.length == descriptor.params.length) {
+                   if (md.params[i].type == CodeConstants.TYPE_OBJECT) {
+@@ -518,6 +519,22 @@ public class InvocationExprent extends Exprent {
        }
      }
  
@@ -144,7 +144,7 @@ index 1c822f357c117f4bc8af4ced1842421d2224af18..4c68bdd8a434ecc0b4dfe2804c1c9c1e
  
      boolean firstParameter = true;
      for (int i = start; i < lstParameters.size(); i++) {
-@@ -678,27 +695,98 @@ public class InvocationExprent extends Exprent {
+@@ -680,27 +697,98 @@ public class InvocationExprent extends Exprent {
  
    private List<StructMethod> getMatchedDescriptors() {
      List<StructMethod> matches = new ArrayList<>();

--- a/FernFlower-Patches/0023-Synthetic-getClass-cleanup.patch
+++ b/FernFlower-Patches/0023-Synthetic-getClass-cleanup.patch
@@ -94,7 +94,7 @@ index 986a8a72ec138ea637d3446ed2e823f6100c31cc..767f6bdb92ecf0ba0bc4a437b8bf8482
                String classname = newExpr.getNewType().value;
                ClassNode node = DecompilerContext.getClassProcessor().getMapRootClasses().get(classname);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 4c68bdd8a434ecc0b4dfe2804c1c9c1e1c819626..0f539b755ab019c0dd3845c22a7721eaa2a37195 100644
+index 9d4eae94966f13ef56e710f53f67f84ef5a50cd3..c5152f9053b274870b5da08acbddb89b12ac0516 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -61,6 +61,7 @@ public class InvocationExprent extends Exprent {
@@ -113,7 +113,7 @@ index 4c68bdd8a434ecc0b4dfe2804c1c9c1e1c819626..0f539b755ab019c0dd3845c22a7721ea
    }
  
    @Override
-@@ -968,6 +970,14 @@ public class InvocationExprent extends Exprent {
+@@ -970,6 +972,14 @@ public class InvocationExprent extends Exprent {
      return bootstrapArguments;
    }
  

--- a/FernFlower-Patches/0028-Fix-ambiguous-lambdas.patch
+++ b/FernFlower-Patches/0028-Fix-ambiguous-lambdas.patch
@@ -41,10 +41,10 @@ index 4933b5c1d375b7beacbb521bc8770cf295e7d98c..cc67f34aeede9a41bd78aeefdf6ac4a8
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 0f539b755ab019c0dd3845c22a7721eaa2a37195..a6a375df951afafd57c739b6585bbf3a1a4e985d 100644
+index c5152f9053b274870b5da08acbddb89b12ac0516..ebb845dff674965ff3e0e8011db33dae5270e24d 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-@@ -804,7 +804,8 @@ public class InvocationExprent extends Exprent {
+@@ -806,7 +806,8 @@ public class InvocationExprent extends Exprent {
        if (md.params.length == lstParameters.size()) {
          boolean exact = true;
          for (int i = 0; i < md.params.length; i++) {
@@ -54,7 +54,7 @@ index 0f539b755ab019c0dd3845c22a7721eaa2a37195..a6a375df951afafd57c739b6585bbf3a
              exact = false;
              missed.set(i);
            }
-@@ -818,7 +819,8 @@ public class InvocationExprent extends Exprent {
+@@ -820,7 +821,8 @@ public class InvocationExprent extends Exprent {
        boolean failed = false;
        MethodDescriptor md = MethodDescriptor.parseDescriptor(mtt.getDescriptor());
        for (int i = 0; i < lstParameters.size(); i++) {
@@ -64,7 +64,7 @@ index 0f539b755ab019c0dd3845c22a7721eaa2a37195..a6a375df951afafd57c739b6585bbf3a
          if (!missed.get(i)) {
            if (!md.params[i].equals(ptype)) {
              failed = true;
-@@ -826,6 +828,17 @@ public class InvocationExprent extends Exprent {
+@@ -828,6 +830,17 @@ public class InvocationExprent extends Exprent {
            }
          }
          else {
@@ -82,7 +82,7 @@ index 0f539b755ab019c0dd3845c22a7721eaa2a37195..a6a375df951afafd57c739b6585bbf3a
            if (md.params[i].type == CodeConstants.TYPE_OBJECT) {
              if (ptype.type != CodeConstants.TYPE_NULL) {
                if (!DecompilerContext.getStructContext().instanceOf(ptype.value, md.params[i].value)) {
-@@ -853,7 +866,10 @@ public class InvocationExprent extends Exprent {
+@@ -855,7 +868,10 @@ public class InvocationExprent extends Exprent {
  
          GenericMethodDescriptor gen = mtt.getSignature(); //TODO: Find synthetic flags for params, as Enum generic signatures do no contain the String,int params
          if (gen != null && gen.parameterTypes.size() > i && gen.parameterTypes.get(i).isGeneric()) {

--- a/FernFlower-Patches/0029-Improve-inferred-generic-types.patch
+++ b/FernFlower-Patches/0029-Improve-inferred-generic-types.patch
@@ -264,7 +264,7 @@ index 8f69e433dce5541e5f42693c67fbb9f8610821d2..1f27ed6c5ab25460b0e67c728c7fdcaa
    public void getBytecodeRange(BitSet values) {
      measureBytecode(values, lstOperands);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index a6a375df951afafd57c739b6585bbf3a1a4e985d..c29602144dd59be01d42a31a12c3b6fc8ceabe1c 100644
+index ebb845dff674965ff3e0e8011db33dae5270e24d..a02c40a8a8a2ad1a1888d8a5370625c29c858e27 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -52,6 +52,7 @@ public class InvocationExprent extends Exprent {
@@ -660,7 +660,7 @@ index a6a375df951afafd57c739b6585bbf3a1a4e985d..c29602144dd59be01d42a31a12c3b6fc
  
      // omit 'new Type[] {}' for the last parameter of a vararg method call
      if (lstParameters.size() == descriptor.params.length && isVarArgCall()) {
-@@ -519,20 +746,32 @@ public class InvocationExprent extends Exprent {
+@@ -521,20 +748,32 @@ public class InvocationExprent extends Exprent {
        }
      }
  
@@ -706,7 +706,7 @@ index a6a375df951afafd57c739b6585bbf3a1a4e985d..c29602144dd59be01d42a31a12c3b6fc
      }
  
  
-@@ -570,6 +809,10 @@ public class InvocationExprent extends Exprent {
+@@ -572,6 +811,10 @@ public class InvocationExprent extends Exprent {
          }
          */
  
@@ -717,7 +717,7 @@ index a6a375df951afafd57c739b6585bbf3a1a4e985d..c29602144dd59be01d42a31a12c3b6fc
          // 'byte' and 'short' literals need an explicit narrowing type cast when used as a parameter
          ExprProcessor.getCastedExprent(lstParameters.get(i), types[i], buff, indent, true, ambiguous, true, true, tracer);
  
-@@ -585,8 +828,6 @@ public class InvocationExprent extends Exprent {
+@@ -587,8 +830,6 @@ public class InvocationExprent extends Exprent {
        }
      }
  
@@ -726,7 +726,7 @@ index a6a375df951afafd57c739b6585bbf3a1a4e985d..c29602144dd59be01d42a31a12c3b6fc
      return buf;
    }
  
-@@ -882,6 +1123,162 @@ public class InvocationExprent extends Exprent {
+@@ -884,6 +1125,162 @@ public class InvocationExprent extends Exprent {
      return ambiguous;
    }
  
@@ -889,7 +889,7 @@ index a6a375df951afafd57c739b6585bbf3a1a4e985d..c29602144dd59be01d42a31a12c3b6fc
    @Override
    public void replaceExprent(Exprent oldExpr, Exprent newExpr) {
      if (oldExpr == instance) {
-@@ -994,6 +1391,18 @@ public class InvocationExprent extends Exprent {
+@@ -996,6 +1393,18 @@ public class InvocationExprent extends Exprent {
      return isSyntheticGetClass;
    }
  

--- a/FernFlower-Patches/0030-Improve-stack-var-processor-output.patch
+++ b/FernFlower-Patches/0030-Improve-stack-var-processor-output.patch
@@ -320,7 +320,7 @@ index 1232e643fae990a7a3a9ee5f2e2ece46e607f934..1a085709ed7a120d109542e4bf710101
  }
 \ No newline at end of file
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index c29602144dd59be01d42a31a12c3b6fc8ceabe1c..af6e0b9fdfb93a1e11f44a1a122f351deb988e5a 100644
+index a02c40a8a8a2ad1a1888d8a5370625c29c858e27..44927da60f640d940d0ccb6c52d8e4eba42ed2aa 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -166,6 +166,11 @@ public class InvocationExprent extends Exprent {

--- a/FernFlower-Patches/0033-Add-explicit-cast-to-invocations-of-java-nio-Buffer-.patch
+++ b/FernFlower-Patches/0033-Add-explicit-cast-to-invocations-of-java-nio-Buffer-.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Add explicit cast to invocations of java/nio/Buffer
 Java 9+ added overrides to these functions to return the specific subclass, however, when there is a compiler "bug" that when targeting release * or below, it will still reference these new methods, causing exceptions at runtime on Java 8.
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index af6e0b9fdfb93a1e11f44a1a122f351deb988e5a..7a58b3df1ea3c24d9ebd2fd7ef8d750c0b94eabc 100644
+index 44927da60f640d940d0ccb6c52d8e4eba42ed2aa..74e4440c8cb062db041ca853b7292196e89b106f 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -46,6 +46,8 @@ public class InvocationExprent extends Exprent {


### PR DESCRIPTION
fixes #93