### PR TITLE
Expose line-mapping for decompiled jars

### DIFF
--- a/FernFlower-Patches/0010-LVT-Fixes-and-Support-for-Enhanced-For-loop-detectio.patch
+++ b/FernFlower-Patches/0010-LVT-Fixes-and-Support-for-Enhanced-For-loop-detectio.patch
@@ -1919,7 +1919,7 @@ index 5168f05b5f073d661ca39c4446c8edbcbf1ccc00..7e41176d17729f6acdf5420c9ed98eb7
                                  new VarType(CodeConstants.TYPE_OBJECT, 0, edge.getExceptions().get(0)),
                                  // FIXME: for now simply the first type. Should get the first common superclass when possible.
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DoStatement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DoStatement.java
-index 46b2f2c2bab6bc401205c3a3523267927beae652..e86b2959dc7c3add12cc82f59f8cb6ab50a53252 100644
+index 46b2f2c2bab6bc401205c3a3523267927beae652..76009831d84f399b9a9dc1b8afc09eff519e000a 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DoStatement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DoStatement.java
 @@ -17,6 +17,7 @@ public final class DoStatement extends Statement {
@@ -1930,7 +1930,7 @@ index 46b2f2c2bab6bc401205c3a3523267927beae652..e86b2959dc7c3add12cc82f59f8cb6ab
  
    private int looptype;
  
-@@ -122,6 +123,13 @@ public final class DoStatement extends Statement {
+@@ -122,6 +123,14 @@ public final class DoStatement extends Statement {
          buf.append(ExprProcessor.jmpWrapper(first, indent + 1, false, tracer));
          buf.appendIndent(indent).append("}").appendLineSeparator();
          tracer.incrementCurrentSourceLine();
@@ -1941,10 +1941,11 @@ index 46b2f2c2bab6bc401205c3a3523267927beae652..e86b2959dc7c3add12cc82f59f8cb6ab
 +        tracer.incrementCurrentSourceLine();
 +        buf.append(ExprProcessor.jmpWrapper(first, indent + 1, true, tracer));
 +        buf.appendIndent(indent).append("}").appendLineSeparator();
++        tracer.incrementCurrentSourceLine();
      }
  
      return buf;
-@@ -139,6 +147,10 @@ public final class DoStatement extends Statement {
+@@ -139,6 +148,10 @@ public final class DoStatement extends Statement {
          }
        case LOOP_WHILE:
          lst.add(getConditionExprent());

--- a/FernFlower-Patches/0011-Rework-of-Generics-system-for-better-output.patch
+++ b/FernFlower-Patches/0011-Rework-of-Generics-system-for-better-output.patch
@@ -1305,7 +1305,7 @@ index 60048a473001b72b6eb6b8d903a257c043d76902..899ca15489fb70ff5f81aa3c947ca4c2
                  }
                }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DoStatement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DoStatement.java
-index e86b2959dc7c3add12cc82f59f8cb6ab50a53252..989a9aa6e34c2ac1f8644d84564c7b1ad8468e11 100644
+index 76009831d84f399b9a9dc1b8afc09eff519e000a..46635ec712d20adf9dd3396d2c62846aa8ef6bee 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DoStatement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DoStatement.java
 @@ -126,6 +126,7 @@ public final class DoStatement extends Statement {

--- a/FernFlower-Patches/0040-Expose-line-mapping-information-in-archive-mode.patch
+++ b/FernFlower-Patches/0040-Expose-line-mapping-information-in-archive-mode.patch
@@ -1,0 +1,61 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zml <zml@stellardrift.ca>
+Date: Fri, 23 Apr 2021 14:59:09 -0700
+Subject: [PATCH] Expose line mapping information in archive mode
+
+This allows modifying the input classes to have line numbers that match
+the decompiled source, allowing for easier debugging.
+
+diff --git a/src/org/jetbrains/java/decompiler/main/extern/IResultSaver.java b/src/org/jetbrains/java/decompiler/main/extern/IResultSaver.java
+index fad1ddcfb9d2e43720b4cd3acaa165ba86e94892..3ff9f2a770ac93ca28d5d32dff24318d1e271f48 100644
+--- a/src/org/jetbrains/java/decompiler/main/extern/IResultSaver.java
++++ b/src/org/jetbrains/java/decompiler/main/extern/IResultSaver.java
+@@ -8,6 +8,7 @@ public interface IResultSaver {
+ 
+   void copyFile(String source, String path, String entryName);
+ 
++  // mapping: a flat array of pairs of (input line number, output line number). null when -bsm=0
+   void saveClassFile(String path, String qualifiedName, String entryName, String content, int[] mapping);
+ 
+   void createArchive(String path, String archiveName, Manifest manifest);
+@@ -18,5 +19,10 @@ public interface IResultSaver {
+ 
+   void saveClassEntry(String path, String archiveName, String qualifiedName, String entryName, String content);
+ 
++  // mapping: a flat array of pairs of (input line number, output line number). null when -bsm=0
++  default void saveClassEntry(String path, String archiveName, String qualifiedName, String entryName, String content, int[] mapping) {
++    this.saveClassEntry(path, archiveName, qualifiedName, entryName, content);
++  }
++
+   void closeArchive(String path, String archiveName);
+ }
+diff --git a/src/org/jetbrains/java/decompiler/struct/ContextUnit.java b/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
+index 9eb1e3b71ee54001c902f11f6fa6c132c5a670fc..5e119e5030efab2bccc1bd96601075c081056339 100644
+--- a/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
++++ b/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
+@@ -201,7 +201,11 @@ public class ContextUnit {
+               futures.add(executor.submit(() -> {
+                 DecompilerContext.setCurrentContext(clCtx.ctx);
+                 String content = decompiledData.getClassContent(clCtx.cl);
+-                resultSaver.saveClassEntry(archivePath, filename, clCtx.cl.qualifiedName, clCtx.entryName, content);
++                int[] mapping = null;
++                if (DecompilerContext.getOption(IFernflowerPreferences.BYTECODE_SOURCE_MAPPING)) {
++                  mapping = DecompilerContext.getBytecodeSourceMapper().getOriginalLinesMapping();
++                }
++                resultSaver.saveClassEntry(archivePath, filename, clCtx.cl.qualifiedName, clCtx.entryName, content, mapping);
+                 DecompilerContext.setCurrentContext(null);
+               }));
+             }
+@@ -216,7 +220,11 @@ public class ContextUnit {
+             if (entryName != null) {
+               if (decompiledData.processClass(cl)) {
+                 String content = decompiledData.getClassContent(cl);
+-                resultSaver.saveClassEntry(archivePath, filename, cl.qualifiedName, entryName, content);
++                int[] mapping = null;
++                if (DecompilerContext.getOption(IFernflowerPreferences.BYTECODE_SOURCE_MAPPING)) {
++                  mapping = DecompilerContext.getBytecodeSourceMapper().getOriginalLinesMapping();
++                }
++                resultSaver.saveClassEntry(archivePath, filename, cl.qualifiedName, entryName, content, mapping);
+               }
+             }
+           }


### PR DESCRIPTION
This also fixes a case where the tracer wasn't incremented,
which caused misaligned linemaps.

I've tested this in my work on VanillaGradle, seems to make the debugger way happier now.

See [VanillaGradle's implementation](https://github.com/SpongePowered/VanillaGradle/blob/b9f6d3fcea5cafd639069081ad6461921e6036e0/src/jarDecompile/java/org/spongepowered/gradle/vanilla/worker/LineMappingResultSaver.java#L50) for an example of linemapping being applied.

There should be no impact on the decompiled output -- this whole bytecode tracer infrastructure is only used for the `-bsm` flag.