### PR TITLE
Changes for 21w19a+/J16

### DIFF
--- a/FernFlower-Patches/0016-Add-better-debug-logging.patch
+++ b/FernFlower-Patches/0016-Add-better-debug-logging.patch
@@ -4,6 +4,32 @@ Date: Mon, 25 Sep 2017 13:46:14 -0700
 Subject: [PATCH] Add better debug logging
 
 
+diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
+index 632a12c7bee16de80b5edc011d4aac783b4dc76a..490c01566b62aab791ef7be41ec0852fbb966ccc 100644
+--- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
++++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
+@@ -939,7 +939,7 @@ public class ClassWriter {
+             tracer.addTracer(codeTracer);
+           }
+           catch (Throwable t) {
+-            String message = "Method " + mt.getName() + " " + mt.getDescriptor() + " couldn't be written.";
++            String message = "Method " + mt.getName() + " " + mt.getDescriptor() + " in class " + node.classStruct.qualifiedName + " couldn't be written.";
+             DecompilerContext.getLogger().writeMessage(message, IFernflowerLogger.Severity.WARN, t);
+             methodWrapper.decompiledWithErrors = true;
+           }
+diff --git a/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java b/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
+index 438b04c518f193ac3b229701ddfdaf7cde5cad6e..9ce662b88d6a7406784b8aa1b4e1dc6700cebaa6 100644
+--- a/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
++++ b/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
+@@ -122,7 +122,7 @@ public class ClassWrapper {
+         }
+       }
+       catch (Throwable t) {
+-        String message = "Method " + mt.getName() + " " + mt.getDescriptor() + " couldn't be decompiled.";
++        String message = "Method " + mt.getName() + " " + mt.getDescriptor() + " in class " + classStruct.qualifiedName + " couldn't be decompiled.";
+         DecompilerContext.getLogger().writeMessage(message, IFernflowerLogger.Severity.WARN, t);
+         isError = true;
+       }
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructContext.java b/src/org/jetbrains/java/decompiler/struct/StructContext.java
 index 36d1d6c4ae8e3b9f1a64dae514d9efa65722033a..7c91206d1b64b9873fa24d6d3ad38e736413c0a3 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructContext.java

