### PR TITLE
Handle J9+ using Objects.requireNonNull rather than .getClass for null checks

### DIFF
--- a/FernFlower-Patches/0016-Add-better-debug-logging.patch
+++ b/FernFlower-Patches/0016-Add-better-debug-logging.patch
@@ -4,6 +4,32 @@ Date: Mon, 25 Sep 2017 13:46:14 -0700
 Subject: [PATCH] Add better debug logging
 
 
+diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
+index 632a12c7bee16de80b5edc011d4aac783b4dc76a..490c01566b62aab791ef7be41ec0852fbb966ccc 100644
+--- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
++++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
+@@ -939,7 +939,7 @@ public class ClassWriter {
+             tracer.addTracer(codeTracer);
+           }
+           catch (Throwable t) {
+-            String message = "Method " + mt.getName() + " " + mt.getDescriptor() + " couldn't be written.";
++            String message = "Method " + mt.getName() + " " + mt.getDescriptor() + " in class " + node.classStruct.qualifiedName + " couldn't be written.";
+             DecompilerContext.getLogger().writeMessage(message, IFernflowerLogger.Severity.WARN, t);
+             methodWrapper.decompiledWithErrors = true;
+           }
+diff --git a/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java b/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
+index 438b04c518f193ac3b229701ddfdaf7cde5cad6e..9ce662b88d6a7406784b8aa1b4e1dc6700cebaa6 100644
+--- a/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
++++ b/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
+@@ -122,7 +122,7 @@ public class ClassWrapper {
+         }
+       }
+       catch (Throwable t) {
+-        String message = "Method " + mt.getName() + " " + mt.getDescriptor() + " couldn't be decompiled.";
++        String message = "Method " + mt.getName() + " " + mt.getDescriptor() + " in class " + classStruct.qualifiedName + " couldn't be decompiled.";
+         DecompilerContext.getLogger().writeMessage(message, IFernflowerLogger.Severity.WARN, t);
+         isError = true;
+       }
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructContext.java b/src/org/jetbrains/java/decompiler/struct/StructContext.java
 index 36d1d6c4ae8e3b9f1a64dae514d9efa65722033a..7c91206d1b64b9873fa24d6d3ad38e736413c0a3 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructContext.java