--- a/FernFlower-Patches/0022-Add-a-metadata-file-named-fernflower_abstract_parame.patch
+++ b/FernFlower-Patches/0022-Add-a-metadata-file-named-fernflower_abstract_parame.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Add a metadata file named
 Format: ClassName MethodName Descriptor Param1[ Param2...]
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 632a12c7bee16de80b5edc011d4aac783b4dc76a..124cdd01c4b531937373127576b7f6db90ed48ed 100644
+index 490c01566b62aab791ef7be41ec0852fbb966ccc..dda37ca0513494ca951c1cff0d363c1dcb36b6e1 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -870,7 +870,9 @@ public class ClassWriter {

--- a/FernFlower-Patches/0023-Synthetic-getClass-Objects.requireNonNull-cleanup.patch
+++ b/FernFlower-Patches/0023-Synthetic-getClass-Objects.requireNonNull-cleanup.patch
@@ -1,27 +1,30 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Justin <jrd2558@gmail.com>
 Date: Thu, 26 Jul 2018 13:28:40 -0700
-Subject: [PATCH] Synthetic getClass cleanup
+Subject: [PATCH] Synthetic getClass/Objects.requireNonNull cleanup
 
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
-index 474ffda1b9d610968bd12160f2153713b37f2db9..4933b5c1d375b7beacbb521bc8770cf295e7d98c 100644
+index 474ffda1b9d610968bd12160f2153713b37f2db9..eef5cdaf7fa5c425abddea9ab0717f6844c97460 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
-@@ -617,6 +617,20 @@ public class ExprProcessor implements CodeConstants {
+@@ -617,6 +617,23 @@ public class ExprProcessor implements CodeConstants {
            break;
          case opc_pop:
            stack.pop();
-+          // check for synthetic getClass calls added by the compiler
++          // check for synthetic getClass (J8) / Objects.requireNonNull() (J9+) calls added by the compiler
 +          // see https://stackoverflow.com/a/20130641
 +          if (i > 0) {
 +            Exprent last = exprlist.get(exprlist.size() - 1);
 +            if (last.type == Exprent.EXPRENT_ASSIGNMENT && ((AssignmentExprent)last).getRight().type == Exprent.EXPRENT_INVOCATION) {
-+              InvocationExprent invocation = (InvocationExprent)((AssignmentExprent)last).getRight();
-+              if (i + 1 < seq.length() && !invocation.isStatic() && invocation.getName().equals("getClass") && invocation.getStringDescriptor().equals("()Ljava/lang/Class;")) {
-+                int nextOpc = seq.getInstr(i + 1).opcode;
-+                if (nextOpc >= opc_aconst_null && nextOpc <= opc_ldc2_w) {
-+                  invocation.setSyntheticGetClass();
++              InvocationExprent invocation = (InvocationExprent) ((AssignmentExprent) last).getRight();
++              if (i + 1 < seq.length()) {
++                if ((!invocation.isStatic() && invocation.getName().equals("getClass") && invocation.getStringDescriptor().equals("()Ljava/lang/Class;")) // J8
++                  || (invocation.isStatic() && invocation.getClassname().equals("java/util/Objects") && invocation.getName().equals("requireNonNull") && invocation.getStringDescriptor().equals("(Ljava/lang/Object;)Ljava/lang/Object;"))) { // J9+
++                  int nextOpc = seq.getInstr(i + 1).opcode;
++                  if (nextOpc >= opc_aconst_null && nextOpc <= opc_ldc2_w) {
++                    invocation.setSyntheticNullCheck();
++                  }
 +                }
 +              }
 +            }
@@ -30,7 +33,7 @@ index 474ffda1b9d610968bd12160f2153713b37f2db9..4933b5c1d375b7beacbb521bc8770cf2
          case opc_pop2:
            if (stack.getByOffset(-1).getExprType().stackSize == 1) {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
-index 986a8a72ec138ea637d3446ed2e823f6100c31cc..767f6bdb92ecf0ba0bc4a437b8bf8482fa47bdea 100644
+index 986a8a72ec138ea637d3446ed2e823f6100c31cc..fa48cab3cb2b7da418322db7c10952f2f965e495 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
 @@ -71,6 +71,10 @@ public class SimplifyExprentsHelper {
@@ -44,7 +47,7 @@ index 986a8a72ec138ea637d3446ed2e823f6100c31cc..767f6bdb92ecf0ba0bc4a437b8bf8482
          }
  
          res |= changed;
-@@ -505,21 +509,43 @@ public class SimplifyExprentsHelper {
+@@ -505,21 +509,53 @@ public class SimplifyExprentsHelper {
      return false;
    }
  
@@ -69,10 +72,12 @@ index 986a8a72ec138ea637d3446ed2e823f6100c31cc..767f6bdb92ecf0ba0bc4a437b8bf8482
  
 -      if (!invocation.isStatic() && invocation.getInstance().type == Exprent.EXPRENT_VAR && invocation.getName().equals("getClass") &&
 -          invocation.getStringDescriptor().equals("()Ljava/lang/Class;")) {
-+      if (!invocation.isStatic() &&
-+           invocation.getName().equals("getClass") && invocation.getStringDescriptor().equals("()Ljava/lang/Class;")) {
++      if ((!invocation.isStatic() &&
++           invocation.getName().equals("getClass") && invocation.getStringDescriptor().equals("()Ljava/lang/Class;")) // J8
++        || (invocation.isStatic() && invocation.getClassname().equals("java/util/Objects") && invocation.getName().equals("requireNonNull")
++            && invocation.getStringDescriptor().equals("(Ljava/lang/Object;)Ljava/lang/Object;"))) { // J9+
 +
-+        if (invocation.isSyntheticGetClass()) {
++        if (invocation.isSyntheticNullCheck()) {
 +          return true;
 +        }
  
@@ -81,27 +86,35 @@ index 986a8a72ec138ea637d3446ed2e823f6100c31cc..767f6bdb92ecf0ba0bc4a437b8bf8482
          lstExprents.add(second);
  
 -        for (Exprent expr : lstExprents) {
-+        while (!lstExprents.isEmpty()){
++        final Exprent target;
++        if (invocation.isStatic()) { // Objects.requireNonNull(target) (J9+)
++          // detect target type
++          target = invocation.getLstParameters().get(0);
++        } else { // target.getClass() (J8)
++          target = invocation.getInstance();
++        }
++
++        while (!lstExprents.isEmpty()) {
 +          Exprent expr = lstExprents.removeFirst();
 +          lstExprents.addAll(expr.getAllExprents());
            if (expr.type == Exprent.EXPRENT_NEW) {
              NewExprent newExpr = (NewExprent)expr;
              if (newExpr.getConstructor() != null && !newExpr.getConstructor().getLstParameters().isEmpty() &&
 -                newExpr.getConstructor().getLstParameters().get(0).equals(invocation.getInstance())) {
-+              (newExpr.getConstructor().getLstParameters().get(0).equals(invocation.getInstance()) ||
-+                newExpr.getConstructor().getLstParameters().get(0).getExprType().equals(invocation.getInstance().getExprType()))) {
++              (newExpr.getConstructor().getLstParameters().get(0).equals(target) ||
++                newExpr.getConstructor().getLstParameters().get(0).getExprType().equals(target.getExprType()))) {
  
                String classname = newExpr.getNewType().value;
                ClassNode node = DecompilerContext.getClassProcessor().getMapRootClasses().get(classname);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 9d4eae94966f13ef56e710f53f67f84ef5a50cd3..c5152f9053b274870b5da08acbddb89b12ac0516 100644
+index 9d4eae94966f13ef56e710f53f67f84ef5a50cd3..16158a3d134c7af2ecdf58a539ff1d33ba80c6b9 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -61,6 +61,7 @@ public class InvocationExprent extends Exprent {
    private List<VarType> genericArgs = new ArrayList<>();
    private boolean forceBoxing = false;
    private boolean forceUnboxing = false;
-+  private boolean isSyntheticGetClass = false;
++  private boolean isSyntheticNullCheck = false;
  
    public InvocationExprent() {
      super(EXPRENT_INVOCATION);
@@ -109,7 +122,7 @@ index 9d4eae94966f13ef56e710f53f67f84ef5a50cd3..c5152f9053b274870b5da08acbddb89b
  
      addBytecodeOffsets(expr.bytecode);
      bootstrapArguments = expr.getBootstrapArguments();
-+    isSyntheticGetClass = expr.isSyntheticGetClass();
++    isSyntheticNullCheck = expr.isSyntheticNullCheck();
    }
  
    @Override
@@ -117,12 +130,12 @@ index 9d4eae94966f13ef56e710f53f67f84ef5a50cd3..c5152f9053b274870b5da08acbddb89b
      return bootstrapArguments;
    }
  
-+  public void setSyntheticGetClass() {
-+    isSyntheticGetClass = true;
++  public void setSyntheticNullCheck() {
++    isSyntheticNullCheck = true;
 +  }
 +
-+  public boolean isSyntheticGetClass() {
-+    return isSyntheticGetClass;
++  public boolean isSyntheticNullCheck() {
++    return isSyntheticNullCheck;
 +  }
 +
    @Override

--- a/FernFlower-Patches/0027-Prioritize-self-and-enclosing-class-when-encounterin.patch
+++ b/FernFlower-Patches/0027-Prioritize-self-and-enclosing-class-when-encounterin.patch
@@ -8,7 +8,7 @@ The compiler encodes all REFERENCED inner classes into the class. The first foun
 Fixes AccessTransformers.
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 124cdd01c4b531937373127576b7f6db90ed48ed..908ec69d788adf63487106715f82141cc1c43dac 100644
+index dda37ca0513494ca951c1cff0d363c1dcb36b6e1..6f22466edd1c87e6786ff08498b69005aca41e3e 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -1180,6 +1180,10 @@ public class ClassWriter {

--- a/FernFlower-Patches/0027-Prioritize-self-and-enclosing-class-when-encounterin.patch
+++ b/FernFlower-Patches/0027-Prioritize-self-and-enclosing-class-when-encounterin.patch
@@ -7,6 +7,21 @@ Subject: [PATCH] Prioritize self and enclosing class when encountering
 The compiler encodes all REFERENCED inner classes into the class. The first found used to win, but now ThisClass > EnclosingClass > Others AccessTransformers only edit the targeted class as it can't find all references.
 Fixes AccessTransformers.
 
+Add -win option to suppress warnings on inconsistent inner class
+information.
+
+diff --git a/README.md b/README.md
+index 225b42bcbd388c395fe51d2c5edda8d1cb1127b2..c41dd217b88663552b02ceac510ae13199b64b3c 100644
+--- a/README.md
++++ b/README.md
+@@ -64,6 +64,7 @@ The rest of options can be left as they are: they are aimed at professional reve
+ - inn (1): check for IntelliJ IDEA-specific @NotNull annotation and remove inserted code if found
+ - lac (0): decompile lambda expressions to anonymous classes
+ - nls (0): define new line character to be used for output. 0 - '\r\n' (Windows), 1 - '\n' (Unix), default is OS-dependent
++- win (1): Whether to warn on inconsistent inner class entries
+ - ind: indentation string (default is 3 spaces)
+ - log (INFO): a logging level, possible values are TRACE, INFO, WARN, ERROR
+ 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 index dda37ca0513494ca951c1cff0d363c1dcb36b6e1..6f22466edd1c87e6786ff08498b69005aca41e3e 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
@@ -23,7 +38,7 @@ index dda37ca0513494ca951c1cff0d363c1dcb36b6e1..6f22466edd1c87e6786ff08498b69005
      buffer.append('<');
  
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
-index 26ccf4b2124ab617bfeec45ebbf3451ab2e7aa6d..8ce3a2575b4c9c8268ba9956ea008027982a03fb 100644
+index 26ccf4b2124ab617bfeec45ebbf3451ab2e7aa6d..80b8fd01286f90c3f194385edef47df805611c98 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 @@ -42,10 +42,20 @@ public class ClassesProcessor implements CodeConstants {
@@ -55,12 +70,18 @@ index 26ccf4b2124ab617bfeec45ebbf3451ab2e7aa6d..8ce3a2575b4c9c8268ba9956ea008027
  
                // nested class type
                if (entry.innerName != null) {
-@@ -132,6 +143,13 @@ public class ClassesProcessor implements CodeConstants {
+@@ -130,8 +141,17 @@ public class ClassesProcessor implements CodeConstants {
+                   mapInnerClasses.put(innerName, rec);
+                 }
                  else if (!Inner.equal(existingRec, rec)) {
-                   String message = "Inconsistent inner class entries for " + innerName + "!";
-                   DecompilerContext.getLogger().writeMessage(message, IFernflowerLogger.Severity.WARN);
-+                  DecompilerContext.getLogger().writeMessage("  Old: " + existingRec.toString(), IFernflowerLogger.Severity.WARN);
-+                  DecompilerContext.getLogger().writeMessage("  New: " + rec.toString(), IFernflowerLogger.Severity.WARN);
+-                  String message = "Inconsistent inner class entries for " + innerName + "!";
+-                  DecompilerContext.getLogger().writeMessage(message, IFernflowerLogger.Severity.WARN);
++                  if (DecompilerContext.getOption(IFernflowerPreferences.WARN_INCONSISTENT_INNER_CLASSES)) {
++                    String message = "Inconsistent inner class entries for " + innerName + "!";
++                    DecompilerContext.getLogger().writeMessage(message, IFernflowerLogger.Severity.WARN);
++                    DecompilerContext.getLogger().writeMessage("  Old: " + existingRec.toString(), IFernflowerLogger.Severity.WARN);
++                    DecompilerContext.getLogger().writeMessage("  New: " + rec.toString(), IFernflowerLogger.Severity.WARN);
++                  }
 +                  int oldPriority = existingRec.source.equals(innerName) ? 1 : existingRec.source.equals(enclClassName) ? 2 : 3;
 +                  int newPriority = rec.source.equals(innerName) ? 1 : rec.source.equals(enclClassName) ? 2 : 3;
 +                  if (newPriority < oldPriority) {
@@ -69,3 +90,24 @@ index 26ccf4b2124ab617bfeec45ebbf3451ab2e7aa6d..8ce3a2575b4c9c8268ba9956ea008027
                  }
  
                  // reference to the nested class
+diff --git a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
+index d91d9faebf718192a679c436792a54c24bed8c63..9c6dd387cce2377ffb3eefd7e55aa4b5a04953e7 100644
+--- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
++++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
+@@ -55,6 +55,8 @@ public interface IFernflowerPreferences {
+ 
+   String SKIP_EXTRA_FILES = "sef";
+ 
++  String WARN_INCONSISTENT_INNER_CLASSES = "win";
++
+   Map<String, Object> DEFAULTS = getDefaults();
+ 
+   static Map<String, Object> getDefaults() {
+@@ -99,6 +101,7 @@ public interface IFernflowerPreferences {
+     defaults.put(DUMP_ORIGINAL_LINES, "0");
+     defaults.put(USE_JAD_VARNAMING, "0");
+     defaults.put(SKIP_EXTRA_FILES, "0");
++    defaults.put(WARN_INCONSISTENT_INNER_CLASSES, "1");
+ 
+     return Collections.unmodifiableMap(defaults);
+   }

--- a/FernFlower-Patches/0028-Fix-ambiguous-lambdas.patch
+++ b/FernFlower-Patches/0028-Fix-ambiguous-lambdas.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix ambiguous lambdas
 
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
-index 4933b5c1d375b7beacbb521bc8770cf295e7d98c..cc67f34aeede9a41bd78aeefdf6ac4a88d79348c 100644
+index eef5cdaf7fa5c425abddea9ab0717f6844c97460..7b554126313ad7abc3c1a6773a8f1ee69549ca93 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
-@@ -910,6 +910,9 @@ public class ExprProcessor implements CodeConstants {
+@@ -913,6 +913,9 @@ public class ExprProcessor implements CodeConstants {
        (castNull && rightType.type == CodeConstants.TYPE_NULL && !UNDEFINED_TYPE_STRING.equals(getTypeName(leftType))) ||
        (castNarrowing && isIntConstant(exprent) && isNarrowedIntType(leftType));
  
@@ -18,7 +18,7 @@ index 4933b5c1d375b7beacbb521bc8770cf295e7d98c..cc67f34aeede9a41bd78aeefdf6ac4a8
      boolean quote = cast && exprent.getPrecedence() >= FunctionExprent.getPrecedence(FunctionExprent.FUNCTION_CAST);
  
      // cast instead to 'byte' / 'short' when int constant is used as a value for 'Byte' / 'Short'
-@@ -924,6 +927,8 @@ public class ExprProcessor implements CodeConstants {
+@@ -927,6 +930,8 @@ public class ExprProcessor implements CodeConstants {
  
      if (cast) buffer.append('(').append(getCastTypeName(leftType)).append(')');
  
@@ -27,7 +27,7 @@ index 4933b5c1d375b7beacbb521bc8770cf295e7d98c..cc67f34aeede9a41bd78aeefdf6ac4a8
      if (quote) buffer.append('(');
  
      if (exprent.type == Exprent.EXPRENT_CONST) {
-@@ -956,4 +961,12 @@ public class ExprProcessor implements CodeConstants {
+@@ -959,4 +964,12 @@ public class ExprProcessor implements CodeConstants {
      return VarType.VARTYPE_INT.isStrictSuperset(type) ||
             type.equals(VarType.VARTYPE_BYTE_OBJ) || type.equals(VarType.VARTYPE_SHORT_OBJ);
    }
@@ -41,7 +41,7 @@ index 4933b5c1d375b7beacbb521bc8770cf295e7d98c..cc67f34aeede9a41bd78aeefdf6ac4a8
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index c5152f9053b274870b5da08acbddb89b12ac0516..ebb845dff674965ff3e0e8011db33dae5270e24d 100644
+index 16158a3d134c7af2ecdf58a539ff1d33ba80c6b9..4dc461a2da1073a74d9df787ff21d9f27a5a59f2 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -806,7 +806,8 @@ public class InvocationExprent extends Exprent {

--- a/FernFlower-Patches/0029-Improve-inferred-generic-types.patch
+++ b/FernFlower-Patches/0029-Improve-inferred-generic-types.patch
@@ -264,7 +264,7 @@ index 8f69e433dce5541e5f42693c67fbb9f8610821d2..1f27ed6c5ab25460b0e67c728c7fdcaa
    public void getBytecodeRange(BitSet values) {
      measureBytecode(values, lstOperands);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index ebb845dff674965ff3e0e8011db33dae5270e24d..a02c40a8a8a2ad1a1888d8a5370625c29c858e27 100644
+index 4dc461a2da1073a74d9df787ff21d9f27a5a59f2..7848ea1ea8169049f2b7e43eafba3fc7cdb9ed90 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -52,6 +52,7 @@ public class InvocationExprent extends Exprent {
@@ -283,7 +283,7 @@ index ebb845dff674965ff3e0e8011db33dae5270e24d..a02c40a8a8a2ad1a1888d8a5370625c2
 +  private boolean isInvocationInstance = false;
    private boolean forceBoxing = false;
    private boolean forceUnboxing = false;
-   private boolean isSyntheticGetClass = false;
+   private boolean isSyntheticNullCheck = false;
 @@ -173,45 +176,272 @@ public class InvocationExprent extends Exprent {
  
    @Override
@@ -890,7 +890,7 @@ index ebb845dff674965ff3e0e8011db33dae5270e24d..a02c40a8a8a2ad1a1888d8a5370625c2
    public void replaceExprent(Exprent oldExpr, Exprent newExpr) {
      if (oldExpr == instance) {
 @@ -996,6 +1393,18 @@ public class InvocationExprent extends Exprent {
-     return isSyntheticGetClass;
+     return isSyntheticNullCheck;
    }
  
 +  public List<VarType> getGenericArgs() {

--- a/FernFlower-Patches/0029-Improve-inferred-generic-types.patch
+++ b/FernFlower-Patches/0029-Improve-inferred-generic-types.patch
@@ -264,7 +264,7 @@ index 8f69e433dce5541e5f42693c67fbb9f8610821d2..1f27ed6c5ab25460b0e67c728c7fdcaa
    public void getBytecodeRange(BitSet values) {
      measureBytecode(values, lstOperands);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 4dc461a2da1073a74d9df787ff21d9f27a5a59f2..7848ea1ea8169049f2b7e43eafba3fc7cdb9ed90 100644
+index 4dc461a2da1073a74d9df787ff21d9f27a5a59f2..286c050b26e0b5e46f846e670b0e84911d208c64 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -52,6 +52,7 @@ public class InvocationExprent extends Exprent {
@@ -303,7 +303,7 @@ index 4dc461a2da1073a74d9df787ff21d9f27a5a59f2..7848ea1ea8169049f2b7e43eafba3fc7
 +    StructClass mthCls = DecompilerContext.getStructContext().getClass(classname);
 +
 +    if (desc != null && mthCls != null) {
-+      boolean isNew = functype == TYP_INIT && mthCls.getSignature() != null;
++      boolean isNew = functype == TYP_INIT;
 +      boolean isGenNew = isNew && mthCls.getSignature() != null;
 +      if (desc.getSignature() != null || isGenNew) {
 +        Map<VarType, List<VarType>> named = getNamedGenerics();
@@ -463,7 +463,7 @@ index 4dc461a2da1073a74d9df787ff21d9f27a5a59f2..7848ea1ea8169049f2b7e43eafba3fc7
 +
 +          int j = 0;
 +          for (int i = start; i < lstParameters.size(); ++i) {
-+            if (mask == null || mask.get(i) != null) {
++            if (mask == null || mask.get(i) == null) {
 +              VarType paramType = desc.getSignature().parameterTypes.get(j++);
 +              if (paramType.isGeneric()) {
 +

--- a/FernFlower-Patches/0029-Improve-inferred-generic-types.patch
+++ b/FernFlower-Patches/0029-Improve-inferred-generic-types.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Improve inferred generic types
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
-index d91d9faebf718192a679c436792a54c24bed8c63..01b9cef3bb535025f816f18acab5951083e4ec55 100644
+index 9c6dd387cce2377ffb3eefd7e55aa4b5a04953e7..2ee52fc024823932bbbe01d99928cb95287456cf 100644
 --- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
 +++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
 @@ -36,6 +36,7 @@ public interface IFernflowerPreferences {
@@ -16,7 +16,7 @@ index d91d9faebf718192a679c436792a54c24bed8c63..01b9cef3bb535025f816f18acab59510
  
    String LOG_LEVEL = "log";
    String MAX_PROCESSING_METHOD = "mpm";
-@@ -88,6 +89,7 @@ public interface IFernflowerPreferences {
+@@ -90,6 +91,7 @@ public interface IFernflowerPreferences {
      defaults.put(VERIFY_ANONYMOUS_CLASSES, "0");
  
      defaults.put(INCLUDE_ENTIRE_CLASSPATH, "0");

--- a/FernFlower-Patches/0030-Improve-stack-var-processor-output.patch
+++ b/FernFlower-Patches/0030-Improve-stack-var-processor-output.patch
@@ -320,7 +320,7 @@ index 1232e643fae990a7a3a9ee5f2e2ece46e607f934..1a085709ed7a120d109542e4bf710101
  }
 \ No newline at end of file
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 7848ea1ea8169049f2b7e43eafba3fc7cdb9ed90..64e0373955a977a5c4de9aa804b4ee9736f6b821 100644
+index 286c050b26e0b5e46f846e670b0e84911d208c64..12a58c9dc1ec95d56f14b4008bec3fc29d908ad3 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -166,6 +166,11 @@ public class InvocationExprent extends Exprent {

--- a/FernFlower-Patches/0030-Improve-stack-var-processor-output.patch
+++ b/FernFlower-Patches/0030-Improve-stack-var-processor-output.patch
@@ -38,7 +38,7 @@ index 9942e125766f6162506ff6418f00e8bcbe6d8072..7f80109f80ec5686fd6934504022be51
                }
                else {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
-index 767f6bdb92ecf0ba0bc4a437b8bf8482fa47bdea..261756b9e05f7e11d1c77e52e924cfefad988f45 100644
+index fa48cab3cb2b7da418322db7c10952f2f965e495..172e8a21885bb07dbbbeacf1f548d19605b079d5 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
 @@ -132,6 +132,11 @@ public class SimplifyExprentsHelper {
@@ -320,13 +320,13 @@ index 1232e643fae990a7a3a9ee5f2e2ece46e607f934..1a085709ed7a120d109542e4bf710101
  }
 \ No newline at end of file
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index a02c40a8a8a2ad1a1888d8a5370625c29c858e27..44927da60f640d940d0ccb6c52d8e4eba42ed2aa 100644
+index 7848ea1ea8169049f2b7e43eafba3fc7cdb9ed90..64e0373955a977a5c4de9aa804b4ee9736f6b821 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -166,6 +166,11 @@ public class InvocationExprent extends Exprent {
      addBytecodeOffsets(expr.bytecode);
      bootstrapArguments = expr.getBootstrapArguments();
-     isSyntheticGetClass = expr.isSyntheticGetClass();
+     isSyntheticNullCheck = expr.isSyntheticNullCheck();
 +
 +    if (invocationTyp == INVOKE_DYNAMIC && !isStatic && instance != null && !lstParameters.isEmpty()) {
 +      // method reference, instance and first param are expected to be the same var object

--- a/FernFlower-Patches/0032-Simple-lambda-syntax-support-isl-0-to-disable.patch
+++ b/FernFlower-Patches/0032-Simple-lambda-syntax-support-isl-0-to-disable.patch
@@ -109,7 +109,7 @@ index 6f22466edd1c87e6786ff08498b69005aca41e3e..0f33bafca987e5e736d602ebff88efb8
      }
      finally {
 diff --git a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
-index 01b9cef3bb535025f816f18acab5951083e4ec55..41f7389f3931a6a3c87647f7fde98f04c37af5c0 100644
+index 2ee52fc024823932bbbe01d99928cb95287456cf..d216cf9669b44a7d2cfdd6e95225535cdad55ca7 100644
 --- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
 +++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
 @@ -37,6 +37,7 @@ public interface IFernflowerPreferences {
@@ -120,7 +120,7 @@ index 01b9cef3bb535025f816f18acab5951083e4ec55..41f7389f3931a6a3c87647f7fde98f04
  
    String LOG_LEVEL = "log";
    String MAX_PROCESSING_METHOD = "mpm";
-@@ -90,6 +91,7 @@ public interface IFernflowerPreferences {
+@@ -92,6 +93,7 @@ public interface IFernflowerPreferences {
  
      defaults.put(INCLUDE_ENTIRE_CLASSPATH, "0");
      defaults.put(EXPLICIT_GENERIC_ARGUMENTS, "0");

--- a/FernFlower-Patches/0032-Simple-lambda-syntax-support-isl-0-to-disable.patch
+++ b/FernFlower-Patches/0032-Simple-lambda-syntax-support-isl-0-to-disable.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Simple lambda syntax support, --isl=0 to disable.
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 908ec69d788adf63487106715f82141cc1c43dac..beeeead1e0507eb80016eb5e071f90ec91086333 100644
+index 6f22466edd1c87e6786ff08498b69005aca41e3e..0f33bafca987e5e736d602ebff88efb81a168554 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -11,6 +11,7 @@ import org.jetbrains.java.decompiler.main.rels.MethodWrapper;

--- a/FernFlower-Patches/0033-Add-explicit-cast-to-invocations-of-java-nio-Buffer-.patch
+++ b/FernFlower-Patches/0033-Add-explicit-cast-to-invocations-of-java-nio-Buffer-.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Add explicit cast to invocations of java/nio/Buffer
 Java 9+ added overrides to these functions to return the specific subclass, however, when there is a compiler "bug" that when targeting release * or below, it will still reference these new methods, causing exceptions at runtime on Java 8.
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 64e0373955a977a5c4de9aa804b4ee9736f6b821..c3017a63e008d3f65770c73bfdcbe1ceaab604b9 100644
+index 12a58c9dc1ec95d56f14b4008bec3fc29d908ad3..dfd8078b728c0439a6a0accb6d9f17b7eb2979fb 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -46,6 +46,8 @@ public class InvocationExprent extends Exprent {

--- a/FernFlower-Patches/0033-Add-explicit-cast-to-invocations-of-java-nio-Buffer-.patch
+++ b/FernFlower-Patches/0033-Add-explicit-cast-to-invocations-of-java-nio-Buffer-.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Add explicit cast to invocations of java/nio/Buffer
 Java 9+ added overrides to these functions to return the specific subclass, however, when there is a compiler "bug" that when targeting release * or below, it will still reference these new methods, causing exceptions at runtime on Java 8.
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 44927da60f640d940d0ccb6c52d8e4eba42ed2aa..74e4440c8cb062db041ca853b7292196e89b106f 100644
+index 64e0373955a977a5c4de9aa804b4ee9736f6b821..c3017a63e008d3f65770c73bfdcbe1ceaab604b9 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -46,6 +46,8 @@ public class InvocationExprent extends Exprent {

--- a/FernFlower-Patches/0035-Add-only-argument-It-will-filter-what-classes-are-de.patch
+++ b/FernFlower-Patches/0035-Add-only-argument-It-will-filter-what-classes-are-de.patch
@@ -8,7 +8,7 @@ Uses a prefix system, so -only=net/minecraft/block/ will decompile all classes i
 Useful for debugging to limit scope/runtime.
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
-index 8ce3a2575b4c9c8268ba9956ea008027982a03fb..76b362a5f0bc04f74f26091a54d7f42d385c5037 100644
+index 80b8fd01286f90c3f194385edef47df805611c98..7323887590542fdfb4791dee3c929651baa3a092 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 @@ -37,6 +37,7 @@ public class ClassesProcessor implements CodeConstants {
@@ -42,7 +42,7 @@ index 8ce3a2575b4c9c8268ba9956ea008027982a03fb..76b362a5f0bc04f74f26091a54d7f42d
    public void loadClasses(IIdentifierRenamer renamer) {
      Map<String, Inner> mapInnerClasses = new HashMap<>();
      Map<String, Set<String>> mapNestedClassReferences = new HashMap<>();
-@@ -161,9 +178,11 @@ public class ClassesProcessor implements CodeConstants {
+@@ -163,9 +180,11 @@ public class ClassesProcessor implements CodeConstants {
            }
          }
  

--- a/FernFlower-Patches/0039-Make-decomp-threaded.patch
+++ b/FernFlower-Patches/0039-Make-decomp-threaded.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Make decomp threaded
 `-thr AUTO` to auto select, (default)
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
-index 76b362a5f0bc04f74f26091a54d7f42d385c5037..366bc3195304ae80ff539041d01202e57a6a1349 100644
+index 7323887590542fdfb4791dee3c929651baa3a092..dc5b67108878c4f37fa245699f977097f7fe5a4e 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 @@ -36,7 +36,8 @@ public class ClassesProcessor implements CodeConstants {
@@ -20,7 +20,7 @@ index 76b362a5f0bc04f74f26091a54d7f42d385c5037..366bc3195304ae80ff539041d01202e5
    private final Set<String> whitelist = new HashSet<>();
  
    private static class Inner {
-@@ -361,7 +362,7 @@ public class ClassesProcessor implements CodeConstants {
+@@ -363,7 +364,7 @@ public class ClassesProcessor implements CodeConstants {
      return true;
    }
  
@@ -29,7 +29,7 @@ index 76b362a5f0bc04f74f26091a54d7f42d385c5037..366bc3195304ae80ff539041d01202e5
      ClassNode root = mapRootClasses.get(cl.qualifiedName);
      if (root.type != ClassNode.CLASS_ROOT) {
        return;
-@@ -370,25 +371,12 @@ public class ClassesProcessor implements CodeConstants {
+@@ -372,25 +373,12 @@ public class ClassesProcessor implements CodeConstants {
      boolean packageInfo = cl.isSynthetic() && "package-info".equals(root.simpleName);
      boolean moduleInfo = cl.hasModifier(CodeConstants.ACC_MODULE) && cl.hasAttribute(StructGeneralAttribute.ATTRIBUTE_MODULE);
  
@@ -58,7 +58,7 @@ index 76b362a5f0bc04f74f26091a54d7f42d385c5037..366bc3195304ae80ff539041d01202e5
          new LambdaProcessor().processClass(root);
  
          // add simple class names to implicit import
-@@ -400,7 +388,36 @@ public class ClassesProcessor implements CodeConstants {
+@@ -402,7 +390,36 @@ public class ClassesProcessor implements CodeConstants {
          new NestedClassProcessor().processClass(root, root);
  
          new NestedMemberAccess().propagateMemberAccess(root);
@@ -95,7 +95,7 @@ index 76b362a5f0bc04f74f26091a54d7f42d385c5037..366bc3195304ae80ff539041d01202e5
          TextBuffer classBuffer = new TextBuffer(AVERAGE_CLASS_SIZE);
          new ClassWriter().classToJava(root, classBuffer, 0, null);
  
-@@ -410,7 +427,7 @@ public class ClassesProcessor implements CodeConstants {
+@@ -412,7 +429,7 @@ public class ClassesProcessor implements CodeConstants {
            buffer.append("package ").append(packageName).append(';').appendLineSeparator().appendLineSeparator();
          }
  
@@ -670,7 +670,7 @@ index c9ece039b0d986c1d84b62426a65e6780ddc80e1..3ca43800b47e1d26a1dc036f21cb6e6e
  
    public void endReadingClass() { }
 diff --git a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
-index 41f7389f3931a6a3c87647f7fde98f04c37af5c0..a2be81c2a329812c30ffe2606cae2b5f7ab43c3c 100644
+index d216cf9669b44a7d2cfdd6e95225535cdad55ca7..94d285522b4444dab8eb2c15d869aef7ea3b48b1 100644
 --- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
 +++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
 @@ -38,6 +38,7 @@ public interface IFernflowerPreferences {
@@ -681,7 +681,7 @@ index 41f7389f3931a6a3c87647f7fde98f04c37af5c0..a2be81c2a329812c30ffe2606cae2b5f
  
    String LOG_LEVEL = "log";
    String MAX_PROCESSING_METHOD = "mpm";
-@@ -92,6 +93,7 @@ public interface IFernflowerPreferences {
+@@ -94,6 +95,7 @@ public interface IFernflowerPreferences {
      defaults.put(INCLUDE_ENTIRE_CLASSPATH, "0");
      defaults.put(EXPLICIT_GENERIC_ARGUMENTS, "0");
      defaults.put(INLINE_SIMPLE_LAMBDAS, "1");

--- a/FernFlower-Patches/0041-More-correctly-handle-inner-class-synthetic-paramete.patch
+++ b/FernFlower-Patches/0041-More-correctly-handle-inner-class-synthetic-paramete.patch
@@ -1,0 +1,155 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zml <zml@stellardrift.ca>
+Date: Thu, 13 May 2021 23:55:33 -0700
+Subject: [PATCH] More correctly handle inner class synthetic parameters
+
+
+diff --git a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
+index fe372662be3fbd310f94831b47f21b92033a851c..f50e767ab81de739cad2059b5a8279fcd7cdba25 100644
+--- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
++++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
+@@ -35,6 +35,8 @@ import java.util.*;
+ import java.util.Map.Entry;
+ 
+ public class NestedClassProcessor {
++  public static final String ENUM_SYNTHETIC_SUPER = "<synthetic_super>";
++
+   public void processClass(ClassNode root, ClassNode node) {
+     // hide synthetic lambda content methods
+     if (node.type == ClassNode.CLASS_LAMBDA && !node.lambdaInformation.is_method_reference) {
+@@ -386,7 +388,6 @@ public class NestedClassProcessor {
+     for (ClassNode nd : node.nested) {
+       if (nd.type != ClassNode.CLASS_LAMBDA &&
+           !nd.classStruct.isSynthetic() &&
+-          (nd.access & CodeConstants.ACC_STATIC) == 0 &&
+           (nd.access & CodeConstants.ACC_INTERFACE) == 0) {
+         clTypes |= nd.type;
+ 
+@@ -503,23 +504,12 @@ public class NestedClassProcessor {
+ 
+       if (interPairMask == null) { // member or local and never instantiated
+         interPairMask = interMask != null ? new ArrayList<>(interMask) : new ArrayList<>();
+-
+-        boolean found = false;
+-
+-        for (int i = 0; i < interPairMask.size(); i++) {
+-          if (interPairMask.get(i) != null) {
+-            if (found) {
+-              interPairMask.set(i, null);
+-            }
+-            found = true;
+-          }
+-        }
++      } else {
++        mergeListSignatures(interPairMask, interMask, true);
+       }
+ 
+-      mergeListSignatures(interPairMask, interMask, true);
+-
+       for (VarFieldPair pair : interPairMask) {
+-        if (pair != null && !pair.fieldKey.isEmpty()) {
++        if (pair != null && !pair.fieldKey.isEmpty() && !NestedClassProcessor.ENUM_SYNTHETIC_SUPER.equals(pair.fieldKey)) {
+           nestedNode.mapFieldsToVars.put(pair.fieldKey, pair.varPair);
+         }
+       }
+@@ -764,7 +754,14 @@ public class NestedClassProcessor {
+           List<VarFieldPair> fields = new ArrayList<>(md.params.length);
+ 
+           int varIndex = 1;
+-          for (int i = 0; i < md.params.length; i++) {  // no static methods allowed
++          int start = 0;
++          if ((wrapper.getClassStruct().getAccessFlags() & CodeConstants.ACC_ENUM) != 0) { // enums have 2x synthetic params. not handled by normal detection because they go to the superclass constructor rather than to synthetic fields
++            fields.add(new VarFieldPair(NestedClassProcessor.ENUM_SYNTHETIC_SUPER, new VarVersionPair(-1, 0)));
++            fields.add(new VarFieldPair(NestedClassProcessor.ENUM_SYNTHETIC_SUPER, new VarVersionPair(-1, 0)));
++            varIndex += 2;
++            start += 2;
++          }
++          for (int i = start; i < md.params.length; i++) {  // no static methods allowed
+             String keyField = getEnclosingVarField(cl, method, graph, varIndex);
+             fields.add(keyField == null ? null : new VarFieldPair(keyField, new VarVersionPair(-1, 0))); // TODO: null?
+             varIndex += md.params[i].stackSize;
+@@ -819,17 +816,31 @@ public class NestedClassProcessor {
+     return fd.getName().contains("$") && fd.hasModifier(CodeConstants.ACC_FINAL) && fd.hasModifier(CodeConstants.ACC_PRIVATE);
+   }
+ 
++  /**
++   * Merge two sets of method signatures.
++   *
++   * This ensures that synthetic parameters are properly captured when field writes may go through another constructor.
++   *
++   * @param first the list to modify
++   * @param second the list compared against
++   * @param both if the comparison list should also be modified to align
++   */
+   private static void mergeListSignatures(List<VarFieldPair> first, List<VarFieldPair> second, boolean both) {
+-    int i = 1;
++    // Upstream this merges from the end of the list forwards
++    // However, synthetic parameters are added at the beginnings of method signatures (at least usually)
++    // so we really want to start from the beginning
++    // if it ends up that this assumption is not true, we'd have to do some sort of fuzzy matching here, or earlier
++    // on traverse multiple steps in the graph in getEnclosingVarField
++    int i = 0;
+ 
+-    while (first.size() > i && second.size() > i) {
+-      VarFieldPair fObj = first.get(first.size() - i);
+-      VarFieldPair sObj = second.get(second.size() - i);
++    while (i < first.size() && i < second.size()) {
++      VarFieldPair fObj = first.get(i);
++      VarFieldPair sObj = second.get(i);
+ 
+       if (!isEqual(both, fObj, sObj)) {
+-        first.set(first.size() - i, null);
++        first.set(i, null);
+         if (both) {
+-          second.set(second.size() - i, null);
++          second.set(i, null);
+         }
+       }
+       else if (fObj != null) {
+@@ -844,44 +855,15 @@ public class NestedClassProcessor {
+       i++;
+     }
+ 
+-    for (int j = 1; j <= first.size() - i; j++) {
++    for (int j = i; j < first.size(); j++) {
+       first.set(j, null);
+     }
+ 
+     if (both) {
+-      for (int j = 1; j <= second.size() - i; j++) {
++      for (int j = i; j < second.size(); j++) {
+         second.set(j, null);
+       }
+     }
+-
+-    // first
+-    if (first.isEmpty()) {
+-      if (!second.isEmpty() && both) {
+-        second.set(0, null);
+-      }
+-    }
+-    else if (second.isEmpty()) {
+-      first.set(0, null);
+-    }
+-    else {
+-      VarFieldPair fObj = first.get(0);
+-      VarFieldPair sObj = second.get(0);
+-
+-      if (!isEqual(both, fObj, sObj)) {
+-        first.set(0, null);
+-        if (both) {
+-          second.set(0, null);
+-        }
+-      }
+-      else if (fObj != null) {
+-        if (fObj.varPair.var == -1) {
+-          fObj.varPair = sObj.varPair;
+-        }
+-        else {
+-          sObj.varPair = fObj.varPair;
+-        }
+-      }
+-    }
+   }
+ 
+   private static boolean isEqual(boolean both, VarFieldPair fObj, VarFieldPair sObj) {


### PR DESCRIPTION
With 21w19a, Mojang changed a lot of their build toolchain around. This PR aims to patch up the decompiler for some of the bytecode changes that resulted.

## Objects.requireNonNull

This is the simplest change -- javac generates nullness checks a bit differently. FF is patched to support both the old .getClass() and new Objects.requireNonNull() variants.

## Inner classes

It appears that a lot of inner classes have gained a `Signature` attribute, which causes generic signature processing to activate. This exposed some issues in its handling of synthetic constructor parameters, which I think I've taken care of enough to correctly

(not sure how these changes would react if someone disabled enum handling though)

## Visibility changes

There have been broad changes to field and method visibility anywhere inner classes are involved, which appears to be done by a tool that results in inconsistent inner class attributes. I've added an option to suppress that warning, `-win=0`

## try-with-resources (not done yet)

looks like FF isn't collapsing finally blocks properly -- there are a bunch of changes to exception ranges in the bytecode that may be related, haven't looked too much

## nextGaussian (not done yet)

#89, will look at applying the proposed fix more properly

---

I've tested this based off of diffs of 21w19a -- once I make it through the list of issues above I'll do a more thorough comparison on 1.16.5 to ensure nothing regressed on that end.

cc @SuperCoder7979 who I discussed a lot of this with