--- a/FernFlower-Patches/0022-Add-a-metadata-file-named-fernflower_abstract_parame.patch
+++ b/FernFlower-Patches/0022-Add-a-metadata-file-named-fernflower_abstract_parame.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Add a metadata file named
 Format: ClassName MethodName Descriptor Param1[ Param2...]
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 632a12c7bee16de80b5edc011d4aac783b4dc76a..124cdd01c4b531937373127576b7f6db90ed48ed 100644
+index 490c01566b62aab791ef7be41ec0852fbb966ccc..dda37ca0513494ca951c1cff0d363c1dcb36b6e1 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -870,7 +870,9 @@ public class ClassWriter {

--- a/FernFlower-Patches/0023-Synthetic-getClass-Objects.requireNonNull-cleanup.patch
+++ b/FernFlower-Patches/0023-Synthetic-getClass-Objects.requireNonNull-cleanup.patch
@@ -1,27 +1,30 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Justin <jrd2558@gmail.com>
 Date: Thu, 26 Jul 2018 13:28:40 -0700
-Subject: [PATCH] Synthetic getClass cleanup
+Subject: [PATCH] Synthetic getClass/Objects.requireNonNull cleanup
 
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
-index 474ffda1b9d610968bd12160f2153713b37f2db9..4933b5c1d375b7beacbb521bc8770cf295e7d98c 100644
+index 474ffda1b9d610968bd12160f2153713b37f2db9..eef5cdaf7fa5c425abddea9ab0717f6844c97460 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
-@@ -617,6 +617,20 @@ public class ExprProcessor implements CodeConstants {
+@@ -617,6 +617,23 @@ public class ExprProcessor implements CodeConstants {
            break;
          case opc_pop:
            stack.pop();
-+          // check for synthetic getClass calls added by the compiler
++          // check for synthetic getClass (J8) / Objects.requireNonNull() (J9+) calls added by the compiler
 +          // see https://stackoverflow.com/a/20130641
 +          if (i > 0) {
 +            Exprent last = exprlist.get(exprlist.size() - 1);
 +            if (last.type == Exprent.EXPRENT_ASSIGNMENT && ((AssignmentExprent)last).getRight().type == Exprent.EXPRENT_INVOCATION) {
-+              InvocationExprent invocation = (InvocationExprent)((AssignmentExprent)last).getRight();
-+              if (i + 1 < seq.length() && !invocation.isStatic() && invocation.getName().equals("getClass") && invocation.getStringDescriptor().equals("()Ljava/lang/Class;")) {
-+                int nextOpc = seq.getInstr(i + 1).opcode;
-+                if (nextOpc >= opc_aconst_null && nextOpc <= opc_ldc2_w) {
-+                  invocation.setSyntheticGetClass();
++              InvocationExprent invocation = (InvocationExprent) ((AssignmentExprent) last).getRight();
++              if (i + 1 < seq.length()) {
++                if ((!invocation.isStatic() && invocation.getName().equals("getClass") && invocation.getStringDescriptor().equals("()Ljava/lang/Class;")) // J8
++                  || (invocation.isStatic() && invocation.getClassname().equals("java/util/Objects") && invocation.getName().equals("requireNonNull") && invocation.getStringDescriptor().equals("(Ljava/lang/Object;)Ljava/lang/Object;"))) { // J9+
++                  int nextOpc = seq.getInstr(i + 1).opcode;
++                  if (nextOpc >= opc_aconst_null && nextOpc <= opc_ldc2_w) {
++                    invocation.setSyntheticNullCheck();
++                  }
 +                }
 +              }
 +            }
@@ -30,7 +33,7 @@ index 474ffda1b9d610968bd12160f2153713b37f2db9..4933b5c1d375b7beacbb521bc8770cf2
          case opc_pop2:
            if (stack.getByOffset(-1).getExprType().stackSize == 1) {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
-index 986a8a72ec138ea637d3446ed2e823f6100c31cc..767f6bdb92ecf0ba0bc4a437b8bf8482fa47bdea 100644
+index 986a8a72ec138ea637d3446ed2e823f6100c31cc..c93911d7e3b3df1e7b455e764f6a96a3843a5df5 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
 @@ -71,6 +71,10 @@ public class SimplifyExprentsHelper {
@@ -44,7 +47,7 @@ index 986a8a72ec138ea637d3446ed2e823f6100c31cc..767f6bdb92ecf0ba0bc4a437b8bf8482
          }
  
          res |= changed;
-@@ -505,21 +509,43 @@ public class SimplifyExprentsHelper {
+@@ -505,21 +509,53 @@ public class SimplifyExprentsHelper {
      return false;
    }
  
@@ -69,39 +72,77 @@ index 986a8a72ec138ea637d3446ed2e823f6100c31cc..767f6bdb92ecf0ba0bc4a437b8bf8482
  
 -      if (!invocation.isStatic() && invocation.getInstance().type == Exprent.EXPRENT_VAR && invocation.getName().equals("getClass") &&
 -          invocation.getStringDescriptor().equals("()Ljava/lang/Class;")) {
-+      if (!invocation.isStatic() &&
-+           invocation.getName().equals("getClass") && invocation.getStringDescriptor().equals("()Ljava/lang/Class;")) {
-+
-+        if (invocation.isSyntheticGetClass()) {
-+          return true;
-+        }
++      if ((!invocation.isStatic() &&
++           invocation.getName().equals("getClass") && invocation.getStringDescriptor().equals("()Ljava/lang/Class;")) // J8
++        || (invocation.isStatic() && invocation.getClassname().equals("java/util/Objects") && invocation.getName().equals("requireNonNull")
++            && invocation.getStringDescriptor().equals("(Ljava/lang/Object;)Ljava/lang/Object;"))) { // J9+
  
 -        List<Exprent> lstExprents = second.getAllExprents();
++        if (invocation.isSyntheticNullCheck()) {
++          return true;
++        }
++
 +        LinkedList<Exprent> lstExprents = new LinkedList<>();
          lstExprents.add(second);
  
 -        for (Exprent expr : lstExprents) {
-+        while (!lstExprents.isEmpty()){
++        final Exprent target;
++        if (invocation.isStatic()) { // Objects.requireNonNull(target) (J9+)
++          // detect target type
++          target = invocation.getLstParameters().get(0);
++        } else { // target.getClass() (J8)
++          target = invocation.getInstance();
++        }
++
++        while (!lstExprents.isEmpty()) {
 +          Exprent expr = lstExprents.removeFirst();
 +          lstExprents.addAll(expr.getAllExprents());
            if (expr.type == Exprent.EXPRENT_NEW) {
              NewExprent newExpr = (NewExprent)expr;
              if (newExpr.getConstructor() != null && !newExpr.getConstructor().getLstParameters().isEmpty() &&
 -                newExpr.getConstructor().getLstParameters().get(0).equals(invocation.getInstance())) {
-+              (newExpr.getConstructor().getLstParameters().get(0).equals(invocation.getInstance()) ||
-+                newExpr.getConstructor().getLstParameters().get(0).getExprType().equals(invocation.getInstance().getExprType()))) {
++              (newExpr.getConstructor().getLstParameters().get(0).equals(target) ||
++                isUnambiguouslySameParam(invocation.isStatic(), target, newExpr.getConstructor().getLstParameters()))) {
  
                String classname = newExpr.getNewType().value;
                ClassNode node = DecompilerContext.getClassProcessor().getMapRootClasses().get(classname);
+@@ -535,6 +571,27 @@ public class SimplifyExprentsHelper {
+     return false;
+   }
+ 
++  private static boolean isUnambiguouslySameParam(boolean isStatic, Exprent target, List<Exprent> parameters) {
++    boolean firstParamOfSameType = parameters.get(0).getExprType().equals(target.getExprType());
++    if (!isStatic) { // X.getClass()/J8, this is less likely to overlap with legitimate use
++      return firstParamOfSameType;
++    }
++    // Calling Objects.requireNonNull and discarding the result is a common pattern in normal code, so we have to be a bit more
++    // cautious about stripping calls when a constructor takes parameters of the instance type
++    // ex. given a class X, `Objects.requireNonNull(someInstanceOfX); new X(someInstanceOfX)` should not have the rNN stripped.
++    if (!firstParamOfSameType) {
++      return false;
++    }
++
++    for (int i = 1; i < parameters.size(); i++) {
++      if (parameters.get(i).getExprType().equals(target.getExprType())) {
++        return false;
++      }
++    }
++
++    return true;
++  }
++
+   // propagate (var = new X) forward to the <init> invocation
+   private static boolean isConstructorInvocationRemote(List<Exprent> list, int index) {
+     Exprent current = list.get(index);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 9d4eae94966f13ef56e710f53f67f84ef5a50cd3..c5152f9053b274870b5da08acbddb89b12ac0516 100644
+index 9d4eae94966f13ef56e710f53f67f84ef5a50cd3..16158a3d134c7af2ecdf58a539ff1d33ba80c6b9 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -61,6 +61,7 @@ public class InvocationExprent extends Exprent {
    private List<VarType> genericArgs = new ArrayList<>();
    private boolean forceBoxing = false;
    private boolean forceUnboxing = false;
-+  private boolean isSyntheticGetClass = false;
++  private boolean isSyntheticNullCheck = false;
  
    public InvocationExprent() {
      super(EXPRENT_INVOCATION);
@@ -109,7 +150,7 @@ index 9d4eae94966f13ef56e710f53f67f84ef5a50cd3..c5152f9053b274870b5da08acbddb89b
  
      addBytecodeOffsets(expr.bytecode);
      bootstrapArguments = expr.getBootstrapArguments();
-+    isSyntheticGetClass = expr.isSyntheticGetClass();
++    isSyntheticNullCheck = expr.isSyntheticNullCheck();
    }
  
    @Override
@@ -117,12 +158,12 @@ index 9d4eae94966f13ef56e710f53f67f84ef5a50cd3..c5152f9053b274870b5da08acbddb89b
      return bootstrapArguments;
    }
  
-+  public void setSyntheticGetClass() {
-+    isSyntheticGetClass = true;
++  public void setSyntheticNullCheck() {
++    isSyntheticNullCheck = true;
 +  }
 +
-+  public boolean isSyntheticGetClass() {
-+    return isSyntheticGetClass;
++  public boolean isSyntheticNullCheck() {
++    return isSyntheticNullCheck;
 +  }
 +
    @Override

--- a/FernFlower-Patches/0027-Prioritize-self-and-enclosing-class-when-encounterin.patch
+++ b/FernFlower-Patches/0027-Prioritize-self-and-enclosing-class-when-encounterin.patch
@@ -8,7 +8,7 @@ The compiler encodes all REFERENCED inner classes into the class. The first foun
 Fixes AccessTransformers.
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 124cdd01c4b531937373127576b7f6db90ed48ed..908ec69d788adf63487106715f82141cc1c43dac 100644
+index dda37ca0513494ca951c1cff0d363c1dcb36b6e1..6f22466edd1c87e6786ff08498b69005aca41e3e 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -1180,6 +1180,10 @@ public class ClassWriter {

--- a/FernFlower-Patches/0028-Fix-ambiguous-lambdas.patch
+++ b/FernFlower-Patches/0028-Fix-ambiguous-lambdas.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix ambiguous lambdas
 
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
-index 4933b5c1d375b7beacbb521bc8770cf295e7d98c..cc67f34aeede9a41bd78aeefdf6ac4a88d79348c 100644
+index eef5cdaf7fa5c425abddea9ab0717f6844c97460..7b554126313ad7abc3c1a6773a8f1ee69549ca93 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
-@@ -910,6 +910,9 @@ public class ExprProcessor implements CodeConstants {
+@@ -913,6 +913,9 @@ public class ExprProcessor implements CodeConstants {
        (castNull && rightType.type == CodeConstants.TYPE_NULL && !UNDEFINED_TYPE_STRING.equals(getTypeName(leftType))) ||
        (castNarrowing && isIntConstant(exprent) && isNarrowedIntType(leftType));
  
@@ -18,7 +18,7 @@ index 4933b5c1d375b7beacbb521bc8770cf295e7d98c..cc67f34aeede9a41bd78aeefdf6ac4a8
      boolean quote = cast && exprent.getPrecedence() >= FunctionExprent.getPrecedence(FunctionExprent.FUNCTION_CAST);
  
      // cast instead to 'byte' / 'short' when int constant is used as a value for 'Byte' / 'Short'
-@@ -924,6 +927,8 @@ public class ExprProcessor implements CodeConstants {
+@@ -927,6 +930,8 @@ public class ExprProcessor implements CodeConstants {
  
      if (cast) buffer.append('(').append(getCastTypeName(leftType)).append(')');
  
@@ -27,7 +27,7 @@ index 4933b5c1d375b7beacbb521bc8770cf295e7d98c..cc67f34aeede9a41bd78aeefdf6ac4a8
      if (quote) buffer.append('(');
  
      if (exprent.type == Exprent.EXPRENT_CONST) {
-@@ -956,4 +961,12 @@ public class ExprProcessor implements CodeConstants {
+@@ -959,4 +964,12 @@ public class ExprProcessor implements CodeConstants {
      return VarType.VARTYPE_INT.isStrictSuperset(type) ||
             type.equals(VarType.VARTYPE_BYTE_OBJ) || type.equals(VarType.VARTYPE_SHORT_OBJ);
    }
@@ -41,7 +41,7 @@ index 4933b5c1d375b7beacbb521bc8770cf295e7d98c..cc67f34aeede9a41bd78aeefdf6ac4a8
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index c5152f9053b274870b5da08acbddb89b12ac0516..ebb845dff674965ff3e0e8011db33dae5270e24d 100644
+index 16158a3d134c7af2ecdf58a539ff1d33ba80c6b9..4dc461a2da1073a74d9df787ff21d9f27a5a59f2 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -806,7 +806,8 @@ public class InvocationExprent extends Exprent {

--- a/FernFlower-Patches/0029-Improve-inferred-generic-types.patch
+++ b/FernFlower-Patches/0029-Improve-inferred-generic-types.patch
@@ -264,7 +264,7 @@ index 8f69e433dce5541e5f42693c67fbb9f8610821d2..1f27ed6c5ab25460b0e67c728c7fdcaa
    public void getBytecodeRange(BitSet values) {
      measureBytecode(values, lstOperands);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index ebb845dff674965ff3e0e8011db33dae5270e24d..a02c40a8a8a2ad1a1888d8a5370625c29c858e27 100644
+index 4dc461a2da1073a74d9df787ff21d9f27a5a59f2..7848ea1ea8169049f2b7e43eafba3fc7cdb9ed90 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -52,6 +52,7 @@ public class InvocationExprent extends Exprent {
@@ -283,7 +283,7 @@ index ebb845dff674965ff3e0e8011db33dae5270e24d..a02c40a8a8a2ad1a1888d8a5370625c2
 +  private boolean isInvocationInstance = false;
    private boolean forceBoxing = false;
    private boolean forceUnboxing = false;
-   private boolean isSyntheticGetClass = false;
+   private boolean isSyntheticNullCheck = false;
 @@ -173,45 +176,272 @@ public class InvocationExprent extends Exprent {
  
    @Override
@@ -890,7 +890,7 @@ index ebb845dff674965ff3e0e8011db33dae5270e24d..a02c40a8a8a2ad1a1888d8a5370625c2
    public void replaceExprent(Exprent oldExpr, Exprent newExpr) {
      if (oldExpr == instance) {
 @@ -996,6 +1393,18 @@ public class InvocationExprent extends Exprent {
-     return isSyntheticGetClass;
+     return isSyntheticNullCheck;
    }
  
 +  public List<VarType> getGenericArgs() {

--- a/FernFlower-Patches/0030-Improve-stack-var-processor-output.patch
+++ b/FernFlower-Patches/0030-Improve-stack-var-processor-output.patch
@@ -38,7 +38,7 @@ index 9942e125766f6162506ff6418f00e8bcbe6d8072..7f80109f80ec5686fd6934504022be51
                }
                else {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
-index 767f6bdb92ecf0ba0bc4a437b8bf8482fa47bdea..261756b9e05f7e11d1c77e52e924cfefad988f45 100644
+index c93911d7e3b3df1e7b455e764f6a96a3843a5df5..0b6938f11bf202bf1c84930daddce204395d38de 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
 @@ -132,6 +132,11 @@ public class SimplifyExprentsHelper {
@@ -320,13 +320,13 @@ index 1232e643fae990a7a3a9ee5f2e2ece46e607f934..1a085709ed7a120d109542e4bf710101
  }
 \ No newline at end of file
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index a02c40a8a8a2ad1a1888d8a5370625c29c858e27..44927da60f640d940d0ccb6c52d8e4eba42ed2aa 100644
+index 7848ea1ea8169049f2b7e43eafba3fc7cdb9ed90..64e0373955a977a5c4de9aa804b4ee9736f6b821 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -166,6 +166,11 @@ public class InvocationExprent extends Exprent {
      addBytecodeOffsets(expr.bytecode);
      bootstrapArguments = expr.getBootstrapArguments();
-     isSyntheticGetClass = expr.isSyntheticGetClass();
+     isSyntheticNullCheck = expr.isSyntheticNullCheck();
 +
 +    if (invocationTyp == INVOKE_DYNAMIC && !isStatic && instance != null && !lstParameters.isEmpty()) {
 +      // method reference, instance and first param are expected to be the same var object

--- a/FernFlower-Patches/0032-Simple-lambda-syntax-support-isl-0-to-disable.patch
+++ b/FernFlower-Patches/0032-Simple-lambda-syntax-support-isl-0-to-disable.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Simple lambda syntax support, --isl=0 to disable.
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 908ec69d788adf63487106715f82141cc1c43dac..beeeead1e0507eb80016eb5e071f90ec91086333 100644
+index 6f22466edd1c87e6786ff08498b69005aca41e3e..0f33bafca987e5e736d602ebff88efb81a168554 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -11,6 +11,7 @@ import org.jetbrains.java.decompiler.main.rels.MethodWrapper;

--- a/FernFlower-Patches/0033-Add-explicit-cast-to-invocations-of-java-nio-Buffer-.patch
+++ b/FernFlower-Patches/0033-Add-explicit-cast-to-invocations-of-java-nio-Buffer-.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Add explicit cast to invocations of java/nio/Buffer
 Java 9+ added overrides to these functions to return the specific subclass, however, when there is a compiler "bug" that when targeting release * or below, it will still reference these new methods, causing exceptions at runtime on Java 8.
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 44927da60f640d940d0ccb6c52d8e4eba42ed2aa..74e4440c8cb062db041ca853b7292196e89b106f 100644
+index 64e0373955a977a5c4de9aa804b4ee9736f6b821..c3017a63e008d3f65770c73bfdcbe1ceaab604b9 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -46,6 +46,8 @@ public class InvocationExprent extends Exprent {


### PR DESCRIPTION
Broken out of #96 

This is the simplest change -- javac generates nullness checks a bit differently starting with a Java 9 target. FF is patched to support both the old .getClass() and new Objects.requireNonNull() variants.

I tossed in some more debug logging since I was looking forward to some of the other decompile errors that were introduced at the same time.

## Diffs (via VanillaGradle workspace)

**1.16.5**: no change
**21w19a**: https://paste.gg/p/zml/9e50e0aa7d7c4ab78790f7b5d4b575d1