### PR TITLE
Add option to suppress inner class warnings

### DIFF
--- a/FernFlower-Patches/0027-Prioritize-self-and-enclosing-class-when-encounterin.patch
+++ b/FernFlower-Patches/0027-Prioritize-self-and-enclosing-class-when-encounterin.patch
@@ -7,6 +7,21 @@ Subject: [PATCH] Prioritize self and enclosing class when encountering
 The compiler encodes all REFERENCED inner classes into the class. The first found used to win, but now ThisClass > EnclosingClass > Others AccessTransformers only edit the targeted class as it can't find all references.
 Fixes AccessTransformers.
 
+Add -win option to suppress warnings on inconsistent inner class
+information.
+
+diff --git a/README.md b/README.md
+index 225b42bcbd388c395fe51d2c5edda8d1cb1127b2..c41dd217b88663552b02ceac510ae13199b64b3c 100644
+--- a/README.md
++++ b/README.md
+@@ -64,6 +64,7 @@ The rest of options can be left as they are: they are aimed at professional reve
+ - inn (1): check for IntelliJ IDEA-specific @NotNull annotation and remove inserted code if found
+ - lac (0): decompile lambda expressions to anonymous classes
+ - nls (0): define new line character to be used for output. 0 - '\r\n' (Windows), 1 - '\n' (Unix), default is OS-dependent
++- win (1): Whether to warn on inconsistent inner class entries
+ - ind: indentation string (default is 3 spaces)
+ - log (INFO): a logging level, possible values are TRACE, INFO, WARN, ERROR
+ 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 index 124cdd01c4b531937373127576b7f6db90ed48ed..908ec69d788adf63487106715f82141cc1c43dac 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
@@ -23,7 +38,7 @@ index 124cdd01c4b531937373127576b7f6db90ed48ed..908ec69d788adf63487106715f82141c
      buffer.append('<');
  
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
-index 26ccf4b2124ab617bfeec45ebbf3451ab2e7aa6d..8ce3a2575b4c9c8268ba9956ea008027982a03fb 100644
+index 26ccf4b2124ab617bfeec45ebbf3451ab2e7aa6d..80b8fd01286f90c3f194385edef47df805611c98 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 @@ -42,10 +42,20 @@ public class ClassesProcessor implements CodeConstants {
@@ -55,12 +70,18 @@ index 26ccf4b2124ab617bfeec45ebbf3451ab2e7aa6d..8ce3a2575b4c9c8268ba9956ea008027
  
                // nested class type
                if (entry.innerName != null) {
-@@ -132,6 +143,13 @@ public class ClassesProcessor implements CodeConstants {
+@@ -130,8 +141,17 @@ public class ClassesProcessor implements CodeConstants {
+                   mapInnerClasses.put(innerName, rec);
+                 }
                  else if (!Inner.equal(existingRec, rec)) {
-                   String message = "Inconsistent inner class entries for " + innerName + "!";
-                   DecompilerContext.getLogger().writeMessage(message, IFernflowerLogger.Severity.WARN);
-+                  DecompilerContext.getLogger().writeMessage("  Old: " + existingRec.toString(), IFernflowerLogger.Severity.WARN);
-+                  DecompilerContext.getLogger().writeMessage("  New: " + rec.toString(), IFernflowerLogger.Severity.WARN);
+-                  String message = "Inconsistent inner class entries for " + innerName + "!";
+-                  DecompilerContext.getLogger().writeMessage(message, IFernflowerLogger.Severity.WARN);
++                  if (DecompilerContext.getOption(IFernflowerPreferences.WARN_INCONSISTENT_INNER_CLASSES)) {
++                    String message = "Inconsistent inner class entries for " + innerName + "!";
++                    DecompilerContext.getLogger().writeMessage(message, IFernflowerLogger.Severity.WARN);
++                    DecompilerContext.getLogger().writeMessage("  Old: " + existingRec.toString(), IFernflowerLogger.Severity.WARN);
++                    DecompilerContext.getLogger().writeMessage("  New: " + rec.toString(), IFernflowerLogger.Severity.WARN);
++                  }
 +                  int oldPriority = existingRec.source.equals(innerName) ? 1 : existingRec.source.equals(enclClassName) ? 2 : 3;
 +                  int newPriority = rec.source.equals(innerName) ? 1 : rec.source.equals(enclClassName) ? 2 : 3;
 +                  if (newPriority < oldPriority) {
@@ -69,3 +90,24 @@ index 26ccf4b2124ab617bfeec45ebbf3451ab2e7aa6d..8ce3a2575b4c9c8268ba9956ea008027
                  }
  
                  // reference to the nested class
+diff --git a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
+index d91d9faebf718192a679c436792a54c24bed8c63..9c6dd387cce2377ffb3eefd7e55aa4b5a04953e7 100644
+--- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
++++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
+@@ -55,6 +55,8 @@ public interface IFernflowerPreferences {
+ 
+   String SKIP_EXTRA_FILES = "sef";
+ 
++  String WARN_INCONSISTENT_INNER_CLASSES = "win";
++
+   Map<String, Object> DEFAULTS = getDefaults();
+ 
+   static Map<String, Object> getDefaults() {
+@@ -99,6 +101,7 @@ public interface IFernflowerPreferences {
+     defaults.put(DUMP_ORIGINAL_LINES, "0");
+     defaults.put(USE_JAD_VARNAMING, "0");
+     defaults.put(SKIP_EXTRA_FILES, "0");
++    defaults.put(WARN_INCONSISTENT_INNER_CLASSES, "1");
+ 
+     return Collections.unmodifiableMap(defaults);
+   }

--- a/FernFlower-Patches/0029-Improve-inferred-generic-types.patch
+++ b/FernFlower-Patches/0029-Improve-inferred-generic-types.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Improve inferred generic types
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
-index d91d9faebf718192a679c436792a54c24bed8c63..01b9cef3bb535025f816f18acab5951083e4ec55 100644
+index 9c6dd387cce2377ffb3eefd7e55aa4b5a04953e7..2ee52fc024823932bbbe01d99928cb95287456cf 100644
 --- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
 +++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
 @@ -36,6 +36,7 @@ public interface IFernflowerPreferences {
@@ -16,7 +16,7 @@ index d91d9faebf718192a679c436792a54c24bed8c63..01b9cef3bb535025f816f18acab59510
  
    String LOG_LEVEL = "log";
    String MAX_PROCESSING_METHOD = "mpm";
-@@ -88,6 +89,7 @@ public interface IFernflowerPreferences {
+@@ -90,6 +91,7 @@ public interface IFernflowerPreferences {
      defaults.put(VERIFY_ANONYMOUS_CLASSES, "0");
  
      defaults.put(INCLUDE_ENTIRE_CLASSPATH, "0");

--- a/FernFlower-Patches/0032-Simple-lambda-syntax-support-isl-0-to-disable.patch
+++ b/FernFlower-Patches/0032-Simple-lambda-syntax-support-isl-0-to-disable.patch
@@ -109,7 +109,7 @@ index 908ec69d788adf63487106715f82141cc1c43dac..beeeead1e0507eb80016eb5e071f90ec
      }
      finally {
 diff --git a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
-index 01b9cef3bb535025f816f18acab5951083e4ec55..41f7389f3931a6a3c87647f7fde98f04c37af5c0 100644
+index 2ee52fc024823932bbbe01d99928cb95287456cf..d216cf9669b44a7d2cfdd6e95225535cdad55ca7 100644
 --- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
 +++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
 @@ -37,6 +37,7 @@ public interface IFernflowerPreferences {
@@ -120,7 +120,7 @@ index 01b9cef3bb535025f816f18acab5951083e4ec55..41f7389f3931a6a3c87647f7fde98f04
  
    String LOG_LEVEL = "log";
    String MAX_PROCESSING_METHOD = "mpm";
-@@ -90,6 +91,7 @@ public interface IFernflowerPreferences {
+@@ -92,6 +93,7 @@ public interface IFernflowerPreferences {
  
      defaults.put(INCLUDE_ENTIRE_CLASSPATH, "0");
      defaults.put(EXPLICIT_GENERIC_ARGUMENTS, "0");

--- a/FernFlower-Patches/0035-Add-only-argument-It-will-filter-what-classes-are-de.patch
+++ b/FernFlower-Patches/0035-Add-only-argument-It-will-filter-what-classes-are-de.patch
@@ -8,7 +8,7 @@ Uses a prefix system, so -only=net/minecraft/block/ will decompile all classes i
 Useful for debugging to limit scope/runtime.
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
-index 8ce3a2575b4c9c8268ba9956ea008027982a03fb..76b362a5f0bc04f74f26091a54d7f42d385c5037 100644
+index 80b8fd01286f90c3f194385edef47df805611c98..7323887590542fdfb4791dee3c929651baa3a092 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 @@ -37,6 +37,7 @@ public class ClassesProcessor implements CodeConstants {
@@ -42,7 +42,7 @@ index 8ce3a2575b4c9c8268ba9956ea008027982a03fb..76b362a5f0bc04f74f26091a54d7f42d
    public void loadClasses(IIdentifierRenamer renamer) {
      Map<String, Inner> mapInnerClasses = new HashMap<>();
      Map<String, Set<String>> mapNestedClassReferences = new HashMap<>();
-@@ -161,9 +178,11 @@ public class ClassesProcessor implements CodeConstants {
+@@ -163,9 +180,11 @@ public class ClassesProcessor implements CodeConstants {
            }
          }
  

--- a/FernFlower-Patches/0039-Make-decomp-threaded.patch
+++ b/FernFlower-Patches/0039-Make-decomp-threaded.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Make decomp threaded
 `-thr AUTO` to auto select, (default)
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
-index 76b362a5f0bc04f74f26091a54d7f42d385c5037..366bc3195304ae80ff539041d01202e57a6a1349 100644
+index 7323887590542fdfb4791dee3c929651baa3a092..dc5b67108878c4f37fa245699f977097f7fe5a4e 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 @@ -36,7 +36,8 @@ public class ClassesProcessor implements CodeConstants {
@@ -20,7 +20,7 @@ index 76b362a5f0bc04f74f26091a54d7f42d385c5037..366bc3195304ae80ff539041d01202e5
    private final Set<String> whitelist = new HashSet<>();
  
    private static class Inner {
-@@ -361,7 +362,7 @@ public class ClassesProcessor implements CodeConstants {
+@@ -363,7 +364,7 @@ public class ClassesProcessor implements CodeConstants {
      return true;
    }
  
@@ -29,7 +29,7 @@ index 76b362a5f0bc04f74f26091a54d7f42d385c5037..366bc3195304ae80ff539041d01202e5
      ClassNode root = mapRootClasses.get(cl.qualifiedName);
      if (root.type != ClassNode.CLASS_ROOT) {
        return;
-@@ -370,25 +371,12 @@ public class ClassesProcessor implements CodeConstants {
+@@ -372,25 +373,12 @@ public class ClassesProcessor implements CodeConstants {
      boolean packageInfo = cl.isSynthetic() && "package-info".equals(root.simpleName);
      boolean moduleInfo = cl.hasModifier(CodeConstants.ACC_MODULE) && cl.hasAttribute(StructGeneralAttribute.ATTRIBUTE_MODULE);
  
@@ -58,7 +58,7 @@ index 76b362a5f0bc04f74f26091a54d7f42d385c5037..366bc3195304ae80ff539041d01202e5
          new LambdaProcessor().processClass(root);
  
          // add simple class names to implicit import
-@@ -400,7 +388,36 @@ public class ClassesProcessor implements CodeConstants {
+@@ -402,7 +390,36 @@ public class ClassesProcessor implements CodeConstants {
          new NestedClassProcessor().processClass(root, root);
  
          new NestedMemberAccess().propagateMemberAccess(root);
@@ -95,7 +95,7 @@ index 76b362a5f0bc04f74f26091a54d7f42d385c5037..366bc3195304ae80ff539041d01202e5
          TextBuffer classBuffer = new TextBuffer(AVERAGE_CLASS_SIZE);
          new ClassWriter().classToJava(root, classBuffer, 0, null);
  
-@@ -410,7 +427,7 @@ public class ClassesProcessor implements CodeConstants {
+@@ -412,7 +429,7 @@ public class ClassesProcessor implements CodeConstants {
            buffer.append("package ").append(packageName).append(';').appendLineSeparator().appendLineSeparator();
          }
  
@@ -670,7 +670,7 @@ index c9ece039b0d986c1d84b62426a65e6780ddc80e1..3ca43800b47e1d26a1dc036f21cb6e6e
  
    public void endReadingClass() { }
 diff --git a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
-index 41f7389f3931a6a3c87647f7fde98f04c37af5c0..a2be81c2a329812c30ffe2606cae2b5f7ab43c3c 100644
+index d216cf9669b44a7d2cfdd6e95225535cdad55ca7..94d285522b4444dab8eb2c15d869aef7ea3b48b1 100644
 --- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
 +++ b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
 @@ -38,6 +38,7 @@ public interface IFernflowerPreferences {
@@ -681,7 +681,7 @@ index 41f7389f3931a6a3c87647f7fde98f04c37af5c0..a2be81c2a329812c30ffe2606cae2b5f
  
    String LOG_LEVEL = "log";
    String MAX_PROCESSING_METHOD = "mpm";
-@@ -92,6 +93,7 @@ public interface IFernflowerPreferences {
+@@ -94,6 +95,7 @@ public interface IFernflowerPreferences {
      defaults.put(INCLUDE_ENTIRE_CLASSPATH, "0");
      defaults.put(EXPLICIT_GENERIC_ARGUMENTS, "0");
      defaults.put(INLINE_SIMPLE_LAMBDAS, "1");


### PR DESCRIPTION
Mojang has messed up metadata in recent MC versions (starting with 21w19a), so we make them suppressable.

An example of the warnings from a decompile:

```
Inconsistent inner class entries for net/minecraft/gametest/framework/TestCommand$TestSummaryDisplayer!
  Old: TestSummaryDisplayer private static MEMBER net/minecraft/gametest/framework/TestCommand
  New: TestSummaryDisplayer static MEMBER net/minecraft/gametest/framework/TestCommand$TestSummaryDisplayer
Inconsistent inner class entries for com/mojang/realmsclient/gui/screens/RealmsSelectWorldTemplateScreen$WorldTemplateObjectSelectionList!
  Old: WorldTemplateObjectSelectionList  MEMBER com/mojang/realmsclient/gui/screens/RealmsSelectWorldTemplateScreen$WorldTemplateObjectSelectionList
  New: WorldTemplateObjectSelectionList private MEMBER com/mojang/realmsclient/gui/screens/RealmsSelectWorldTemplateScreen$1
Inconsistent inner class entries for net/minecraft/world/entity/animal/Fox$PerchAndSearchGoal!
  Old: PerchAndSearchGoal  MEMBER net/minecraft/world/entity/animal/Fox$PerchAndSearchGoal
  New: PerchAndSearchGoal private MEMBER net/minecraft/world/entity/animal/Fox
Inconsistent inner class entries for net/minecraft/world/entity/animal/Fox$DefendTrustedTargetGoal!
  Old: DefendTrustedTargetGoal  MEMBER net/minecraft/world/entity/animal/Fox$DefendTrustedTargetGoal
  New: DefendTrustedTargetGoal private MEMBER net/minecraft/world/entity/animal/Fox
Inconsistent inner class entries for net/minecraft/world/entity/animal/Fox$FoxSearchForItemsGoal!
  Old: FoxSearchForItemsGoal private MEMBER net/minecraft/world/entity/animal/Fox
  New: FoxSearchForItemsGoal  MEMBER net/minecraft/world/entity/animal/Fox$FoxSearchForItemsGoal
Inconsistent inner class entries for net/minecraft/world/entity/npc/VillagerTrades$ItemsAndEmeraldsToItems!
  Old: ItemsAndEmeraldsToItems private static MEMBER net/minecraft/world/entity/npc/VillagerTrades
  New: ItemsAndEmeraldsToItems static MEMBER net/minecraft/world/entity/npc/VillagerTrades$ItemsAndEmeraldsToItems
Inconsistent inner class entries for net/minecraft/world/entity/animal/Bee$BeeEnterHiveGoal!
  Old: BeeEnterHiveGoal  MEMBER net/minecraft/world/entity/animal/Bee$BeeEnterHiveGoal
  New: BeeEnterHiveGoal private MEMBER net/minecraft/world/entity/animal/Bee
Inconsistent inner class entries for net/minecraft/world/entity/animal/Bee$BeeWanderGoal!
  Old: BeeWanderGoal  MEMBER net/minecraft/world/entity/animal/Bee$BeeWanderGoal
  New: BeeWanderGoal private MEMBER net/minecraft/world/entity/animal/Bee
Inconsistent inner class entries for net/minecraft/world/entity/animal/Bee$BeeHurtByOtherGoal!
  Old: BeeHurtByOtherGoal  MEMBER net/minecraft/world/entity/animal/Bee$BeeHurtByOtherGoal
  New: BeeHurtByOtherGoal private MEMBER net/minecraft/world/entity/animal/Bee
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$FloorRoomCollection!
  Old: FloorRoomCollection abstract static MEMBER net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$FloorRoomCollection
  New: FloorRoomCollection private abstract static MEMBER net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces
Inconsistent inner class entries for net/minecraft/client/particle/DripParticle$FallingParticle!
  Old: FallingParticle static MEMBER net/minecraft/client/particle/DripParticle$FallingParticle
  New: FallingParticle private static MEMBER net/minecraft/client/particle/DripParticle$FallAndLandParticle
Inconsistent inner class entries for net/minecraft/client/particle/DripParticle$FallAndLandParticle!
  Old: FallAndLandParticle private static MEMBER net/minecraft/client/particle/DripParticle$ObsidianTearFallProvider
  New: FallAndLandParticle static MEMBER net/minecraft/client/particle/DripParticle$FallAndLandParticle
Inconsistent inner class entries for net/minecraft/world/entity/animal/Cat$CatRelaxOnOwnerGoal!
  Old: CatRelaxOnOwnerGoal private static MEMBER net/minecraft/world/entity/animal/Cat
  New: CatRelaxOnOwnerGoal static MEMBER net/minecraft/world/entity/animal/Cat$CatRelaxOnOwnerGoal
Inconsistent inner class entries for net/minecraft/world/entity/npc/VillagerTrades$TreasureMapForEmeralds!
  Old: TreasureMapForEmeralds private static MEMBER net/minecraft/world/entity/npc/VillagerTrades
  New: TreasureMapForEmeralds static MEMBER net/minecraft/world/entity/npc/VillagerTrades$TreasureMapForEmeralds
Inconsistent inner class entries for net/minecraft/world/entity/animal/Bee$BeeLocateHiveGoal!
  Old: BeeLocateHiveGoal private MEMBER net/minecraft/world/entity/animal/Bee
  New: BeeLocateHiveGoal  MEMBER net/minecraft/world/entity/animal/Bee$BeeLocateHiveGoal
Inconsistent inner class entries for com/mojang/blaze3d/platform/PngInfo$StbReaderSeekableByteChannel!
  Old: StbReaderSeekableByteChannel static MEMBER com/mojang/blaze3d/platform/PngInfo$StbReaderSeekableByteChannel
  New: StbReaderSeekableByteChannel private static MEMBER com/mojang/blaze3d/platform/PngInfo
Inconsistent inner class entries for com/mojang/blaze3d/platform/PngInfo$StbReader!
  Old: StbReader private abstract static MEMBER com/mojang/blaze3d/platform/PngInfo$StbReaderSeekableByteChannel
  New: StbReader abstract static MEMBER com/mojang/blaze3d/platform/PngInfo$StbReader
Inconsistent inner class entries for net/minecraft/world/entity/animal/TropicalFish$Pattern!
  Old: Pattern private static final MEMBER net/minecraft/world/entity/animal/TropicalFish
  New: Pattern static final MEMBER net/minecraft/world/entity/animal/TropicalFish$Pattern
Inconsistent inner class entries for net/minecraft/network/protocol/game/ClientboundBossEventPacket$OperationType!
  Old: OperationType private static final MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$UpdatePropertiesOperation
  New: OperationType static final MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$OperationType
Inconsistent inner class entries for net/minecraft/network/protocol/game/ClientboundBossEventPacket$UpdatePropertiesOperation!
  Old: UpdatePropertiesOperation static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$UpdatePropertiesOperation
  New: UpdatePropertiesOperation private static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$OperationType
Inconsistent inner class entries for net/minecraft/client/particle/DripParticle$DripHangParticle!
  Old: DripHangParticle private static MEMBER net/minecraft/client/particle/DripParticle$ObsidianTearHangProvider
  New: DripHangParticle static MEMBER net/minecraft/client/particle/DripParticle$DripHangParticle
Inconsistent inner class entries for net/minecraft/world/entity/animal/Fox$FoxLookAtPlayerGoal!
  Old: FoxLookAtPlayerGoal private MEMBER net/minecraft/world/entity/animal/Fox
  New: FoxLookAtPlayerGoal  MEMBER net/minecraft/world/entity/animal/Fox$FoxLookAtPlayerGoal
Inconsistent inner class entries for net/minecraft/world/entity/animal/Rabbit$RabbitMoveControl!
  Old: RabbitMoveControl private static MEMBER net/minecraft/world/entity/animal/Rabbit
  New: RabbitMoveControl static MEMBER net/minecraft/world/entity/animal/Rabbit$RabbitMoveControl
Inconsistent inner class entries for net/minecraft/client/renderer/block/model/ItemOverrides$PropertyMatcher!
  Old: PropertyMatcher static MEMBER net/minecraft/client/renderer/block/model/ItemOverrides$PropertyMatcher
  New: PropertyMatcher private static MEMBER net/minecraft/client/renderer/block/model/ItemOverrides
Inconsistent inner class entries for com/mojang/realmsclient/gui/screens/RealmsSelectWorldTemplateScreen$Entry!
  Old: Entry private MEMBER com/mojang/realmsclient/gui/screens/RealmsSelectWorldTemplateScreen$WorldTemplateObjectSelectionList
  New: Entry  MEMBER com/mojang/realmsclient/gui/screens/RealmsSelectWorldTemplateScreen$Entry
Inconsistent inner class entries for net/minecraft/world/level/levelgen/VerticalAnchor$AboveBottom!
  Old: AboveBottom static final MEMBER net/minecraft/world/level/levelgen/VerticalAnchor$AboveBottom
  New: AboveBottom private static final MEMBER net/minecraft/world/level/levelgen/VerticalAnchor
Inconsistent inner class entries for net/minecraft/server/network/ServerLoginPacketListenerImpl$State!
  Old: State static final MEMBER net/minecraft/server/network/ServerLoginPacketListenerImpl$State
  New: State private static final MEMBER net/minecraft/server/network/ServerLoginPacketListenerImpl$1
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/EndCityPieces$SectionGenerator!
  Old: SectionGenerator private abstract static MEMBER net/minecraft/world/level/levelgen/structure/EndCityPieces
  New: SectionGenerator abstract static MEMBER net/minecraft/world/level/levelgen/structure/EndCityPieces$SectionGenerator
Inconsistent inner class entries for net/minecraft/network/protocol/game/ClientboundBossEventPacket$Operation!
  Old: Operation private abstract static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$UpdatePropertiesOperation
  New: Operation abstract static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$Operation
Inconsistent inner class entries for net/minecraft/network/protocol/game/ClientboundBossEventPacket$OperationType!
  Old: OperationType static final MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$OperationType
  New: OperationType private static final MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$Operation
Inconsistent inner class entries for net/minecraft/world/level/chunk/ChunkStatus$LoadingTask!
  Old: LoadingTask abstract static MEMBER net/minecraft/world/level/chunk/ChunkStatus$LoadingTask
  New: LoadingTask private abstract static MEMBER net/minecraft/world/level/chunk/ChunkStatus
Inconsistent inner class entries for net/minecraft/world/level/chunk/ChunkStatus$SimpleGenerationTask!
  Old: SimpleGenerationTask abstract static MEMBER net/minecraft/world/level/chunk/ChunkStatus$SimpleGenerationTask
  New: SimpleGenerationTask private abstract static MEMBER net/minecraft/world/level/chunk/ChunkStatus
Inconsistent inner class entries for net/minecraft/client/model/geom/ModelPart$Polygon!
  Old: Polygon private static MEMBER net/minecraft/client/model/geom/ModelPart
  New: Polygon static MEMBER net/minecraft/client/model/geom/ModelPart$Polygon
Inconsistent inner class entries for net/minecraft/world/entity/monster/Zombie$ZombieAttackTurtleEggGoal!
  Old: ZombieAttackTurtleEggGoal private MEMBER net/minecraft/world/entity/monster/Zombie
  New: ZombieAttackTurtleEggGoal  MEMBER net/minecraft/world/entity/monster/Zombie$ZombieAttackTurtleEggGoal
Inconsistent inner class entries for net/minecraft/client/gui/screens/achievement/StatsScreen$ItemStatisticsList!
  Old: ItemStatisticsList  MEMBER net/minecraft/client/gui/screens/achievement/StatsScreen$ItemStatisticsList
  New: ItemStatisticsList private MEMBER net/minecraft/client/gui/screens/achievement/StatsScreen$ItemStatisticsList$ItemComparator
Inconsistent inner class entries for net/minecraft/client/gui/screens/achievement/StatsScreen$ItemStatisticsList$ItemComparator!
  Old: ItemComparator private MEMBER net/minecraft/client/gui/screens/achievement/StatsScreen$ItemStatisticsList
  New: ItemComparator  MEMBER net/minecraft/client/gui/screens/achievement/StatsScreen$ItemStatisticsList$ItemComparator
Inconsistent inner class entries for net/minecraft/advancements/critereon/StatePropertiesPredicate$PropertyMatcher!
  Old: PropertyMatcher private abstract static MEMBER net/minecraft/advancements/critereon/StatePropertiesPredicate$Builder
  New: PropertyMatcher abstract static MEMBER net/minecraft/advancements/critereon/StatePropertiesPredicate$PropertyMatcher
Inconsistent inner class entries for net/minecraft/client/renderer/OutlineBufferSource$EntityOutlineGenerator!
  Old: EntityOutlineGenerator static MEMBER net/minecraft/client/renderer/OutlineBufferSource$EntityOutlineGenerator
  New: EntityOutlineGenerator private static MEMBER net/minecraft/client/renderer/OutlineBufferSource
Inconsistent inner class entries for net/minecraft/world/entity/animal/Fox$FoxFloatGoal!
  Old: FoxFloatGoal private MEMBER net/minecraft/world/entity/animal/Fox
  New: FoxFloatGoal  MEMBER net/minecraft/world/entity/animal/Fox$FoxFloatGoal
Inconsistent inner class entries for net/minecraft/advancements/critereon/PlayerPredicate$AdvancementPredicate!
  Old: AdvancementPredicate abstract static MEMBER net/minecraft/advancements/critereon/PlayerPredicate$AdvancementPredicate
  New: AdvancementPredicate private abstract static MEMBER net/minecraft/advancements/critereon/PlayerPredicate$AdvancementDonePredicate
Inconsistent inner class entries for net/minecraft/world/entity/monster/Ravager$RavagerMeleeAttackGoal!
  Old: RavagerMeleeAttackGoal private MEMBER net/minecraft/world/entity/monster/Ravager
  New: RavagerMeleeAttackGoal  MEMBER net/minecraft/world/entity/monster/Ravager$RavagerMeleeAttackGoal
Inconsistent inner class entries for net/minecraft/client/particle/FireworkParticles$SparkParticle!
  Old: SparkParticle private static MEMBER net/minecraft/client/particle/FireworkParticles$SparkProvider
  New: SparkParticle static MEMBER net/minecraft/client/particle/FireworkParticles$SparkParticle
Inconsistent inner class entries for com/mojang/blaze3d/systems/RenderSystem$AutoStorageIndexBuffer$IndexGenerator!
  Old: IndexGenerator private abstract static MEMBER com/mojang/blaze3d/systems/RenderSystem
  New: IndexGenerator abstract static MEMBER com/mojang/blaze3d/systems/RenderSystem$AutoStorageIndexBuffer$IndexGenerator
Inconsistent inner class entries for net/minecraft/client/renderer/debug/GameTestDebugRenderer$Marker!
  Old: Marker static MEMBER net/minecraft/client/renderer/debug/GameTestDebugRenderer$Marker
  New: Marker private static MEMBER net/minecraft/client/renderer/debug/GameTestDebugRenderer
Inconsistent inner class entries for net/minecraft/world/entity/animal/Cat$CatTemptGoal!
  Old: CatTemptGoal private static MEMBER net/minecraft/world/entity/animal/Cat
  New: CatTemptGoal static MEMBER net/minecraft/world/entity/animal/Cat$CatTemptGoal
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$MonumentRoomFitter!
  Old: MonumentRoomFitter private abstract static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitDoubleYRoom
  New: MonumentRoomFitter abstract static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$MonumentRoomFitter
Inconsistent inner class entries for net/minecraft/world/entity/monster/Ravager$RavagerNodeEvaluator!
  Old: RavagerNodeEvaluator private static MEMBER net/minecraft/world/entity/monster/Ravager
  New: RavagerNodeEvaluator static MEMBER net/minecraft/world/entity/monster/Ravager$RavagerNodeEvaluator
Inconsistent inner class entries for net/minecraft/server/network/ServerConnectionListener$LatencySimulator!
  Old: LatencySimulator private static MEMBER net/minecraft/server/network/ServerConnectionListener$LatencySimulator$DelayedMessage
  New: LatencySimulator static MEMBER net/minecraft/server/network/ServerConnectionListener$LatencySimulator
Inconsistent inner class entries for net/minecraft/server/network/ServerConnectionListener$LatencySimulator$DelayedMessage!
  Old: DelayedMessage static MEMBER net/minecraft/server/network/ServerConnectionListener$LatencySimulator$DelayedMessage
  New: DelayedMessage private static MEMBER net/minecraft/server/network/ServerConnectionListener$LatencySimulator
Inconsistent inner class entries for net/minecraft/client/particle/DripParticle$FallAndLandParticle!
  Old: FallAndLandParticle static MEMBER net/minecraft/client/particle/DripParticle$FallAndLandParticle
  New: FallAndLandParticle private static MEMBER net/minecraft/client/particle/DripParticle$HoneyFallAndLandParticle
Inconsistent inner class entries for net/minecraft/resources/RegistryReadOps$ReadCache!
  Old: ReadCache private static final MEMBER net/minecraft/resources/RegistryReadOps
  New: ReadCache static final MEMBER net/minecraft/resources/RegistryReadOps$ReadCache
Inconsistent inner class entries for net/minecraft/world/level/border/WorldBorder$BorderExtent!
  Old: BorderExtent private abstract static MEMBER net/minecraft/world/level/border/WorldBorder$StaticBorderExtent
  New: BorderExtent abstract static MEMBER net/minecraft/world/level/border/WorldBorder$BorderExtent
Inconsistent inner class entries for net/minecraft/network/protocol/game/ClientboundBossEventPacket$OperationType!
  Old: OperationType static final MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$OperationType
  New: OperationType private static final MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$1
Inconsistent inner class entries for net/minecraft/network/protocol/game/ClientboundBossEventPacket$Operation!
  Old: Operation abstract static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$Operation
  New: Operation private abstract static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$1
Inconsistent inner class entries for net/minecraft/world/item/alchemy/PotionBrewing$Mix!
  Old: Mix static MEMBER net/minecraft/world/item/alchemy/PotionBrewing$Mix
  New: Mix private static MEMBER net/minecraft/world/item/alchemy/PotionBrewing
Inconsistent inner class entries for net/minecraft/world/level/levelgen/OreVeinifier$VeinType!
  Old: VeinType private static final MEMBER net/minecraft/world/level/levelgen/OreVeinifier
  New: VeinType static final MEMBER net/minecraft/world/level/levelgen/OreVeinifier$VeinType
Inconsistent inner class entries for net/minecraft/world/inventory/BeaconMenu$PaymentSlot!
  Old: PaymentSlot private MEMBER net/minecraft/world/inventory/BeaconMenu
  New: PaymentSlot  MEMBER net/minecraft/world/inventory/BeaconMenu$PaymentSlot
Inconsistent inner class entries for net/minecraft/world/entity/animal/Fox$FoxMoveControl!
  Old: FoxMoveControl private MEMBER net/minecraft/world/entity/animal/Fox
  New: FoxMoveControl  MEMBER net/minecraft/world/entity/animal/Fox$FoxMoveControl
Inconsistent inner class entries for net/minecraft/world/level/entity/PersistentEntitySectionManager$Callback!
  Old: Callback  MEMBER net/minecraft/world/level/entity/PersistentEntitySectionManager$Callback
  New: Callback private MEMBER net/minecraft/world/level/entity/PersistentEntitySectionManager
Inconsistent inner class entries for net/minecraft/world/entity/npc/VillagerTrades$SuspisciousStewForEmerald!
  Old: SuspisciousStewForEmerald private static MEMBER net/minecraft/world/entity/npc/VillagerTrades
  New: SuspisciousStewForEmerald static MEMBER net/minecraft/world/entity/npc/VillagerTrades$SuspisciousStewForEmerald
Inconsistent inner class entries for net/minecraft/util/SortedArraySet$ArrayIterator!
  Old: ArrayIterator  MEMBER net/minecraft/util/SortedArraySet$ArrayIterator
  New: ArrayIterator private MEMBER net/minecraft/util/SortedArraySet
Inconsistent inner class entries for net/minecraft/world/entity/animal/AbstractFish$FishMoveControl!
  Old: FishMoveControl private static MEMBER net/minecraft/world/entity/animal/AbstractFish
  New: FishMoveControl static MEMBER net/minecraft/world/entity/animal/AbstractFish$FishMoveControl
Inconsistent inner class entries for net/minecraft/world/entity/animal/Bee$BeeGrowCropGoal!
  Old: BeeGrowCropGoal private MEMBER net/minecraft/world/entity/animal/Bee
  New: BeeGrowCropGoal  MEMBER net/minecraft/world/entity/animal/Bee$BeeGrowCropGoal
Inconsistent inner class entries for net/minecraft/network/protocol/game/ClientboundBossEventPacket$UpdateStyleOperation!
  Old: UpdateStyleOperation private static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$OperationType
  New: UpdateStyleOperation static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$UpdateStyleOperation
Inconsistent inner class entries for net/minecraft/network/protocol/game/ClientboundBossEventPacket$OperationType!
  Old: OperationType static final MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$OperationType
  New: OperationType private static final MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$UpdateStyleOperation
Inconsistent inner class entries for net/minecraft/network/protocol/game/ClientboundBossEventPacket$Operation!
  Old: Operation abstract static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$Operation
  New: Operation private abstract static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$UpdateStyleOperation
Inconsistent inner class entries for net/minecraft/world/entity/animal/Fox$FaceplantGoal!
  Old: FaceplantGoal private MEMBER net/minecraft/world/entity/animal/Fox
  New: FaceplantGoal  MEMBER net/minecraft/world/entity/animal/Fox$FaceplantGoal
Inconsistent inner class entries for net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator$NoodleCaveNoiseModifier!
  Old: NoodleCaveNoiseModifier  MEMBER net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator$NoodleCaveNoiseModifier
  New: NoodleCaveNoiseModifier private MEMBER net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator
Inconsistent inner class entries for net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator$OreVeinNoiseSource!
  Old: OreVeinNoiseSource  MEMBER net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator$OreVeinNoiseSource
  New: OreVeinNoiseSource private MEMBER net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator
Inconsistent inner class entries for net/minecraft/world/level/levelgen/feature/SpikeFeature$SpikeCacheLoader!
  Old: SpikeCacheLoader private static MEMBER net/minecraft/world/level/levelgen/feature/SpikeFeature
  New: SpikeCacheLoader static MEMBER net/minecraft/world/level/levelgen/feature/SpikeFeature$SpikeCacheLoader
Inconsistent inner class entries for net/minecraft/world/level/storage/loot/ItemModifierManager$FunctionSequence!
  Old: FunctionSequence private static MEMBER net/minecraft/world/level/storage/loot/ItemModifierManager
  New: FunctionSequence static MEMBER net/minecraft/world/level/storage/loot/ItemModifierManager$FunctionSequence
Inconsistent inner class entries for com/mojang/realmsclient/gui/screens/RealmsPlayerScreen$Entry!
  Old: Entry private MEMBER com/mojang/realmsclient/gui/screens/RealmsPlayerScreen$InvitedObjectSelectionList
  New: Entry  MEMBER com/mojang/realmsclient/gui/screens/RealmsPlayerScreen$Entry
Inconsistent inner class entries for net/minecraft/client/gui/screens/recipebook/OverlayRecipeComponent$OverlayRecipeButton!
  Old: OverlayRecipeButton  MEMBER net/minecraft/client/gui/screens/recipebook/OverlayRecipeComponent$OverlayRecipeButton
  New: OverlayRecipeButton private MEMBER net/minecraft/client/gui/screens/recipebook/OverlayRecipeComponent
Inconsistent inner class entries for net/minecraft/world/entity/animal/Pufferfish$PufferfishPuffGoal!
  Old: PufferfishPuffGoal static MEMBER net/minecraft/world/entity/animal/Pufferfish$PufferfishPuffGoal
  New: PufferfishPuffGoal private static MEMBER net/minecraft/world/entity/animal/Pufferfish
Inconsistent inner class entries for net/minecraft/world/level/biome/Biome$ClimateSettings!
  Old: ClimateSettings private static MEMBER net/minecraft/world/level/biome/Biome$1
  New: ClimateSettings static MEMBER net/minecraft/world/level/biome/Biome$ClimateSettings
Inconsistent inner class entries for net/minecraft/world/entity/animal/Fox$FoxPanicGoal!
  Old: FoxPanicGoal private MEMBER net/minecraft/world/entity/animal/Fox
  New: FoxPanicGoal  MEMBER net/minecraft/world/entity/animal/Fox$FoxPanicGoal
Inconsistent inner class entries for net/minecraft/client/gui/screens/inventory/tooltip/ClientBundleTooltip$Texture!
  Old: Texture static final MEMBER net/minecraft/client/gui/screens/inventory/tooltip/ClientBundleTooltip$Texture
  New: Texture private static final MEMBER net/minecraft/client/gui/screens/inventory/tooltip/ClientBundleTooltip
Inconsistent inner class entries for net/minecraft/world/entity/animal/Rabbit$RaidGardenGoal!
  Old: RaidGardenGoal private static MEMBER net/minecraft/world/entity/animal/Rabbit
  New: RaidGardenGoal static MEMBER net/minecraft/world/entity/animal/Rabbit$RaidGardenGoal
Inconsistent inner class entries for com/mojang/realmsclient/client/FileDownload$DownloadCountingOutputStream!
  Old: DownloadCountingOutputStream  MEMBER com/mojang/realmsclient/client/FileDownload$DownloadCountingOutputStream
  New: DownloadCountingOutputStream private MEMBER com/mojang/realmsclient/client/FileDownload$ProgressListener
Inconsistent inner class entries for net/minecraft/server/commands/data/DataCommands$DataManipulator!
  Old: DataManipulator private abstract static MEMBER net/minecraft/server/commands/data/DataCommands
  New: DataManipulator abstract static MEMBER net/minecraft/server/commands/data/DataCommands$DataManipulator
Inconsistent inner class entries for net/minecraft/core/RegistryAccess$RegistryData!
  Old: RegistryData private static final MEMBER net/minecraft/core/RegistryAccess$RegistryHolder
  New: RegistryData static final MEMBER net/minecraft/core/RegistryAccess$RegistryData
Inconsistent inner class entries for net/minecraft/world/entity/animal/Squid$SquidFleeGoal!
  Old: SquidFleeGoal private MEMBER net/minecraft/world/entity/animal/Squid
  New: SquidFleeGoal  MEMBER net/minecraft/world/entity/animal/Squid$SquidFleeGoal
Inconsistent inner class entries for net/minecraft/world/entity/animal/Bee$BeeAttackGoal!
  Old: BeeAttackGoal private MEMBER net/minecraft/world/entity/animal/Bee
  New: BeeAttackGoal  MEMBER net/minecraft/world/entity/animal/Bee$BeeAttackGoal
Inconsistent inner class entries for net/minecraft/client/renderer/debug/ChunkDebugRenderer$ChunkData!
  Old: ChunkData final MEMBER net/minecraft/client/renderer/debug/ChunkDebugRenderer$ChunkData
  New: ChunkData private final MEMBER net/minecraft/client/renderer/debug/ChunkDebugRenderer
Inconsistent inner class entries for net/minecraft/client/renderer/texture/Stitcher$Holder!
  Old: Holder static MEMBER net/minecraft/client/renderer/texture/Stitcher$Holder
  New: Holder private static MEMBER net/minecraft/client/renderer/texture/Stitcher$Region
Inconsistent inner class entries for net/minecraft/client/particle/DripParticle$DripHangParticle!
  Old: DripHangParticle static MEMBER net/minecraft/client/particle/DripParticle$DripHangParticle
  New: DripHangParticle private static MEMBER net/minecraft/client/particle/DripParticle$WaterHangProvider
Inconsistent inner class entries for net/minecraft/CrashReportCategory$Entry!
  Old: Entry static MEMBER net/minecraft/CrashReportCategory$Entry
  New: Entry private static MEMBER net/minecraft/CrashReportCategory
Inconsistent inner class entries for com/mojang/blaze3d/vertex/VertexFormatElement$Usage$ClearState!
  Old: ClearState abstract static MEMBER com/mojang/blaze3d/vertex/VertexFormatElement$Usage$ClearState
  New: ClearState private abstract static MEMBER com/mojang/blaze3d/vertex/VertexFormatElement
Inconsistent inner class entries for net/minecraft/client/gui/screens/CreateBuffetWorldScreen$BiomeList!
  Old: BiomeList private MEMBER net/minecraft/client/gui/screens/CreateBuffetWorldScreen$BiomeList$Entry
  New: BiomeList  MEMBER net/minecraft/client/gui/screens/CreateBuffetWorldScreen$BiomeList
Inconsistent inner class entries for net/minecraft/client/gui/screens/CreateBuffetWorldScreen$BiomeList$Entry!
  Old: Entry  MEMBER net/minecraft/client/gui/screens/CreateBuffetWorldScreen$BiomeList$Entry
  New: Entry private MEMBER net/minecraft/client/gui/screens/CreateBuffetWorldScreen$BiomeList
Inconsistent inner class entries for net/minecraft/client/gui/screens/worldselection/EditGameRulesScreen$EntryFactory!
  Old: EntryFactory private abstract static MEMBER net/minecraft/client/gui/screens/worldselection/EditGameRulesScreen
  New: EntryFactory abstract static MEMBER net/minecraft/client/gui/screens/worldselection/EditGameRulesScreen$EntryFactory
Inconsistent inner class entries for net/minecraft/world/entity/npc/VillagerTrades$DyedArmorForEmeralds!
  Old: DyedArmorForEmeralds private static MEMBER net/minecraft/world/entity/npc/VillagerTrades
  New: DyedArmorForEmeralds static MEMBER net/minecraft/world/entity/npc/VillagerTrades$DyedArmorForEmeralds
Inconsistent inner class entries for net/minecraft/client/particle/DripParticle$FallAndLandParticle!
  Old: FallAndLandParticle static MEMBER net/minecraft/client/particle/DripParticle$FallAndLandParticle
  New: FallAndLandParticle private static MEMBER net/minecraft/client/particle/DripParticle$WaterFallProvider
Inconsistent inner class entries for net/minecraft/client/particle/DripParticle$DripLandParticle!
  Old: DripLandParticle private static MEMBER net/minecraft/client/particle/DripParticle$LavaLandProvider
  New: DripLandParticle static MEMBER net/minecraft/client/particle/DripParticle$DripLandParticle
Inconsistent inner class entries for com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen$PendingInvitationSelectionList!
  Old: PendingInvitationSelectionList private MEMBER com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen
  New: PendingInvitationSelectionList  MEMBER com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen$PendingInvitationSelectionList
Inconsistent inner class entries for net/minecraft/world/level/levelgen/feature/trunkplacers/FancyTrunkPlacer$FoliageCoords!
  Old: FoliageCoords private static MEMBER net/minecraft/world/level/levelgen/feature/trunkplacers/FancyTrunkPlacer
  New: FoliageCoords static MEMBER net/minecraft/world/level/levelgen/feature/trunkplacers/FancyTrunkPlacer$FoliageCoords
Inconsistent inner class entries for net/minecraft/world/level/chunk/LevelChunk$BoundTickingBlockEntity!
  Old: BoundTickingBlockEntity private MEMBER net/minecraft/world/level/chunk/LevelChunk
  New: BoundTickingBlockEntity  MEMBER net/minecraft/world/level/chunk/LevelChunk$BoundTickingBlockEntity
Inconsistent inner class entries for net/minecraft/world/entity/animal/Bee$BeePollinateGoal!
  Old: BeePollinateGoal private MEMBER net/minecraft/world/entity/animal/Bee
  New: BeePollinateGoal  MEMBER net/minecraft/world/entity/animal/Bee$BeePollinateGoal
Inconsistent inner class entries for net/minecraft/world/entity/player/StackedContents$RecipePicker!
  Old: RecipePicker  MEMBER net/minecraft/world/entity/player/StackedContents$RecipePicker
  New: RecipePicker private MEMBER net/minecraft/world/entity/player/StackedContents
Inconsistent inner class entries for net/minecraft/advancements/critereon/StatePropertiesPredicate$PropertyMatcher!
  Old: PropertyMatcher abstract static MEMBER net/minecraft/advancements/critereon/StatePropertiesPredicate$PropertyMatcher
  New: PropertyMatcher private abstract static MEMBER net/minecraft/advancements/critereon/StatePropertiesPredicate$ExactPropertyMatcher
Inconsistent inner class entries for net/minecraft/advancements/critereon/StatePropertiesPredicate$ExactPropertyMatcher!
  Old: ExactPropertyMatcher private static MEMBER net/minecraft/advancements/critereon/StatePropertiesPredicate$Builder
  New: ExactPropertyMatcher static MEMBER net/minecraft/advancements/critereon/StatePropertiesPredicate$ExactPropertyMatcher
Inconsistent inner class entries for net/minecraft/server/players/OldUsersConverter$ConversionError!
  Old: ConversionError private static MEMBER net/minecraft/server/players/OldUsersConverter
  New: ConversionError static MEMBER net/minecraft/server/players/OldUsersConverter$ConversionError
Inconsistent inner class entries for net/minecraft/world/level/block/ComposterBlock$EmptyContainer!
  Old: EmptyContainer static MEMBER net/minecraft/world/level/block/ComposterBlock$EmptyContainer
  New: EmptyContainer private static MEMBER net/minecraft/world/level/block/ComposterBlock
Inconsistent inner class entries for net/minecraft/world/entity/monster/Phantom$AttackPhase!
  Old: AttackPhase private static final MEMBER net/minecraft/world/entity/monster/Phantom$PhantomSweepAttackGoal
  New: AttackPhase static final MEMBER net/minecraft/world/entity/monster/Phantom$AttackPhase
Inconsistent inner class entries for net/minecraft/client/gui/components/CycleButton$ValueListSupplier!
  Old: ValueListSupplier private abstract static MEMBER net/minecraft/client/gui/components/CycleButton$Builder
  New: ValueListSupplier abstract static MEMBER net/minecraft/client/gui/components/CycleButton$ValueListSupplier
Inconsistent inner class entries for net/minecraft/world/entity/ai/gossip/GossipContainer$EntityGossips!
  Old: EntityGossips static MEMBER net/minecraft/world/entity/ai/gossip/GossipContainer$EntityGossips
  New: EntityGossips private static MEMBER net/minecraft/world/entity/ai/gossip/GossipContainer
Inconsistent inner class entries for net/minecraft/world/entity/monster/Vindicator$VindicatorBreakDoorGoal!
  Old: VindicatorBreakDoorGoal static MEMBER net/minecraft/world/entity/monster/Vindicator$VindicatorBreakDoorGoal
  New: VindicatorBreakDoorGoal private static MEMBER net/minecraft/world/entity/monster/Vindicator
Inconsistent inner class entries for net/minecraft/world/entity/monster/Vindicator$VindicatorJohnnyAttackGoal!
  Old: VindicatorJohnnyAttackGoal static MEMBER net/minecraft/world/entity/monster/Vindicator$VindicatorJohnnyAttackGoal
  New: VindicatorJohnnyAttackGoal private static MEMBER net/minecraft/world/entity/monster/Vindicator
Inconsistent inner class entries for net/minecraft/server/commands/AdvancementCommands$Mode!
  Old: Mode static final MEMBER net/minecraft/server/commands/AdvancementCommands$Mode
  New: Mode private static final MEMBER net/minecraft/server/commands/AdvancementCommands
Inconsistent inner class entries for net/minecraft/server/level/ServerLevel$EntityCallbacks!
  Old: EntityCallbacks private final MEMBER net/minecraft/server/level/ServerLevel
  New: EntityCallbacks final MEMBER net/minecraft/server/level/ServerLevel$EntityCallbacks
Inconsistent inner class entries for net/minecraft/world/entity/animal/PolarBear$PolarBearPanicGoal!
  Old: PolarBearPanicGoal  MEMBER net/minecraft/world/entity/animal/PolarBear$PolarBearPanicGoal
  New: PolarBearPanicGoal private MEMBER net/minecraft/world/entity/animal/PolarBear
Inconsistent inner class entries for net/minecraft/world/entity/animal/PolarBear$PolarBearAttackPlayersGoal!
  Old: PolarBearAttackPlayersGoal  MEMBER net/minecraft/world/entity/animal/PolarBear$PolarBearAttackPlayersGoal
  New: PolarBearAttackPlayersGoal private MEMBER net/minecraft/world/entity/animal/PolarBear
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$ThirdFloorRoomCollection!
  Old: ThirdFloorRoomCollection private static MEMBER net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces
  New: ThirdFloorRoomCollection static MEMBER net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$ThirdFloorRoomCollection
Inconsistent inner class entries for com/mojang/blaze3d/vertex/VertexFormatElement$Usage$SetupState!
  Old: SetupState private abstract static MEMBER com/mojang/blaze3d/vertex/VertexFormatElement
  New: SetupState abstract static MEMBER com/mojang/blaze3d/vertex/VertexFormatElement$Usage$SetupState
Inconsistent inner class entries for net/minecraft/client/gui/spectator/categories/TeleportToTeamMenuCategory$TeamSelectionItem!
  Old: TeamSelectionItem  MEMBER net/minecraft/client/gui/spectator/categories/TeleportToTeamMenuCategory$TeamSelectionItem
  New: TeamSelectionItem private MEMBER net/minecraft/client/gui/spectator/categories/TeleportToTeamMenuCategory
Inconsistent inner class entries for net/minecraft/client/renderer/RenderStateShard$BooleanStateShard!
  Old: BooleanStateShard private static MEMBER net/minecraft/client/renderer/RenderStateShard$LightmapStateShard
  New: BooleanStateShard static MEMBER net/minecraft/client/renderer/RenderStateShard$BooleanStateShard
Inconsistent inner class entries for net/minecraft/server/level/DistanceManager$FixedPlayerDistanceChunkTracker!
  Old: FixedPlayerDistanceChunkTracker private MEMBER net/minecraft/server/level/DistanceManager$PlayerTicketTracker
  New: FixedPlayerDistanceChunkTracker  MEMBER net/minecraft/server/level/DistanceManager$FixedPlayerDistanceChunkTracker
Inconsistent inner class entries for net/minecraft/client/particle/DripParticle$FallingParticle!
  Old: FallingParticle static MEMBER net/minecraft/client/particle/DripParticle$FallingParticle
  New: FallingParticle private static MEMBER net/minecraft/client/particle/DripParticle$SporeBlossomFallProvider
Inconsistent inner class entries for net/minecraft/client/resources/model/ModelBakery$BlockStateDefinitionException!
  Old: BlockStateDefinitionException static MEMBER net/minecraft/client/resources/model/ModelBakery$BlockStateDefinitionException
  New: BlockStateDefinitionException private static MEMBER net/minecraft/client/resources/model/ModelBakery
Inconsistent inner class entries for net/minecraft/client/resources/model/ModelBakery$ModelGroupKey!
  Old: ModelGroupKey static MEMBER net/minecraft/client/resources/model/ModelBakery$ModelGroupKey
  New: ModelGroupKey private static MEMBER net/minecraft/client/resources/model/ModelBakery
Inconsistent inner class entries for net/minecraft/client/particle/DripParticle$DripHangParticle!
  Old: DripHangParticle static MEMBER net/minecraft/client/particle/DripParticle$DripHangParticle
  New: DripHangParticle private static MEMBER net/minecraft/client/particle/DripParticle$CoolingDripHangParticle
Inconsistent inner class entries for net/minecraft/client/particle/DripParticle$CoolingDripHangParticle!
  Old: CoolingDripHangParticle private static MEMBER net/minecraft/client/particle/DripParticle$DripstoneLavaHangProvider
  New: CoolingDripHangParticle static MEMBER net/minecraft/client/particle/DripParticle$CoolingDripHangParticle
Inconsistent inner class entries for com/mojang/realmsclient/gui/screens/RealmsSelectWorldTemplateScreen$WorldTemplateObjectSelectionList!
  Old: WorldTemplateObjectSelectionList  MEMBER com/mojang/realmsclient/gui/screens/RealmsSelectWorldTemplateScreen$WorldTemplateObjectSelectionList
  New: WorldTemplateObjectSelectionList private MEMBER com/mojang/realmsclient/gui/screens/RealmsSelectWorldTemplateScreen
Inconsistent inner class entries for com/mojang/realmsclient/gui/screens/RealmsSelectWorldTemplateScreen$Entry!
  Old: Entry  MEMBER com/mojang/realmsclient/gui/screens/RealmsSelectWorldTemplateScreen$Entry
  New: Entry private MEMBER com/mojang/realmsclient/gui/screens/RealmsSelectWorldTemplateScreen
Inconsistent inner class entries for net/minecraft/world/entity/animal/Fox$FoxBehaviorGoal!
  Old: FoxBehaviorGoal private abstract MEMBER net/minecraft/world/entity/animal/Fox$PerchAndSearchGoal
  New: FoxBehaviorGoal abstract MEMBER net/minecraft/world/entity/animal/Fox$FoxBehaviorGoal
Inconsistent inner class entries for net/minecraft/client/particle/DripParticle$FallingParticle!
  Old: FallingParticle static MEMBER net/minecraft/client/particle/DripParticle$FallingParticle
  New: FallingParticle private static MEMBER net/minecraft/client/particle/DripParticle$NectarFallProvider
Inconsistent inner class entries for net/minecraft/client/gui/screens/debug/GameModeSwitcherScreen$GameModeIcon!
  Old: GameModeIcon private static final MEMBER net/minecraft/client/gui/screens/debug/GameModeSwitcherScreen$GameModeSlot
  New: GameModeIcon static final MEMBER net/minecraft/client/gui/screens/debug/GameModeSwitcherScreen$GameModeIcon
Inconsistent inner class entries for com/mojang/realmsclient/gui/screens/RealmsPlayerScreen$UserAction!
  Old: UserAction private static final MEMBER com/mojang/realmsclient/gui/screens/RealmsPlayerScreen$InvitedObjectSelectionList
  New: UserAction static final MEMBER com/mojang/realmsclient/gui/screens/RealmsPlayerScreen$UserAction
Inconsistent inner class entries for net/minecraft/world/entity/npc/VillagerTrades$EnchantedItemForEmeralds!
  Old: EnchantedItemForEmeralds private static MEMBER net/minecraft/world/entity/npc/VillagerTrades
  New: EnchantedItemForEmeralds static MEMBER net/minecraft/world/entity/npc/VillagerTrades$EnchantedItemForEmeralds
Inconsistent inner class entries for net/minecraft/world/level/storage/loot/GsonAdapterFactory$JsonAdapter!
  Old: JsonAdapter private static MEMBER net/minecraft/world/level/storage/loot/GsonAdapterFactory
  New: JsonAdapter static MEMBER net/minecraft/world/level/storage/loot/GsonAdapterFactory$JsonAdapter
Inconsistent inner class entries for net/minecraft/world/entity/ai/gossip/GossipContainer$GossipEntry!
  Old: GossipEntry private static MEMBER net/minecraft/world/entity/ai/gossip/GossipContainer$EntityGossips
  New: GossipEntry static MEMBER net/minecraft/world/entity/ai/gossip/GossipContainer$GossipEntry
Inconsistent inner class entries for com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen$PendingInvitationSelectionList!
  Old: PendingInvitationSelectionList  MEMBER com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen$PendingInvitationSelectionList
  New: PendingInvitationSelectionList private MEMBER com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen$1
Inconsistent inner class entries for com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen$PendingInvitationSelectionList!
  Old: PendingInvitationSelectionList  MEMBER com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen$PendingInvitationSelectionList
  New: PendingInvitationSelectionList private MEMBER com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen$3
Inconsistent inner class entries for com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen$PendingInvitationSelectionList!
  Old: PendingInvitationSelectionList  MEMBER com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen$PendingInvitationSelectionList
  New: PendingInvitationSelectionList private MEMBER com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen$2
Inconsistent inner class entries for net/minecraft/world/level/storage/loot/functions/CopyNbtFunction$CopyOperation!
  Old: CopyOperation private static MEMBER net/minecraft/world/level/storage/loot/functions/CopyNbtFunction$Builder
  New: CopyOperation static MEMBER net/minecraft/world/level/storage/loot/functions/CopyNbtFunction$CopyOperation
Inconsistent inner class entries for net/minecraft/world/level/biome/Biome$ClimateSettings!
  Old: ClimateSettings static MEMBER net/minecraft/world/level/biome/Biome$ClimateSettings
  New: ClimateSettings private static MEMBER net/minecraft/world/level/biome/Biome
Inconsistent inner class entries for net/minecraft/world/level/levelgen/VerticalAnchor$BelowTop!
  Old: BelowTop private static final MEMBER net/minecraft/world/level/levelgen/VerticalAnchor
  New: BelowTop static final MEMBER net/minecraft/world/level/levelgen/VerticalAnchor$BelowTop
Inconsistent inner class entries for net/minecraft/server/network/ServerGamePacketListenerImpl$EntityInteraction!
  Old: EntityInteraction private abstract static MEMBER net/minecraft/server/network/ServerGamePacketListenerImpl
  New: EntityInteraction abstract static MEMBER net/minecraft/server/network/ServerGamePacketListenerImpl$EntityInteraction
Inconsistent inner class entries for net/minecraft/client/StringSplitter$WidthLimitedCharSink!
  Old: WidthLimitedCharSink  MEMBER net/minecraft/client/StringSplitter$WidthLimitedCharSink
  New: WidthLimitedCharSink private MEMBER net/minecraft/client/StringSplitter$1
Inconsistent inner class entries for net/minecraft/client/renderer/texture/TextureAtlasSprite$FrameInfo!
  Old: FrameInfo private static MEMBER net/minecraft/client/renderer/texture/TextureAtlasSprite$InterpolationData
  New: FrameInfo static MEMBER net/minecraft/client/renderer/texture/TextureAtlasSprite$FrameInfo
Inconsistent inner class entries for com/mojang/blaze3d/platform/GlStateManager$BooleanState!
  Old: BooleanState private static MEMBER com/mojang/blaze3d/platform/GlStateManager$CullState
  New: BooleanState static MEMBER com/mojang/blaze3d/platform/GlStateManager$BooleanState
Inconsistent inner class entries for net/minecraft/client/color/block/BlockTintCache$LatestCacheInfo!
  Old: LatestCacheInfo static MEMBER net/minecraft/client/color/block/BlockTintCache$LatestCacheInfo
  New: LatestCacheInfo private static MEMBER net/minecraft/client/color/block/BlockTintCache
Inconsistent inner class entries for net/minecraft/world/level/GameRules$VisitorCaller!
  Old: VisitorCaller abstract static MEMBER net/minecraft/world/level/GameRules$VisitorCaller
  New: VisitorCaller private abstract static MEMBER net/minecraft/world/level/GameRules
Inconsistent inner class entries for net/minecraft/client/gui/screens/worldselection/CreateWorldScreen$OperationFailedException!
  Old: OperationFailedException static MEMBER net/minecraft/client/gui/screens/worldselection/CreateWorldScreen$OperationFailedException
  New: OperationFailedException private static MEMBER net/minecraft/client/gui/screens/worldselection/CreateWorldScreen
Inconsistent inner class entries for net/minecraft/world/entity/animal/AbstractFish$FishSwimGoal!
  Old: FishSwimGoal private static MEMBER net/minecraft/world/entity/animal/AbstractFish
  New: FishSwimGoal static MEMBER net/minecraft/world/entity/animal/AbstractFish$FishSwimGoal
Inconsistent inner class entries for net/minecraft/client/particle/DripParticle$FallAndLandParticle!
  Old: FallAndLandParticle static MEMBER net/minecraft/client/particle/DripParticle$FallAndLandParticle
  New: FallAndLandParticle private static MEMBER net/minecraft/client/particle/DripParticle$DripstoneFallAndLandParticle
Inconsistent inner class entries for net/minecraft/client/particle/DripParticle$DripstoneFallAndLandParticle!
  Old: DripstoneFallAndLandParticle private static MEMBER net/minecraft/client/particle/DripParticle$DripstoneLavaFallProvider
  New: DripstoneFallAndLandParticle static MEMBER net/minecraft/client/particle/DripParticle$DripstoneFallAndLandParticle
Inconsistent inner class entries for net/minecraft/client/gui/components/CycleButton$ValueListSupplier!
  Old: ValueListSupplier abstract static MEMBER net/minecraft/client/gui/components/CycleButton$ValueListSupplier
  New: ValueListSupplier private abstract static MEMBER net/minecraft/client/gui/components/CycleButton$ValueListSupplier$1
Inconsistent inner class entries for net/minecraft/client/gui/components/CycleButton$ValueListSupplier!
  Old: ValueListSupplier abstract static MEMBER net/minecraft/client/gui/components/CycleButton$ValueListSupplier
  New: ValueListSupplier private abstract static MEMBER net/minecraft/client/gui/components/CycleButton$ValueListSupplier$2
Inconsistent inner class entries for net/minecraft/server/packs/resources/FallbackResourceManager$LeakedResourceWarningInputStream!
  Old: LeakedResourceWarningInputStream private static MEMBER net/minecraft/server/packs/resources/FallbackResourceManager
  New: LeakedResourceWarningInputStream static MEMBER net/minecraft/server/packs/resources/FallbackResourceManager$LeakedResourceWarningInputStream
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$MansionPiecePlacer!
  Old: MansionPiecePlacer private static MEMBER net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces
  New: MansionPiecePlacer static MEMBER net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$MansionPiecePlacer
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$FloorRoomCollection!
  Old: FloorRoomCollection abstract static MEMBER net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$FloorRoomCollection
  New: FloorRoomCollection private abstract static MEMBER net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$MansionPiecePlacer
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$ThirdFloorRoomCollection!
  Old: ThirdFloorRoomCollection static MEMBER net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$ThirdFloorRoomCollection
  New: ThirdFloorRoomCollection private static MEMBER net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$MansionPiecePlacer
Inconsistent inner class entries for net/minecraft/world/entity/animal/Fox$FoxBreedGoal!
  Old: FoxBreedGoal private MEMBER net/minecraft/world/entity/animal/Fox
  New: FoxBreedGoal  MEMBER net/minecraft/world/entity/animal/Fox$FoxBreedGoal
Inconsistent inner class entries for net/minecraft/client/Minecraft$ExperimentalDialogType!
  Old: ExperimentalDialogType static final MEMBER net/minecraft/client/Minecraft$ExperimentalDialogType
  New: ExperimentalDialogType private static final MEMBER net/minecraft/client/Minecraft
Inconsistent inner class entries for net/minecraft/world/level/storage/loot/functions/ApplyBonusCount$FormulaDeserializer!
  Old: FormulaDeserializer private abstract static MEMBER net/minecraft/world/level/storage/loot/functions/ApplyBonusCount$Serializer
  New: FormulaDeserializer abstract static MEMBER net/minecraft/world/level/storage/loot/functions/ApplyBonusCount$FormulaDeserializer
Inconsistent inner class entries for net/minecraft/server/rcon/thread/QueryThreadGs4$RequestChallenge!
  Old: RequestChallenge private static MEMBER net/minecraft/server/rcon/thread/QueryThreadGs4
  New: RequestChallenge static MEMBER net/minecraft/server/rcon/thread/QueryThreadGs4$RequestChallenge
Inconsistent inner class entries for com/mojang/realmsclient/RealmsMainScreen$Entry!
  Old: Entry abstract MEMBER com/mojang/realmsclient/RealmsMainScreen$Entry
  New: Entry private abstract MEMBER com/mojang/realmsclient/RealmsMainScreen$RealmSelectionList
Inconsistent inner class entries for net/minecraft/world/entity/animal/goat/Goat$GoatPathNavigation!
  Old: GoatPathNavigation private static MEMBER net/minecraft/world/entity/animal/goat/Goat
  New: GoatPathNavigation static MEMBER net/minecraft/world/entity/animal/goat/Goat$GoatPathNavigation
Inconsistent inner class entries for net/minecraft/server/commands/FillCommand$Mode!
  Old: Mode private static final MEMBER net/minecraft/server/commands/FillCommand
  New: Mode static final MEMBER net/minecraft/server/commands/FillCommand$Mode
Inconsistent inner class entries for net/minecraft/world/entity/animal/Cat$CatAvoidEntityGoal!
  Old: CatAvoidEntityGoal private static MEMBER net/minecraft/world/entity/animal/Cat
  New: CatAvoidEntityGoal static MEMBER net/minecraft/world/entity/animal/Cat$CatAvoidEntityGoal
Inconsistent inner class entries for net/minecraft/util/datafix/fixes/ChunkPalettedStorageFix$UpgradeChunk!
  Old: UpgradeChunk private static final MEMBER net/minecraft/util/datafix/fixes/ChunkPalettedStorageFix
  New: UpgradeChunk static final MEMBER net/minecraft/util/datafix/fixes/ChunkPalettedStorageFix$UpgradeChunk
Inconsistent inner class entries for net/minecraft/commands/arguments/blocks/BlockPredicateArgument$BlockPredicate!
  Old: BlockPredicate static MEMBER net/minecraft/commands/arguments/blocks/BlockPredicateArgument$BlockPredicate
  New: BlockPredicate private static MEMBER net/minecraft/commands/arguments/blocks/BlockPredicateArgument
Inconsistent inner class entries for net/minecraft/commands/arguments/blocks/BlockPredicateArgument$TagPredicate!
  Old: TagPredicate static MEMBER net/minecraft/commands/arguments/blocks/BlockPredicateArgument$TagPredicate
  New: TagPredicate private static MEMBER net/minecraft/commands/arguments/blocks/BlockPredicateArgument
Inconsistent inner class entries for net/minecraft/world/entity/monster/Silverfish$SilverfishWakeUpFriendsGoal!
  Old: SilverfishWakeUpFriendsGoal private static MEMBER net/minecraft/world/entity/monster/Silverfish
  New: SilverfishWakeUpFriendsGoal static MEMBER net/minecraft/world/entity/monster/Silverfish$SilverfishWakeUpFriendsGoal
Inconsistent inner class entries for net/minecraft/commands/arguments/NbtPathArgument$Node!
  Old: Node private abstract static MEMBER net/minecraft/commands/arguments/NbtPathArgument$MatchElementNode
  New: Node abstract static MEMBER net/minecraft/commands/arguments/NbtPathArgument$Node
Inconsistent inner class entries for net/minecraft/world/level/storage/loot/functions/SetAttributesFunction$Modifier!
  Old: Modifier private static MEMBER net/minecraft/world/level/storage/loot/functions/SetAttributesFunction
  New: Modifier static MEMBER net/minecraft/world/level/storage/loot/functions/SetAttributesFunction$Modifier
Inconsistent inner class entries for net/minecraft/world/level/biome/MultiNoiseBiomeSource$NoiseParameters!
  Old: NoiseParameters private static MEMBER net/minecraft/world/level/biome/MultiNoiseBiomeSource
  New: NoiseParameters static MEMBER net/minecraft/world/level/biome/MultiNoiseBiomeSource$NoiseParameters
Inconsistent inner class entries for net/minecraft/server/level/ThreadedLevelLightEngine$TaskType!
  Old: TaskType private static final MEMBER net/minecraft/server/level/ThreadedLevelLightEngine
  New: TaskType static final MEMBER net/minecraft/server/level/ThreadedLevelLightEngine$TaskType
Inconsistent inner class entries for net/minecraft/world/item/crafting/Ingredient$Value!
  Old: Value private abstract static MEMBER net/minecraft/world/item/crafting/Ingredient$ItemValue
  New: Value abstract static MEMBER net/minecraft/world/item/crafting/Ingredient$Value
Inconsistent inner class entries for net/minecraft/world/level/storage/loot/providers/nbt/ContextNbtProvider$Getter!
  Old: Getter private abstract static MEMBER net/minecraft/world/level/storage/loot/providers/nbt/ContextNbtProvider
  New: Getter abstract static MEMBER net/minecraft/world/level/storage/loot/providers/nbt/ContextNbtProvider$Getter
Inconsistent inner class entries for net/minecraft/network/protocol/game/ClientboundBossEventPacket$UpdateProgressOperation!
  Old: UpdateProgressOperation private static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$OperationType
  New: UpdateProgressOperation static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$UpdateProgressOperation
Inconsistent inner class entries for net/minecraft/network/protocol/game/ClientboundBossEventPacket$OperationType!
  Old: OperationType static final MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$OperationType
  New: OperationType private static final MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$UpdateProgressOperation
Inconsistent inner class entries for net/minecraft/network/protocol/game/ClientboundBossEventPacket$Operation!
  Old: Operation abstract static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$Operation
  New: Operation private abstract static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$UpdateProgressOperation
Inconsistent inner class entries for net/minecraft/world/level/chunk/ChunkStatus$GenerationTask!
  Old: GenerationTask private abstract static MEMBER net/minecraft/world/level/chunk/ChunkStatus$SimpleGenerationTask
  New: GenerationTask abstract static MEMBER net/minecraft/world/level/chunk/ChunkStatus$GenerationTask
Inconsistent inner class entries for net/minecraft/world/entity/animal/PolarBear$PolarBearHurtByTargetGoal!
  Old: PolarBearHurtByTargetGoal private MEMBER net/minecraft/world/entity/animal/PolarBear
  New: PolarBearHurtByTargetGoal  MEMBER net/minecraft/world/entity/animal/PolarBear$PolarBearHurtByTargetGoal
Inconsistent inner class entries for net/minecraft/world/level/border/WorldBorder$StaticBorderExtent!
  Old: StaticBorderExtent  MEMBER net/minecraft/world/level/border/WorldBorder$StaticBorderExtent
  New: StaticBorderExtent private MEMBER net/minecraft/world/level/border/WorldBorder$MovingBorderExtent
Inconsistent inner class entries for net/minecraft/world/level/border/WorldBorder$BorderExtent!
  Old: BorderExtent abstract static MEMBER net/minecraft/world/level/border/WorldBorder$BorderExtent
  New: BorderExtent private abstract static MEMBER net/minecraft/world/level/border/WorldBorder$MovingBorderExtent
Inconsistent inner class entries for net/minecraft/client/renderer/item/ItemProperties$CompassWobble!
  Old: CompassWobble private static MEMBER net/minecraft/client/renderer/item/ItemProperties$2
  New: CompassWobble static MEMBER net/minecraft/client/renderer/item/ItemProperties$CompassWobble
Inconsistent inner class entries for net/minecraft/util/datafix/fixes/ChunkPalettedStorageFix$DataLayer!
  Old: DataLayer private static MEMBER net/minecraft/util/datafix/fixes/ChunkPalettedStorageFix
  New: DataLayer static MEMBER net/minecraft/util/datafix/fixes/ChunkPalettedStorageFix$DataLayer
Inconsistent inner class entries for net/minecraft/world/entity/npc/VillagerTrades$EmeraldForItems!
  Old: EmeraldForItems private static MEMBER net/minecraft/world/entity/npc/VillagerTrades
  New: EmeraldForItems static MEMBER net/minecraft/world/entity/npc/VillagerTrades$EmeraldForItems
Inconsistent inner class entries for net/minecraft/network/protocol/game/ServerboundInteractPacket$InteractionAction!
  Old: InteractionAction static MEMBER net/minecraft/network/protocol/game/ServerboundInteractPacket$InteractionAction
  New: InteractionAction private static MEMBER net/minecraft/network/protocol/game/ServerboundInteractPacket
Inconsistent inner class entries for net/minecraft/server/commands/DataPackCommand$Inserter!
  Old: Inserter private abstract static MEMBER net/minecraft/server/commands/DataPackCommand
  New: Inserter abstract static MEMBER net/minecraft/server/commands/DataPackCommand$Inserter
Inconsistent inner class entries for net/minecraft/world/level/block/entity/BeehiveBlockEntity$BeeData!
  Old: BeeData private static MEMBER net/minecraft/world/level/block/entity/BeehiveBlockEntity
  New: BeeData static MEMBER net/minecraft/world/level/block/entity/BeehiveBlockEntity$BeeData
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/StrongholdPieces$SmoothStoneSelector!
  Old: SmoothStoneSelector private static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$LeftTurn
  New: SmoothStoneSelector static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$SmoothStoneSelector
Inconsistent inner class entries for net/minecraft/network/protocol/game/ClientboundBossEventPacket$Operation!
  Old: Operation abstract static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$Operation
  New: Operation private abstract static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket
Inconsistent inner class entries for net/minecraft/network/protocol/game/ClientboundBossEventPacket$OperationType!
  Old: OperationType static final MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$OperationType
  New: OperationType private static final MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket
Inconsistent inner class entries for net/minecraft/network/protocol/game/ClientboundBossEventPacket$UpdateProgressOperation!
  Old: UpdateProgressOperation static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$UpdateProgressOperation
  New: UpdateProgressOperation private static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket
Inconsistent inner class entries for net/minecraft/network/protocol/game/ClientboundBossEventPacket$UpdateStyleOperation!
  Old: UpdateStyleOperation static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$UpdateStyleOperation
  New: UpdateStyleOperation private static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket
Inconsistent inner class entries for net/minecraft/network/protocol/game/ClientboundBossEventPacket$UpdatePropertiesOperation!
  Old: UpdatePropertiesOperation static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$UpdatePropertiesOperation
  New: UpdatePropertiesOperation private static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket
Inconsistent inner class entries for net/minecraft/world/entity/animal/Panda$PandaLookAtPlayerGoal!
  Old: PandaLookAtPlayerGoal static MEMBER net/minecraft/world/entity/animal/Panda$PandaLookAtPlayerGoal
  New: PandaLookAtPlayerGoal private static MEMBER net/minecraft/world/entity/animal/Panda$PandaBreedGoal
Inconsistent inner class entries for net/minecraft/client/renderer/LevelRenderer$RenderChunkInfo!
  Old: RenderChunkInfo static MEMBER net/minecraft/client/renderer/LevelRenderer$RenderChunkInfo
  New: RenderChunkInfo private static MEMBER net/minecraft/client/renderer/LevelRenderer$RenderInfoMap
Inconsistent inner class entries for net/minecraft/world/entity/monster/Strider$StriderGoToLavaGoal!
  Old: StriderGoToLavaGoal private static MEMBER net/minecraft/world/entity/monster/Strider
  New: StriderGoToLavaGoal static MEMBER net/minecraft/world/entity/monster/Strider$StriderGoToLavaGoal
Inconsistent inner class entries for net/minecraft/client/renderer/chunk/ChunkRenderDispatcher$RenderChunk$ResortTransparencyTask!
  Old: ResortTransparencyTask private MEMBER net/minecraft/client/renderer/chunk/ChunkRenderDispatcher$RenderChunk
  New: ResortTransparencyTask  MEMBER net/minecraft/client/renderer/chunk/ChunkRenderDispatcher$RenderChunk$ResortTransparencyTask
Inconsistent inner class entries for net/minecraft/client/renderer/chunk/ChunkRenderDispatcher$ChunkTaskResult!
  Old: ChunkTaskResult static final MEMBER net/minecraft/client/renderer/chunk/ChunkRenderDispatcher$ChunkTaskResult
  New: ChunkTaskResult private static final MEMBER net/minecraft/client/renderer/chunk/ChunkRenderDispatcher$RenderChunk$ResortTransparencyTask
Inconsistent inner class entries for com/mojang/realmsclient/gui/screens/RealmsResetWorldScreen$FrameButton!
  Old: FrameButton private MEMBER com/mojang/realmsclient/gui/screens/RealmsResetWorldScreen
  New: FrameButton  MEMBER com/mojang/realmsclient/gui/screens/RealmsResetWorldScreen$FrameButton
Inconsistent inner class entries for net/minecraft/client/gui/screens/inventory/BeaconScreen$BeaconConfirmButton!
  Old: BeaconConfirmButton  MEMBER net/minecraft/client/gui/screens/inventory/BeaconScreen$BeaconConfirmButton
  New: BeaconConfirmButton private MEMBER net/minecraft/client/gui/screens/inventory/BeaconScreen
Inconsistent inner class entries for net/minecraft/client/gui/screens/inventory/BeaconScreen$BeaconPowerButton!
  Old: BeaconPowerButton  MEMBER net/minecraft/client/gui/screens/inventory/BeaconScreen$BeaconPowerButton
  New: BeaconPowerButton private MEMBER net/minecraft/client/gui/screens/inventory/BeaconScreen
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitDoubleYZRoom!
  Old: FitDoubleYZRoom static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitDoubleYZRoom
  New: FitDoubleYZRoom private static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$MonumentBuilding
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitDoubleYRoom!
  Old: FitDoubleYRoom static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitDoubleYRoom
  New: FitDoubleYRoom private static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$MonumentBuilding
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitSimpleRoom!
  Old: FitSimpleRoom static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitSimpleRoom
  New: FitSimpleRoom private static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$MonumentBuilding
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$MonumentRoomFitter!
  Old: MonumentRoomFitter abstract static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$MonumentRoomFitter
  New: MonumentRoomFitter private abstract static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$MonumentBuilding
Inconsistent inner class entries for net/minecraft/world/item/crafting/Ingredient$Value!
  Old: Value abstract static MEMBER net/minecraft/world/item/crafting/Ingredient$Value
  New: Value private abstract static MEMBER net/minecraft/world/item/crafting/Ingredient$TagValue
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/StrongholdPieces$SmoothStoneSelector!
  Old: SmoothStoneSelector static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$SmoothStoneSelector
  New: SmoothStoneSelector private static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$ChestCorridor
Inconsistent inner class entries for com/mojang/blaze3d/platform/GlStateManager$BooleanState!
  Old: BooleanState static MEMBER com/mojang/blaze3d/platform/GlStateManager$BooleanState
  New: BooleanState private static MEMBER com/mojang/blaze3d/platform/GlStateManager$ScissorState
Inconsistent inner class entries for net/minecraft/world/level/GameRules$VisitorCaller!
  Old: VisitorCaller abstract static MEMBER net/minecraft/world/level/GameRules$VisitorCaller
  New: VisitorCaller private abstract static MEMBER net/minecraft/world/level/GameRules$BooleanValue
Inconsistent inner class entries for net/minecraft/world/level/levelgen/VerticalAnchor$Absolute!
  Old: Absolute private static final MEMBER net/minecraft/world/level/levelgen/VerticalAnchor
  New: Absolute static final MEMBER net/minecraft/world/level/levelgen/VerticalAnchor$Absolute
Inconsistent inner class entries for net/minecraft/world/entity/animal/Rabbit$RabbitPanicGoal!
  Old: RabbitPanicGoal private static MEMBER net/minecraft/world/entity/animal/Rabbit
  New: RabbitPanicGoal static MEMBER net/minecraft/world/entity/animal/Rabbit$RabbitPanicGoal
Inconsistent inner class entries for net/minecraft/client/renderer/block/model/ItemOverrides$BakedOverride!
  Old: BakedOverride private static MEMBER net/minecraft/client/renderer/block/model/ItemOverrides
  New: BakedOverride static MEMBER net/minecraft/client/renderer/block/model/ItemOverrides$BakedOverride
Inconsistent inner class entries for net/minecraft/client/renderer/block/model/ItemOverrides$PropertyMatcher!
  Old: PropertyMatcher static MEMBER net/minecraft/client/renderer/block/model/ItemOverrides$PropertyMatcher
  New: PropertyMatcher private static MEMBER net/minecraft/client/renderer/block/model/ItemOverrides$BakedOverride
Inconsistent inner class entries for net/minecraft/world/level/levelgen/feature/LargeDripstoneFeature$WindOffsetter!
  Old: WindOffsetter private static final MEMBER net/minecraft/world/level/levelgen/feature/LargeDripstoneFeature
  New: WindOffsetter static final MEMBER net/minecraft/world/level/levelgen/feature/LargeDripstoneFeature$WindOffsetter
Inconsistent inner class entries for com/mojang/blaze3d/platform/NativeImage$WriteCallback!
  Old: WriteCallback private static MEMBER com/mojang/blaze3d/platform/NativeImage
  New: WriteCallback static MEMBER com/mojang/blaze3d/platform/NativeImage$WriteCallback
Inconsistent inner class entries for net/minecraft/commands/arguments/NbtPathArgument$Node!
  Old: Node abstract static MEMBER net/minecraft/commands/arguments/NbtPathArgument$Node
  New: Node private abstract static MEMBER net/minecraft/commands/arguments/NbtPathArgument$AllElementsNode
Inconsistent inner class entries for net/minecraft/world/inventory/BrewingStandMenu$PotionSlot!
  Old: PotionSlot static MEMBER net/minecraft/world/inventory/BrewingStandMenu$PotionSlot
  New: PotionSlot private static MEMBER net/minecraft/world/inventory/BrewingStandMenu
Inconsistent inner class entries for net/minecraft/world/inventory/BrewingStandMenu$IngredientsSlot!
  Old: IngredientsSlot static MEMBER net/minecraft/world/inventory/BrewingStandMenu$IngredientsSlot
  New: IngredientsSlot private static MEMBER net/minecraft/world/inventory/BrewingStandMenu
Inconsistent inner class entries for net/minecraft/client/particle/DripParticle$CoolingDripHangParticle!
  Old: CoolingDripHangParticle static MEMBER net/minecraft/client/particle/DripParticle$CoolingDripHangParticle
  New: CoolingDripHangParticle private static MEMBER net/minecraft/client/particle/DripParticle$LavaHangProvider
Inconsistent inner class entries for net/minecraft/commands/arguments/NbtPathArgument$Node!
  Old: Node abstract static MEMBER net/minecraft/commands/arguments/NbtPathArgument$Node
  New: Node private abstract static MEMBER net/minecraft/commands/arguments/NbtPathArgument$IndexedElementNode
Inconsistent inner class entries for net/minecraft/client/renderer/chunk/ChunkRenderDispatcher$ChunkTaskResult!
  Old: ChunkTaskResult static final MEMBER net/minecraft/client/renderer/chunk/ChunkRenderDispatcher$ChunkTaskResult
  New: ChunkTaskResult private static final MEMBER net/minecraft/client/renderer/chunk/ChunkRenderDispatcher
Inconsistent inner class entries for net/minecraft/client/renderer/chunk/ChunkRenderDispatcher$RenderChunk$ResortTransparencyTask!
  Old: ResortTransparencyTask  MEMBER net/minecraft/client/renderer/chunk/ChunkRenderDispatcher$RenderChunk$ResortTransparencyTask
  New: ResortTransparencyTask private MEMBER net/minecraft/client/renderer/chunk/ChunkRenderDispatcher
Inconsistent inner class entries for com/mojang/realmsclient/client/FileUpload$CustomInputStreamEntity!
  Old: CustomInputStreamEntity static MEMBER com/mojang/realmsclient/client/FileUpload$CustomInputStreamEntity
  New: CustomInputStreamEntity private static MEMBER com/mojang/realmsclient/client/FileUpload
Inconsistent inner class entries for net/minecraft/client/renderer/block/ModelBlockRenderer$Cache!
  Old: Cache private static MEMBER net/minecraft/client/renderer/block/ModelBlockRenderer$Cache$1
  New: Cache static MEMBER net/minecraft/client/renderer/block/ModelBlockRenderer$Cache
Inconsistent inner class entries for net/minecraft/nbt/ByteTag$Cache!
  Old: Cache private static MEMBER net/minecraft/nbt/ByteTag
  New: Cache static MEMBER net/minecraft/nbt/ByteTag$Cache
Inconsistent inner class entries for net/minecraft/util/monitoring/jmx/MinecraftServerStatistics$AttributeDescription!
  Old: AttributeDescription private static final MEMBER net/minecraft/util/monitoring/jmx/MinecraftServerStatistics
  New: AttributeDescription static final MEMBER net/minecraft/util/monitoring/jmx/MinecraftServerStatistics$AttributeDescription
Inconsistent inner class entries for net/minecraft/world/entity/monster/Ghast$RandomFloatAroundGoal!
  Old: RandomFloatAroundGoal static MEMBER net/minecraft/world/entity/monster/Ghast$RandomFloatAroundGoal
  New: RandomFloatAroundGoal private static MEMBER net/minecraft/world/entity/monster/Ghast
Inconsistent inner class entries for net/minecraft/world/entity/monster/Ghast$GhastLookGoal!
  Old: GhastLookGoal static MEMBER net/minecraft/world/entity/monster/Ghast$GhastLookGoal
  New: GhastLookGoal private static MEMBER net/minecraft/world/entity/monster/Ghast
Inconsistent inner class entries for net/minecraft/client/gui/screens/packs/PackSelectionModel$EntryBase!
  Old: EntryBase abstract MEMBER net/minecraft/client/gui/screens/packs/PackSelectionModel$EntryBase
  New: EntryBase private abstract MEMBER net/minecraft/client/gui/screens/packs/PackSelectionModel$SelectedPackEntry
Inconsistent inner class entries for com/mojang/realmsclient/client/FileDownload$DownloadCountingOutputStream!
  Old: DownloadCountingOutputStream  MEMBER com/mojang/realmsclient/client/FileDownload$DownloadCountingOutputStream
  New: DownloadCountingOutputStream private MEMBER com/mojang/realmsclient/client/FileDownload
Inconsistent inner class entries for com/mojang/realmsclient/client/FileDownload$ProgressListener!
  Old: ProgressListener  MEMBER com/mojang/realmsclient/client/FileDownload$ProgressListener
  New: ProgressListener private MEMBER com/mojang/realmsclient/client/FileDownload
Inconsistent inner class entries for net/minecraft/client/gui/font/providers/BitmapProvider$Glyph!
  Old: Glyph private static final MEMBER net/minecraft/client/gui/font/providers/BitmapProvider$Builder
  New: Glyph static final MEMBER net/minecraft/client/gui/font/providers/BitmapProvider$Glyph
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitDoubleXYRoom!
  Old: FitDoubleXYRoom private static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$MonumentBuilding
  New: FitDoubleXYRoom static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitDoubleXYRoom
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$MonumentRoomFitter!
  Old: MonumentRoomFitter abstract static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$MonumentRoomFitter
  New: MonumentRoomFitter private abstract static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitDoubleXYRoom
Inconsistent inner class entries for net/minecraft/client/particle/DripParticle$FallAndLandParticle!
  Old: FallAndLandParticle static MEMBER net/minecraft/client/particle/DripParticle$FallAndLandParticle
  New: FallAndLandParticle private static MEMBER net/minecraft/client/particle/DripParticle$LavaFallProvider
Inconsistent inner class entries for net/minecraft/client/gui/screens/CreateFlatWorldScreen$DetailsList!
  Old: DetailsList private MEMBER net/minecraft/client/gui/screens/CreateFlatWorldScreen$DetailsList$Entry
  New: DetailsList  MEMBER net/minecraft/client/gui/screens/CreateFlatWorldScreen$DetailsList
Inconsistent inner class entries for net/minecraft/client/gui/screens/CreateFlatWorldScreen$DetailsList$Entry!
  Old: Entry  MEMBER net/minecraft/client/gui/screens/CreateFlatWorldScreen$DetailsList$Entry
  New: Entry private MEMBER net/minecraft/client/gui/screens/CreateFlatWorldScreen$DetailsList
Inconsistent inner class entries for net/minecraft/advancements/critereon/PlayerPredicate$AdvancementPredicate!
  Old: AdvancementPredicate abstract static MEMBER net/minecraft/advancements/critereon/PlayerPredicate$AdvancementPredicate
  New: AdvancementPredicate private abstract static MEMBER net/minecraft/advancements/critereon/PlayerPredicate$AdvancementCriterionsPredicate
Inconsistent inner class entries for com/mojang/blaze3d/vertex/VertexMultiConsumer$Multiple!
  Old: Multiple private static MEMBER com/mojang/blaze3d/vertex/VertexMultiConsumer
  New: Multiple static MEMBER com/mojang/blaze3d/vertex/VertexMultiConsumer$Multiple
Inconsistent inner class entries for net/minecraft/world/level/chunk/storage/IOWorker$PendingStore!
  Old: PendingStore static MEMBER net/minecraft/world/level/chunk/storage/IOWorker$PendingStore
  New: PendingStore private static MEMBER net/minecraft/world/level/chunk/storage/IOWorker
Inconsistent inner class entries for net/minecraft/world/entity/animal/Panda$PandaMoveControl!
  Old: PandaMoveControl static MEMBER net/minecraft/world/entity/animal/Panda$PandaMoveControl
  New: PandaMoveControl private static MEMBER net/minecraft/world/entity/animal/Panda
Inconsistent inner class entries for net/minecraft/world/entity/animal/Panda$PandaBreedGoal!
  Old: PandaBreedGoal  MEMBER net/minecraft/world/entity/animal/Panda$PandaBreedGoal
  New: PandaBreedGoal private MEMBER net/minecraft/world/entity/animal/Panda
Inconsistent inner class entries for net/minecraft/world/entity/animal/Panda$PandaAttackGoal!
  Old: PandaAttackGoal static MEMBER net/minecraft/world/entity/animal/Panda$PandaAttackGoal
  New: PandaAttackGoal private static MEMBER net/minecraft/world/entity/animal/Panda
Inconsistent inner class entries for net/minecraft/world/entity/animal/Panda$PandaAvoidGoal!
  Old: PandaAvoidGoal static MEMBER net/minecraft/world/entity/animal/Panda$PandaAvoidGoal
  New: PandaAvoidGoal private static MEMBER net/minecraft/world/entity/animal/Panda
Inconsistent inner class entries for net/minecraft/world/entity/animal/Panda$PandaLieOnBackGoal!
  Old: PandaLieOnBackGoal static MEMBER net/minecraft/world/entity/animal/Panda$PandaLieOnBackGoal
  New: PandaLieOnBackGoal private static MEMBER net/minecraft/world/entity/animal/Panda
Inconsistent inner class entries for net/minecraft/world/entity/animal/Panda$PandaLookAtPlayerGoal!
  Old: PandaLookAtPlayerGoal static MEMBER net/minecraft/world/entity/animal/Panda$PandaLookAtPlayerGoal
  New: PandaLookAtPlayerGoal private static MEMBER net/minecraft/world/entity/animal/Panda
Inconsistent inner class entries for net/minecraft/world/entity/animal/Panda$PandaRollGoal!
  Old: PandaRollGoal static MEMBER net/minecraft/world/entity/animal/Panda$PandaRollGoal
  New: PandaRollGoal private static MEMBER net/minecraft/world/entity/animal/Panda
Inconsistent inner class entries for net/minecraft/world/entity/animal/Panda$PandaHurtByTargetGoal!
  Old: PandaHurtByTargetGoal static MEMBER net/minecraft/world/entity/animal/Panda$PandaHurtByTargetGoal
  New: PandaHurtByTargetGoal private static MEMBER net/minecraft/world/entity/animal/Panda
Inconsistent inner class entries for net/minecraft/world/level/block/state/pattern/BlockPattern$BlockCacheLoader!
  Old: BlockCacheLoader static MEMBER net/minecraft/world/level/block/state/pattern/BlockPattern$BlockCacheLoader
  New: BlockCacheLoader private static MEMBER net/minecraft/world/level/block/state/pattern/BlockPattern
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitDoubleYZRoom!
  Old: FitDoubleYZRoom static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitDoubleYZRoom
  New: FitDoubleYZRoom private static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitDoubleXYRoom!
  Old: FitDoubleXYRoom static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitDoubleXYRoom
  New: FitDoubleXYRoom private static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitDoubleYRoom!
  Old: FitDoubleYRoom static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitDoubleYRoom
  New: FitDoubleYRoom private static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitSimpleRoom!
  Old: FitSimpleRoom static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitSimpleRoom
  New: FitSimpleRoom private static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$MonumentRoomFitter!
  Old: MonumentRoomFitter abstract static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$MonumentRoomFitter
  New: MonumentRoomFitter private abstract static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces
Inconsistent inner class entries for net/minecraft/world/entity/animal/Rabbit$RabbitAvoidEntityGoal!
  Old: RabbitAvoidEntityGoal private static MEMBER net/minecraft/world/entity/animal/Rabbit
  New: RabbitAvoidEntityGoal static MEMBER net/minecraft/world/entity/animal/Rabbit$RabbitAvoidEntityGoal
Inconsistent inner class entries for net/minecraft/client/gui/screens/packs/PackSelectionModel$SelectedPackEntry!
  Old: SelectedPackEntry  MEMBER net/minecraft/client/gui/screens/packs/PackSelectionModel$SelectedPackEntry
  New: SelectedPackEntry private MEMBER net/minecraft/client/gui/screens/packs/PackSelectionModel
Inconsistent inner class entries for net/minecraft/client/gui/screens/packs/PackSelectionModel$EntryBase!
  Old: EntryBase abstract MEMBER net/minecraft/client/gui/screens/packs/PackSelectionModel$EntryBase
  New: EntryBase private abstract MEMBER net/minecraft/client/gui/screens/packs/PackSelectionModel
Inconsistent inner class entries for net/minecraft/client/renderer/texture/TextureAtlasSprite$AnimatedTexture!
  Old: AnimatedTexture private MEMBER net/minecraft/client/renderer/texture/TextureAtlasSprite$InterpolationData
  New: AnimatedTexture  MEMBER net/minecraft/client/renderer/texture/TextureAtlasSprite$AnimatedTexture
Inconsistent inner class entries for net/minecraft/client/renderer/texture/TextureAtlasSprite$InterpolationData!
  Old: InterpolationData final MEMBER net/minecraft/client/renderer/texture/TextureAtlasSprite$InterpolationData
  New: InterpolationData private final MEMBER net/minecraft/client/renderer/texture/TextureAtlasSprite$AnimatedTexture
Inconsistent inner class entries for net/minecraft/client/renderer/texture/TextureAtlasSprite$FrameInfo!
  Old: FrameInfo static MEMBER net/minecraft/client/renderer/texture/TextureAtlasSprite$FrameInfo
  New: FrameInfo private static MEMBER net/minecraft/client/renderer/texture/TextureAtlasSprite$AnimatedTexture
Inconsistent inner class entries for net/minecraft/world/entity/monster/Evoker$EvokerSummonSpellGoal!
  Old: EvokerSummonSpellGoal  MEMBER net/minecraft/world/entity/monster/Evoker$EvokerSummonSpellGoal
  New: EvokerSummonSpellGoal private MEMBER net/minecraft/world/entity/monster/Evoker
Inconsistent inner class entries for net/minecraft/client/gui/screens/CreateBuffetWorldScreen$BiomeList!
  Old: BiomeList  MEMBER net/minecraft/client/gui/screens/CreateBuffetWorldScreen$BiomeList
  New: BiomeList private MEMBER net/minecraft/client/gui/screens/CreateBuffetWorldScreen
Inconsistent inner class entries for net/minecraft/client/gui/screens/CreateBuffetWorldScreen$BiomeList$Entry!
  Old: Entry  MEMBER net/minecraft/client/gui/screens/CreateBuffetWorldScreen$BiomeList$Entry
  New: Entry private MEMBER net/minecraft/client/gui/screens/CreateBuffetWorldScreen
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition!
  Old: RoomDefinition private static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$OceanMonumentDoubleXYRoom
  New: RoomDefinition static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition
Inconsistent inner class entries for net/minecraft/world/entity/animal/Dolphin$DolphinSwimWithPlayerGoal!
  Old: DolphinSwimWithPlayerGoal private static MEMBER net/minecraft/world/entity/animal/Dolphin
  New: DolphinSwimWithPlayerGoal static MEMBER net/minecraft/world/entity/animal/Dolphin$DolphinSwimWithPlayerGoal
Inconsistent inner class entries for net/minecraft/server/network/ServerLoginPacketListenerImpl$State!
  Old: State static final MEMBER net/minecraft/server/network/ServerLoginPacketListenerImpl$State
  New: State private static final MEMBER net/minecraft/server/network/ServerLoginPacketListenerImpl
Inconsistent inner class entries for net/minecraft/world/entity/ai/village/VillageSiege$State!
  Old: State private static final MEMBER net/minecraft/world/entity/ai/village/VillageSiege
  New: State static final MEMBER net/minecraft/world/entity/ai/village/VillageSiege$State
Inconsistent inner class entries for net/minecraft/world/level/chunk/storage/IOWorker$Priority!
  Old: Priority private static final MEMBER net/minecraft/world/level/chunk/storage/IOWorker
  New: Priority static final MEMBER net/minecraft/world/level/chunk/storage/IOWorker$Priority
Inconsistent inner class entries for com/mojang/blaze3d/pipeline/MainTarget$Dimension!
  Old: Dimension static MEMBER com/mojang/blaze3d/pipeline/MainTarget$Dimension
  New: Dimension private static MEMBER com/mojang/blaze3d/pipeline/MainTarget
Inconsistent inner class entries for com/mojang/blaze3d/pipeline/MainTarget$AttachmentState!
  Old: AttachmentState static final MEMBER com/mojang/blaze3d/pipeline/MainTarget$AttachmentState
  New: AttachmentState private static final MEMBER com/mojang/blaze3d/pipeline/MainTarget
Inconsistent inner class entries for net/minecraft/util/datafix/fixes/WorldGenSettingsFix$StructureFeatureConfiguration!
  Old: StructureFeatureConfiguration private static final MEMBER net/minecraft/util/datafix/fixes/WorldGenSettingsFix
  New: StructureFeatureConfiguration static final MEMBER net/minecraft/util/datafix/fixes/WorldGenSettingsFix$StructureFeatureConfiguration
Inconsistent inner class entries for net/minecraft/server/packs/resources/SimpleReloadableResourceManager$FailingReloadInstance!
  Old: FailingReloadInstance private static MEMBER net/minecraft/server/packs/resources/SimpleReloadableResourceManager
  New: FailingReloadInstance static MEMBER net/minecraft/server/packs/resources/SimpleReloadableResourceManager$FailingReloadInstance
Inconsistent inner class entries for net/minecraft/world/entity/monster/Phantom$AttackPhase!
  Old: AttackPhase static final MEMBER net/minecraft/world/entity/monster/Phantom$AttackPhase
  New: AttackPhase private static final MEMBER net/minecraft/world/entity/monster/Phantom$PhantomAttackStrategyGoal
Inconsistent inner class entries for net/minecraft/world/entity/monster/Evoker$EvokerAttackSpellGoal!
  Old: EvokerAttackSpellGoal private MEMBER net/minecraft/world/entity/monster/Evoker
  New: EvokerAttackSpellGoal  MEMBER net/minecraft/world/entity/monster/Evoker$EvokerAttackSpellGoal
Inconsistent inner class entries for net/minecraft/world/entity/animal/Panda$PandaSneezeGoal!
  Old: PandaSneezeGoal private static MEMBER net/minecraft/world/entity/animal/Panda
  New: PandaSneezeGoal static MEMBER net/minecraft/world/entity/animal/Panda$PandaSneezeGoal
Inconsistent inner class entries for net/minecraft/world/level/block/state/BlockBehaviour$BlockStateBase$Cache!
  Old: Cache static final MEMBER net/minecraft/world/level/block/state/BlockBehaviour$BlockStateBase$Cache
  New: Cache private static final MEMBER net/minecraft/world/level/block/state/BlockBehaviour$BlockStateBase
Inconsistent inner class entries for net/minecraft/world/entity/animal/Fox$FoxFollowParentGoal!
  Old: FoxFollowParentGoal private MEMBER net/minecraft/world/entity/animal/Fox
  New: FoxFollowParentGoal  MEMBER net/minecraft/world/entity/animal/Fox$FoxFollowParentGoal
Inconsistent inner class entries for net/minecraft/world/entity/schedule/ScheduleBuilder$ActivityTransition!
  Old: ActivityTransition static MEMBER net/minecraft/world/entity/schedule/ScheduleBuilder$ActivityTransition
  New: ActivityTransition private static MEMBER net/minecraft/world/entity/schedule/ScheduleBuilder
Inconsistent inner class entries for net/minecraft/network/protocol/game/ServerboundInteractPacket$Action!
  Old: Action private abstract static MEMBER net/minecraft/network/protocol/game/ServerboundInteractPacket$InteractionAction
  New: Action abstract static MEMBER net/minecraft/network/protocol/game/ServerboundInteractPacket$Action
Inconsistent inner class entries for net/minecraft/client/particle/ParticleEngine$SpriteParticleRegistration!
  Old: SpriteParticleRegistration abstract static MEMBER net/minecraft/client/particle/ParticleEngine$SpriteParticleRegistration
  New: SpriteParticleRegistration private abstract static MEMBER net/minecraft/client/particle/ParticleEngine
Inconsistent inner class entries for net/minecraft/client/particle/ParticleEngine$MutableSpriteSet!
  Old: MutableSpriteSet  MEMBER net/minecraft/client/particle/ParticleEngine$MutableSpriteSet
  New: MutableSpriteSet private MEMBER net/minecraft/client/particle/ParticleEngine
Inconsistent inner class entries for net/minecraft/world/level/chunk/LevelChunk$RebindableTickingBlockEntityWrapper!
  Old: RebindableTickingBlockEntityWrapper private MEMBER net/minecraft/world/level/chunk/LevelChunk
  New: RebindableTickingBlockEntityWrapper  MEMBER net/minecraft/world/level/chunk/LevelChunk$RebindableTickingBlockEntityWrapper
Inconsistent inner class entries for net/minecraft/client/particle/FireworkParticles$SparkParticle!
  Old: SparkParticle static MEMBER net/minecraft/client/particle/FireworkParticles$SparkParticle
  New: SparkParticle private static MEMBER net/minecraft/client/particle/FireworkParticles
Inconsistent inner class entries for net/minecraft/world/level/block/entity/BellBlockEntity$ResonationEndAction!
  Old: ResonationEndAction private abstract static MEMBER net/minecraft/world/level/block/entity/BellBlockEntity
  New: ResonationEndAction abstract static MEMBER net/minecraft/world/level/block/entity/BellBlockEntity$ResonationEndAction
Inconsistent inner class entries for com/mojang/blaze3d/vertex/VertexMultiConsumer$Double!
  Old: Double private static MEMBER com/mojang/blaze3d/vertex/VertexMultiConsumer
  New: Double static MEMBER com/mojang/blaze3d/vertex/VertexMultiConsumer$Double
Inconsistent inner class entries for net/minecraft/world/entity/monster/Ghast$GhastShootFireballGoal!
  Old: GhastShootFireballGoal private static MEMBER net/minecraft/world/entity/monster/Ghast
  New: GhastShootFireballGoal static MEMBER net/minecraft/world/entity/monster/Ghast$GhastShootFireballGoal
Inconsistent inner class entries for net/minecraft/client/tutorial/Tutorial$TimedToast!
  Old: TimedToast private static final MEMBER net/minecraft/client/tutorial/Tutorial
  New: TimedToast static final MEMBER net/minecraft/client/tutorial/Tutorial$TimedToast
Inconsistent inner class entries for net/minecraft/world/entity/animal/Bee$BeeBecomeAngryTargetGoal!
  Old: BeeBecomeAngryTargetGoal private static MEMBER net/minecraft/world/entity/animal/Bee
  New: BeeBecomeAngryTargetGoal static MEMBER net/minecraft/world/entity/animal/Bee$BeeBecomeAngryTargetGoal
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition!
  Old: RoomDefinition static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition
  New: RoomDefinition private static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitDoubleZRoom
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitDoubleZRoom!
  Old: FitDoubleZRoom private static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$MonumentBuilding
  New: FitDoubleZRoom static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitDoubleZRoom
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$MonumentRoomFitter!
  Old: MonumentRoomFitter abstract static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$MonumentRoomFitter
  New: MonumentRoomFitter private abstract static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitDoubleZRoom
Inconsistent inner class entries for net/minecraft/world/entity/monster/Ghast$GhastMoveControl!
  Old: GhastMoveControl private static MEMBER net/minecraft/world/entity/monster/Ghast
  New: GhastMoveControl static MEMBER net/minecraft/world/entity/monster/Ghast$GhastMoveControl
Inconsistent inner class entries for net/minecraft/server/players/OldUsersConverter$ConversionError!
  Old: ConversionError static MEMBER net/minecraft/server/players/OldUsersConverter$ConversionError
  New: ConversionError private static MEMBER net/minecraft/server/players/OldUsersConverter$5
Inconsistent inner class entries for net/minecraft/server/players/OldUsersConverter$ConversionError!
  Old: ConversionError static MEMBER net/minecraft/server/players/OldUsersConverter$ConversionError
  New: ConversionError private static MEMBER net/minecraft/server/players/OldUsersConverter$2
Inconsistent inner class entries for net/minecraft/server/players/OldUsersConverter$ConversionError!
  Old: ConversionError static MEMBER net/minecraft/server/players/OldUsersConverter$ConversionError
  New: ConversionError private static MEMBER net/minecraft/server/players/OldUsersConverter$3
Inconsistent inner class entries for net/minecraft/server/players/OldUsersConverter$ConversionError!
  Old: ConversionError static MEMBER net/minecraft/server/players/OldUsersConverter$ConversionError
  New: ConversionError private static MEMBER net/minecraft/server/players/OldUsersConverter$1
Inconsistent inner class entries for net/minecraft/world/entity/animal/Bee$BeeLookControl!
  Old: BeeLookControl private MEMBER net/minecraft/world/entity/animal/Bee
  New: BeeLookControl  MEMBER net/minecraft/world/entity/animal/Bee$BeeLookControl
Inconsistent inner class entries for net/minecraft/world/entity/animal/Bee$BeePollinateGoal!
  Old: BeePollinateGoal  MEMBER net/minecraft/world/entity/animal/Bee$BeePollinateGoal
  New: BeePollinateGoal private MEMBER net/minecraft/world/entity/animal/Bee$BeeLookControl
Inconsistent inner class entries for net/minecraft/world/entity/boss/wither/WitherBoss$WitherDoNothingGoal!
  Old: WitherDoNothingGoal private MEMBER net/minecraft/world/entity/boss/wither/WitherBoss
  New: WitherDoNothingGoal  MEMBER net/minecraft/world/entity/boss/wither/WitherBoss$WitherDoNothingGoal
Inconsistent inner class entries for com/mojang/realmsclient/gui/screens/RealmsSlotOptionsScreen$SettingsSlider!
  Old: SettingsSlider  MEMBER com/mojang/realmsclient/gui/screens/RealmsSlotOptionsScreen$SettingsSlider
  New: SettingsSlider private MEMBER com/mojang/realmsclient/gui/screens/RealmsSlotOptionsScreen
Inconsistent inner class entries for net/minecraft/world/level/storage/loot/IntRange$IntLimiter!
  Old: IntLimiter abstract static MEMBER net/minecraft/world/level/storage/loot/IntRange$IntLimiter
  New: IntLimiter private abstract static MEMBER net/minecraft/world/level/storage/loot/IntRange
Inconsistent inner class entries for net/minecraft/world/level/storage/loot/IntRange$IntChecker!
  Old: IntChecker abstract static MEMBER net/minecraft/world/level/storage/loot/IntRange$IntChecker
  New: IntChecker private abstract static MEMBER net/minecraft/world/level/storage/loot/IntRange
Inconsistent inner class entries for net/minecraft/world/entity/monster/Slime$SlimeFloatGoal!
  Old: SlimeFloatGoal static MEMBER net/minecraft/world/entity/monster/Slime$SlimeFloatGoal
  New: SlimeFloatGoal private static MEMBER net/minecraft/world/entity/monster/Slime
Inconsistent inner class entries for net/minecraft/world/entity/monster/Slime$SlimeAttackGoal!
  Old: SlimeAttackGoal static MEMBER net/minecraft/world/entity/monster/Slime$SlimeAttackGoal
  New: SlimeAttackGoal private static MEMBER net/minecraft/world/entity/monster/Slime
Inconsistent inner class entries for net/minecraft/world/entity/monster/Slime$SlimeRandomDirectionGoal!
  Old: SlimeRandomDirectionGoal static MEMBER net/minecraft/world/entity/monster/Slime$SlimeRandomDirectionGoal
  New: SlimeRandomDirectionGoal private static MEMBER net/minecraft/world/entity/monster/Slime
Inconsistent inner class entries for net/minecraft/world/entity/monster/Slime$SlimeKeepOnJumpingGoal!
  Old: SlimeKeepOnJumpingGoal static MEMBER net/minecraft/world/entity/monster/Slime$SlimeKeepOnJumpingGoal
  New: SlimeKeepOnJumpingGoal private static MEMBER net/minecraft/world/entity/monster/Slime
Inconsistent inner class entries for net/minecraft/world/entity/animal/Dolphin$DolphinSwimToTreasureGoal!
  Old: DolphinSwimToTreasureGoal private static MEMBER net/minecraft/world/entity/animal/Dolphin
  New: DolphinSwimToTreasureGoal static MEMBER net/minecraft/world/entity/animal/Dolphin$DolphinSwimToTreasureGoal
Inconsistent inner class entries for net/minecraft/network/ConnectionProtocol$PacketSet!
  Old: PacketSet private static MEMBER net/minecraft/network/ConnectionProtocol
  New: PacketSet static MEMBER net/minecraft/network/ConnectionProtocol$PacketSet
Inconsistent inner class entries for net/minecraft/client/gui/screens/debug/GameModeSwitcherScreen$GameModeIcon!
  Old: GameModeIcon static final MEMBER net/minecraft/client/gui/screens/debug/GameModeSwitcherScreen$GameModeIcon
  New: GameModeIcon private static final MEMBER net/minecraft/client/gui/screens/debug/GameModeSwitcherScreen$1
Inconsistent inner class entries for net/minecraft/client/renderer/LevelRenderer$RenderInfoMap!
  Old: RenderInfoMap static MEMBER net/minecraft/client/renderer/LevelRenderer$RenderInfoMap
  New: RenderInfoMap private static MEMBER net/minecraft/client/renderer/LevelRenderer
Inconsistent inner class entries for net/minecraft/client/renderer/LevelRenderer$RenderChunkInfo!
  Old: RenderChunkInfo static MEMBER net/minecraft/client/renderer/LevelRenderer$RenderChunkInfo
  New: RenderChunkInfo private static MEMBER net/minecraft/client/renderer/LevelRenderer
Inconsistent inner class entries for net/minecraft/world/entity/monster/Illusioner$IllusionerMirrorSpellGoal!
  Old: IllusionerMirrorSpellGoal  MEMBER net/minecraft/world/entity/monster/Illusioner$IllusionerMirrorSpellGoal
  New: IllusionerMirrorSpellGoal private MEMBER net/minecraft/world/entity/monster/Illusioner
Inconsistent inner class entries for net/minecraft/world/entity/monster/Illusioner$IllusionerBlindnessSpellGoal!
  Old: IllusionerBlindnessSpellGoal  MEMBER net/minecraft/world/entity/monster/Illusioner$IllusionerBlindnessSpellGoal
  New: IllusionerBlindnessSpellGoal private MEMBER net/minecraft/world/entity/monster/Illusioner
Inconsistent inner class entries for net/minecraft/world/entity/monster/Vindicator$VindicatorMeleeAttackGoal!
  Old: VindicatorMeleeAttackGoal private MEMBER net/minecraft/world/entity/monster/Vindicator
  New: VindicatorMeleeAttackGoal  MEMBER net/minecraft/world/entity/monster/Vindicator$VindicatorMeleeAttackGoal
Inconsistent inner class entries for net/minecraft/network/protocol/game/ClientboundBossEventPacket$AddOperation!
  Old: AddOperation private static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$OperationType
  New: AddOperation static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$AddOperation
Inconsistent inner class entries for net/minecraft/network/protocol/game/ClientboundBossEventPacket$OperationType!
  Old: OperationType static final MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$OperationType
  New: OperationType private static final MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$AddOperation
Inconsistent inner class entries for net/minecraft/network/protocol/game/ClientboundBossEventPacket$Operation!
  Old: Operation abstract static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$Operation
  New: Operation private abstract static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$AddOperation
Inconsistent inner class entries for net/minecraft/world/level/storage/loot/functions/SetAttributesFunction$Modifier!
  Old: Modifier static MEMBER net/minecraft/world/level/storage/loot/functions/SetAttributesFunction$Modifier
  New: Modifier private static MEMBER net/minecraft/world/level/storage/loot/functions/SetAttributesFunction$Serializer
Inconsistent inner class entries for com/mojang/realmsclient/RealmsMainScreen$RealmSelectionList!
  Old: RealmSelectionList  MEMBER com/mojang/realmsclient/RealmsMainScreen$RealmSelectionList
  New: RealmSelectionList private MEMBER com/mojang/realmsclient/RealmsMainScreen
Inconsistent inner class entries for com/mojang/realmsclient/RealmsMainScreen$PendingInvitesButton!
  Old: PendingInvitesButton  MEMBER com/mojang/realmsclient/RealmsMainScreen$PendingInvitesButton
  New: PendingInvitesButton private MEMBER com/mojang/realmsclient/RealmsMainScreen
Inconsistent inner class entries for com/mojang/realmsclient/RealmsMainScreen$NewsButton!
  Old: NewsButton  MEMBER com/mojang/realmsclient/RealmsMainScreen$NewsButton
  New: NewsButton private MEMBER com/mojang/realmsclient/RealmsMainScreen
Inconsistent inner class entries for com/mojang/realmsclient/RealmsMainScreen$ShowPopupButton!
  Old: ShowPopupButton  MEMBER com/mojang/realmsclient/RealmsMainScreen$ShowPopupButton
  New: ShowPopupButton private MEMBER com/mojang/realmsclient/RealmsMainScreen
Inconsistent inner class entries for com/mojang/realmsclient/RealmsMainScreen$CloseButton!
  Old: CloseButton  MEMBER com/mojang/realmsclient/RealmsMainScreen$CloseButton
  New: CloseButton private MEMBER com/mojang/realmsclient/RealmsMainScreen
Inconsistent inner class entries for com/mojang/realmsclient/RealmsMainScreen$Entry!
  Old: Entry abstract MEMBER com/mojang/realmsclient/RealmsMainScreen$Entry
  New: Entry private abstract MEMBER com/mojang/realmsclient/RealmsMainScreen
Inconsistent inner class entries for net/minecraft/world/entity/monster/Slime$SlimeMoveControl!
  Old: SlimeMoveControl private static MEMBER net/minecraft/world/entity/monster/Slime$SlimeRandomDirectionGoal
  New: SlimeMoveControl static MEMBER net/minecraft/world/entity/monster/Slime$SlimeMoveControl
Inconsistent inner class entries for net/minecraft/client/renderer/RenderStateShard$BooleanStateShard!
  Old: BooleanStateShard static MEMBER net/minecraft/client/renderer/RenderStateShard$BooleanStateShard
  New: BooleanStateShard private static MEMBER net/minecraft/client/renderer/RenderStateShard
Inconsistent inner class entries for net/minecraft/client/renderer/RenderType$OutlineProperty!
  Old: OutlineProperty private static final MEMBER net/minecraft/client/renderer/RenderType$CompositeState$CompositeStateBuilder
  New: OutlineProperty static final MEMBER net/minecraft/client/renderer/RenderType$OutlineProperty
Inconsistent inner class entries for net/minecraft/client/renderer/RenderType$OutlineProperty!
  Old: OutlineProperty static final MEMBER net/minecraft/client/renderer/RenderType$OutlineProperty
  New: OutlineProperty private static final MEMBER net/minecraft/client/renderer/RenderType$CompositeState
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/StrongholdPieces$PieceWeight!
  Old: PieceWeight static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$PieceWeight
  New: PieceWeight private static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$2
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/StrongholdPieces$PieceWeight!
  Old: PieceWeight static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$PieceWeight
  New: PieceWeight private static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$1
Inconsistent inner class entries for net/minecraft/world/level/chunk/UpgradeData$BlockFixers!
  Old: BlockFixers private abstract static MEMBER net/minecraft/world/level/chunk/UpgradeData
  New: BlockFixers abstract static MEMBER net/minecraft/world/level/chunk/UpgradeData$BlockFixers
Inconsistent inner class entries for net/minecraft/client/gui/screens/inventory/BeaconScreen$BeaconSpriteScreenButton!
  Old: BeaconSpriteScreenButton private abstract static MEMBER net/minecraft/client/gui/screens/inventory/BeaconScreen$BeaconConfirmButton
  New: BeaconSpriteScreenButton abstract static MEMBER net/minecraft/client/gui/screens/inventory/BeaconScreen$BeaconSpriteScreenButton
Inconsistent inner class entries for net/minecraft/world/entity/animal/PolarBear$PolarBearMeleeAttackGoal!
  Old: PolarBearMeleeAttackGoal private MEMBER net/minecraft/world/entity/animal/PolarBear
  New: PolarBearMeleeAttackGoal  MEMBER net/minecraft/world/entity/animal/PolarBear$PolarBearMeleeAttackGoal
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition!
  Old: RoomDefinition static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition
  New: RoomDefinition private static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitDoubleXRoom
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitDoubleXRoom!
  Old: FitDoubleXRoom private static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$MonumentBuilding
  New: FitDoubleXRoom static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitDoubleXRoom
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$MonumentRoomFitter!
  Old: MonumentRoomFitter abstract static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$MonumentRoomFitter
  New: MonumentRoomFitter private abstract static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitDoubleXRoom
Inconsistent inner class entries for com/mojang/realmsclient/client/FileDownload$ResourcePackProgressListener!
  Old: ResourcePackProgressListener private MEMBER com/mojang/realmsclient/client/FileDownload
  New: ResourcePackProgressListener  MEMBER com/mojang/realmsclient/client/FileDownload$ResourcePackProgressListener
Inconsistent inner class entries for com/mojang/realmsclient/client/FileDownload$DownloadCountingOutputStream!
  Old: DownloadCountingOutputStream  MEMBER com/mojang/realmsclient/client/FileDownload$DownloadCountingOutputStream
  New: DownloadCountingOutputStream private MEMBER com/mojang/realmsclient/client/FileDownload$ResourcePackProgressListener
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$MansionGrid!
  Old: MansionGrid private static MEMBER net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces
  New: MansionGrid static MEMBER net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$MansionGrid
Inconsistent inner class entries for net/minecraft/world/level/levelgen/feature/structures/JigsawPlacement$Placer!
  Old: Placer static final MEMBER net/minecraft/world/level/levelgen/feature/structures/JigsawPlacement$Placer
  New: Placer private static final MEMBER net/minecraft/world/level/levelgen/feature/structures/JigsawPlacement
Inconsistent inner class entries for net/minecraft/world/entity/SpawnPlacements$Data!
  Old: Data static MEMBER net/minecraft/world/entity/SpawnPlacements$Data
  New: Data private static MEMBER net/minecraft/world/entity/SpawnPlacements
Inconsistent inner class entries for net/minecraft/world/entity/animal/Panda$PandaPanicGoal!
  Old: PandaPanicGoal private static MEMBER net/minecraft/world/entity/animal/Panda
  New: PandaPanicGoal static MEMBER net/minecraft/world/entity/animal/Panda$PandaPanicGoal
Inconsistent inner class entries for net/minecraft/client/StringSplitter$LineComponent!
  Old: LineComponent static MEMBER net/minecraft/client/StringSplitter$LineComponent
  New: LineComponent private static MEMBER net/minecraft/client/StringSplitter$FlatComponents
Inconsistent inner class entries for net/minecraft/world/entity/animal/Bee$BeePollinateGoal!
  Old: BeePollinateGoal  MEMBER net/minecraft/world/entity/animal/Bee$BeePollinateGoal
  New: BeePollinateGoal private MEMBER net/minecraft/world/entity/animal/Bee$1
Inconsistent inner class entries for net/minecraft/commands/synchronization/ArgumentTypes$Entry!
  Old: Entry private static MEMBER net/minecraft/commands/synchronization/ArgumentTypes
  New: Entry static MEMBER net/minecraft/commands/synchronization/ArgumentTypes$Entry
Inconsistent inner class entries for net/minecraft/client/gui/screens/achievement/StatsScreen$ItemStatisticsList!
  Old: ItemStatisticsList  MEMBER net/minecraft/client/gui/screens/achievement/StatsScreen$ItemStatisticsList
  New: ItemStatisticsList private MEMBER net/minecraft/client/gui/screens/achievement/StatsScreen$ItemStatisticsList$ItemRow
Inconsistent inner class entries for net/minecraft/client/gui/screens/achievement/StatsScreen$ItemStatisticsList$ItemRow!
  Old: ItemRow private MEMBER net/minecraft/client/gui/screens/achievement/StatsScreen$ItemStatisticsList
  New: ItemRow  MEMBER net/minecraft/client/gui/screens/achievement/StatsScreen$ItemStatisticsList$ItemRow
Inconsistent inner class entries for net/minecraft/util/profiling/FilledProfileResults$CounterCollector!
  Old: CounterCollector private static MEMBER net/minecraft/util/profiling/FilledProfileResults
  New: CounterCollector static MEMBER net/minecraft/util/profiling/FilledProfileResults$CounterCollector
Inconsistent inner class entries for net/minecraft/commands/arguments/NbtPathArgument$Node!
  Old: Node abstract static MEMBER net/minecraft/commands/arguments/NbtPathArgument$Node
  New: Node private abstract static MEMBER net/minecraft/commands/arguments/NbtPathArgument$CompoundChildNode
Inconsistent inner class entries for net/minecraft/client/renderer/RenderStateShard$BooleanStateShard!
  Old: BooleanStateShard static MEMBER net/minecraft/client/renderer/RenderStateShard$BooleanStateShard
  New: BooleanStateShard private static MEMBER net/minecraft/client/renderer/RenderStateShard$CullStateShard
Inconsistent inner class entries for net/minecraft/world/level/storage/loot/functions/LootItemConditionalFunction$DummyBuilder!
  Old: DummyBuilder private static final MEMBER net/minecraft/world/level/storage/loot/functions/LootItemConditionalFunction
  New: DummyBuilder static final MEMBER net/minecraft/world/level/storage/loot/functions/LootItemConditionalFunction$DummyBuilder
Inconsistent inner class entries for net/minecraft/world/entity/animal/Fox$FoxMeleeAttackGoal!
  Old: FoxMeleeAttackGoal private MEMBER net/minecraft/world/entity/animal/Fox
  New: FoxMeleeAttackGoal  MEMBER net/minecraft/world/entity/animal/Fox$FoxMeleeAttackGoal
Inconsistent inner class entries for net/minecraft/world/entity/projectile/FishingHook$FishHookState!
  Old: FishHookState private static final MEMBER net/minecraft/world/entity/projectile/FishingHook
  New: FishHookState static final MEMBER net/minecraft/world/entity/projectile/FishingHook$FishHookState
Inconsistent inner class entries for net/minecraft/data/models/BlockModelGenerators$BlockStateGeneratorSupplier!
  Old: BlockStateGeneratorSupplier abstract static MEMBER net/minecraft/data/models/BlockModelGenerators$BlockStateGeneratorSupplier
  New: BlockStateGeneratorSupplier private abstract static MEMBER net/minecraft/data/models/BlockModelGenerators
Inconsistent inner class entries for net/minecraft/data/models/BlockModelGenerators$WoodProvider!
  Old: WoodProvider  MEMBER net/minecraft/data/models/BlockModelGenerators$WoodProvider
  New: WoodProvider private MEMBER net/minecraft/data/models/BlockModelGenerators
Inconsistent inner class entries for net/minecraft/data/models/BlockModelGenerators$TintState!
  Old: TintState static final MEMBER net/minecraft/data/models/BlockModelGenerators$TintState
  New: TintState private static final MEMBER net/minecraft/data/models/BlockModelGenerators
Inconsistent inner class entries for net/minecraft/data/models/BlockModelGenerators$BlockEntityModelGenerator!
  Old: BlockEntityModelGenerator  MEMBER net/minecraft/data/models/BlockModelGenerators$BlockEntityModelGenerator
  New: BlockEntityModelGenerator private MEMBER net/minecraft/data/models/BlockModelGenerators
Inconsistent inner class entries for com/mojang/blaze3d/preprocessor/GlslPreprocessor$Context!
  Old: Context private static final MEMBER com/mojang/blaze3d/preprocessor/GlslPreprocessor
  New: Context static final MEMBER com/mojang/blaze3d/preprocessor/GlslPreprocessor$Context
Inconsistent inner class entries for net/minecraft/world/level/levelgen/Cavifier$QuantizedSpaghettiRarity!
  Old: QuantizedSpaghettiRarity private static final MEMBER net/minecraft/world/level/levelgen/Cavifier
  New: QuantizedSpaghettiRarity static final MEMBER net/minecraft/world/level/levelgen/Cavifier$QuantizedSpaghettiRarity
Inconsistent inner class entries for net/minecraft/client/gui/screens/achievement/StatsScreen$ItemStatisticsList!
  Old: ItemStatisticsList  MEMBER net/minecraft/client/gui/screens/achievement/StatsScreen$ItemStatisticsList
  New: ItemStatisticsList private MEMBER net/minecraft/client/gui/screens/achievement/StatsScreen
Inconsistent inner class entries for net/minecraft/client/gui/screens/achievement/StatsScreen$MobsStatisticsList!
  Old: MobsStatisticsList  MEMBER net/minecraft/client/gui/screens/achievement/StatsScreen$MobsStatisticsList
  New: MobsStatisticsList private MEMBER net/minecraft/client/gui/screens/achievement/StatsScreen
Inconsistent inner class entries for net/minecraft/client/gui/screens/achievement/StatsScreen$ItemStatisticsList$ItemRow!
  Old: ItemRow  MEMBER net/minecraft/client/gui/screens/achievement/StatsScreen$ItemStatisticsList$ItemRow
  New: ItemRow private MEMBER net/minecraft/client/gui/screens/achievement/StatsScreen
Inconsistent inner class entries for net/minecraft/client/gui/screens/achievement/StatsScreen$ItemStatisticsList$ItemComparator!
  Old: ItemComparator  MEMBER net/minecraft/client/gui/screens/achievement/StatsScreen$ItemStatisticsList$ItemComparator
  New: ItemComparator private MEMBER net/minecraft/client/gui/screens/achievement/StatsScreen
Inconsistent inner class entries for net/minecraft/client/gui/screens/achievement/StatsScreen$GeneralStatisticsList$Entry!
  Old: Entry  MEMBER net/minecraft/client/gui/screens/achievement/StatsScreen$GeneralStatisticsList$Entry
  New: Entry private MEMBER net/minecraft/client/gui/screens/achievement/StatsScreen
Inconsistent inner class entries for com/mojang/blaze3d/platform/GlStateManager$ScissorState!
  Old: ScissorState static MEMBER com/mojang/blaze3d/platform/GlStateManager$ScissorState
  New: ScissorState private static MEMBER com/mojang/blaze3d/platform/GlStateManager
Inconsistent inner class entries for com/mojang/blaze3d/platform/GlStateManager$BooleanState!
  Old: BooleanState static MEMBER com/mojang/blaze3d/platform/GlStateManager$BooleanState
  New: BooleanState private static MEMBER com/mojang/blaze3d/platform/GlStateManager
Inconsistent inner class entries for com/mojang/blaze3d/platform/GlStateManager$DepthState!
  Old: DepthState static MEMBER com/mojang/blaze3d/platform/GlStateManager$DepthState
  New: DepthState private static MEMBER com/mojang/blaze3d/platform/GlStateManager
Inconsistent inner class entries for com/mojang/blaze3d/platform/GlStateManager$CullState!
  Old: CullState static MEMBER com/mojang/blaze3d/platform/GlStateManager$CullState
  New: CullState private static MEMBER com/mojang/blaze3d/platform/GlStateManager
Inconsistent inner class entries for com/mojang/blaze3d/platform/GlStateManager$PolygonOffsetState!
  Old: PolygonOffsetState static MEMBER com/mojang/blaze3d/platform/GlStateManager$PolygonOffsetState
  New: PolygonOffsetState private static MEMBER com/mojang/blaze3d/platform/GlStateManager
Inconsistent inner class entries for com/mojang/blaze3d/platform/GlStateManager$ColorLogicState!
  Old: ColorLogicState static MEMBER com/mojang/blaze3d/platform/GlStateManager$ColorLogicState
  New: ColorLogicState private static MEMBER com/mojang/blaze3d/platform/GlStateManager
Inconsistent inner class entries for com/mojang/blaze3d/platform/GlStateManager$TextureState!
  Old: TextureState static MEMBER com/mojang/blaze3d/platform/GlStateManager$TextureState
  New: TextureState private static MEMBER com/mojang/blaze3d/platform/GlStateManager
Inconsistent inner class entries for com/mojang/blaze3d/platform/GlStateManager$ColorMask!
  Old: ColorMask static MEMBER com/mojang/blaze3d/platform/GlStateManager$ColorMask
  New: ColorMask private static MEMBER com/mojang/blaze3d/platform/GlStateManager
Inconsistent inner class entries for com/mojang/blaze3d/platform/GlStateManager$StencilState!
  Old: StencilState static MEMBER com/mojang/blaze3d/platform/GlStateManager$StencilState
  New: StencilState private static MEMBER com/mojang/blaze3d/platform/GlStateManager
Inconsistent inner class entries for com/mojang/realmsclient/gui/screens/RealmsBackupInfoScreen$BackupInfoList!
  Old: BackupInfoList  MEMBER com/mojang/realmsclient/gui/screens/RealmsBackupInfoScreen$BackupInfoList
  New: BackupInfoList private MEMBER com/mojang/realmsclient/gui/screens/RealmsBackupInfoScreen
Inconsistent inner class entries for net/minecraft/client/ResourceLoadStateTracker$RecoveryInfo!
  Old: RecoveryInfo private static MEMBER net/minecraft/client/ResourceLoadStateTracker
  New: RecoveryInfo static MEMBER net/minecraft/client/ResourceLoadStateTracker$RecoveryInfo
Inconsistent inner class entries for net/minecraft/client/particle/DripParticle$DripLandParticle!
  Old: DripLandParticle static MEMBER net/minecraft/client/particle/DripParticle$DripLandParticle
  New: DripLandParticle private static MEMBER net/minecraft/client/particle/DripParticle
Inconsistent inner class entries for net/minecraft/client/particle/DripParticle$FallingParticle!
  Old: FallingParticle static MEMBER net/minecraft/client/particle/DripParticle$FallingParticle
  New: FallingParticle private static MEMBER net/minecraft/client/particle/DripParticle
Inconsistent inner class entries for net/minecraft/client/particle/DripParticle$DripstoneFallAndLandParticle!
  Old: DripstoneFallAndLandParticle static MEMBER net/minecraft/client/particle/DripParticle$DripstoneFallAndLandParticle
  New: DripstoneFallAndLandParticle private static MEMBER net/minecraft/client/particle/DripParticle
Inconsistent inner class entries for net/minecraft/client/particle/DripParticle$HoneyFallAndLandParticle!
  Old: HoneyFallAndLandParticle static MEMBER net/minecraft/client/particle/DripParticle$HoneyFallAndLandParticle
  New: HoneyFallAndLandParticle private static MEMBER net/minecraft/client/particle/DripParticle
Inconsistent inner class entries for net/minecraft/client/particle/DripParticle$FallAndLandParticle!
  Old: FallAndLandParticle static MEMBER net/minecraft/client/particle/DripParticle$FallAndLandParticle
  New: FallAndLandParticle private static MEMBER net/minecraft/client/particle/DripParticle
Inconsistent inner class entries for net/minecraft/client/particle/DripParticle$CoolingDripHangParticle!
  Old: CoolingDripHangParticle static MEMBER net/minecraft/client/particle/DripParticle$CoolingDripHangParticle
  New: CoolingDripHangParticle private static MEMBER net/minecraft/client/particle/DripParticle
Inconsistent inner class entries for net/minecraft/client/particle/DripParticle$DripHangParticle!
  Old: DripHangParticle static MEMBER net/minecraft/client/particle/DripParticle$DripHangParticle
  New: DripHangParticle private static MEMBER net/minecraft/client/particle/DripParticle
Inconsistent inner class entries for net/minecraft/world/entity/monster/Spider$SpiderAttackGoal!
  Old: SpiderAttackGoal static MEMBER net/minecraft/world/entity/monster/Spider$SpiderAttackGoal
  New: SpiderAttackGoal private static MEMBER net/minecraft/world/entity/monster/Spider
Inconsistent inner class entries for net/minecraft/world/entity/monster/Spider$SpiderTargetGoal!
  Old: SpiderTargetGoal static MEMBER net/minecraft/world/entity/monster/Spider$SpiderTargetGoal
  New: SpiderTargetGoal private static MEMBER net/minecraft/world/entity/monster/Spider
Inconsistent inner class entries for net/minecraft/world/level/chunk/storage/RegionFileVersion$StreamWrapper!
  Old: StreamWrapper abstract static MEMBER net/minecraft/world/level/chunk/storage/RegionFileVersion$StreamWrapper
  New: StreamWrapper private abstract static MEMBER net/minecraft/world/level/chunk/storage/RegionFileVersion
Inconsistent inner class entries for com/mojang/realmsclient/RealmsMainScreen$TrialEntry!
  Old: TrialEntry private MEMBER com/mojang/realmsclient/RealmsMainScreen
  New: TrialEntry  MEMBER com/mojang/realmsclient/RealmsMainScreen$TrialEntry
Inconsistent inner class entries for com/mojang/realmsclient/RealmsMainScreen$Entry!
  Old: Entry abstract MEMBER com/mojang/realmsclient/RealmsMainScreen$Entry
  New: Entry private abstract MEMBER com/mojang/realmsclient/RealmsMainScreen$TrialEntry
Inconsistent inner class entries for com/mojang/realmsclient/RealmsMainScreen$RealmSelectionList!
  Old: RealmSelectionList  MEMBER com/mojang/realmsclient/RealmsMainScreen$RealmSelectionList
  New: RealmSelectionList private MEMBER com/mojang/realmsclient/RealmsMainScreen$TrialEntry
Inconsistent inner class entries for net/minecraft/server/commands/ExecuteCommand$CommandNumericPredicate!
  Old: CommandNumericPredicate private abstract static MEMBER net/minecraft/server/commands/ExecuteCommand
  New: CommandNumericPredicate abstract static MEMBER net/minecraft/server/commands/ExecuteCommand$CommandNumericPredicate
Inconsistent inner class entries for net/minecraft/commands/arguments/OperationArgument$SimpleOperation!
  Old: SimpleOperation private abstract static MEMBER net/minecraft/commands/arguments/OperationArgument
  New: SimpleOperation abstract static MEMBER net/minecraft/commands/arguments/OperationArgument$SimpleOperation
Inconsistent inner class entries for com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen$Entry!
  Old: Entry private MEMBER com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen$Entry$RejectRowButton
  New: Entry  MEMBER com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen$Entry
Inconsistent inner class entries for com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen$PendingInvitationSelectionList!
  Old: PendingInvitationSelectionList  MEMBER com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen$PendingInvitationSelectionList
  New: PendingInvitationSelectionList private MEMBER com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen$Entry
Inconsistent inner class entries for net/minecraft/stats/RecipeBookSettings$TypeSettings!
  Old: TypeSettings static final MEMBER net/minecraft/stats/RecipeBookSettings$TypeSettings
  New: TypeSettings private static final MEMBER net/minecraft/stats/RecipeBookSettings
Inconsistent inner class entries for net/minecraft/world/entity/monster/Drowned$DrownedGoToWaterGoal!
  Old: DrownedGoToWaterGoal static MEMBER net/minecraft/world/entity/monster/Drowned$DrownedGoToWaterGoal
  New: DrownedGoToWaterGoal private static MEMBER net/minecraft/world/entity/monster/Drowned
Inconsistent inner class entries for net/minecraft/world/entity/monster/Drowned$DrownedAttackGoal!
  Old: DrownedAttackGoal static MEMBER net/minecraft/world/entity/monster/Drowned$DrownedAttackGoal
  New: DrownedAttackGoal private static MEMBER net/minecraft/world/entity/monster/Drowned
Inconsistent inner class entries for net/minecraft/world/entity/monster/Drowned$DrownedGoToBeachGoal!
  Old: DrownedGoToBeachGoal static MEMBER net/minecraft/world/entity/monster/Drowned$DrownedGoToBeachGoal
  New: DrownedGoToBeachGoal private static MEMBER net/minecraft/world/entity/monster/Drowned
Inconsistent inner class entries for net/minecraft/world/entity/monster/Drowned$DrownedSwimUpGoal!
  Old: DrownedSwimUpGoal static MEMBER net/minecraft/world/entity/monster/Drowned$DrownedSwimUpGoal
  New: DrownedSwimUpGoal private static MEMBER net/minecraft/world/entity/monster/Drowned
Inconsistent inner class entries for net/minecraft/world/inventory/BrewingStandMenu$FuelSlot!
  Old: FuelSlot private static MEMBER net/minecraft/world/inventory/BrewingStandMenu
  New: FuelSlot static MEMBER net/minecraft/world/inventory/BrewingStandMenu$FuelSlot
Inconsistent inner class entries for net/minecraft/client/renderer/chunk/ChunkRenderDispatcher$RenderChunk$RebuildTask!
  Old: RebuildTask private MEMBER net/minecraft/client/renderer/chunk/ChunkRenderDispatcher$RenderChunk
  New: RebuildTask  MEMBER net/minecraft/client/renderer/chunk/ChunkRenderDispatcher$RenderChunk$RebuildTask
Inconsistent inner class entries for net/minecraft/client/renderer/chunk/ChunkRenderDispatcher$ChunkTaskResult!
  Old: ChunkTaskResult static final MEMBER net/minecraft/client/renderer/chunk/ChunkRenderDispatcher$ChunkTaskResult
  New: ChunkTaskResult private static final MEMBER net/minecraft/client/renderer/chunk/ChunkRenderDispatcher$RenderChunk$RebuildTask
Inconsistent inner class entries for net/minecraft/world/entity/animal/Fox$StalkPreyGoal!
  Old: StalkPreyGoal private MEMBER net/minecraft/world/entity/animal/Fox
  New: StalkPreyGoal  MEMBER net/minecraft/world/entity/animal/Fox$StalkPreyGoal
Inconsistent inner class entries for net/minecraft/client/gui/Font$StringRenderOutput!
  Old: StringRenderOutput private MEMBER net/minecraft/client/gui/Font
  New: StringRenderOutput  MEMBER net/minecraft/client/gui/Font$StringRenderOutput
Inconsistent inner class entries for com/mojang/blaze3d/audio/Library$CountingChannelPool!
  Old: CountingChannelPool private static MEMBER com/mojang/blaze3d/audio/Library
  New: CountingChannelPool static MEMBER com/mojang/blaze3d/audio/Library$CountingChannelPool
Inconsistent inner class entries for com/mojang/realmsclient/RealmsMainScreen$ServerEntry!
  Old: ServerEntry private MEMBER com/mojang/realmsclient/RealmsMainScreen
  New: ServerEntry  MEMBER com/mojang/realmsclient/RealmsMainScreen$ServerEntry
Inconsistent inner class entries for com/mojang/realmsclient/RealmsMainScreen$Entry!
  Old: Entry abstract MEMBER com/mojang/realmsclient/RealmsMainScreen$Entry
  New: Entry private abstract MEMBER com/mojang/realmsclient/RealmsMainScreen$ServerEntry
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/StrongholdPieces$StrongholdPiece!
  Old: StrongholdPiece private abstract static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$LeftTurn
  New: StrongholdPiece abstract static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$StrongholdPiece
Inconsistent inner class entries for net/minecraft/server/commands/data/DataCommands$DataManipulatorDecorator!
  Old: DataManipulatorDecorator private abstract static MEMBER net/minecraft/server/commands/data/DataCommands
  New: DataManipulatorDecorator abstract static MEMBER net/minecraft/server/commands/data/DataCommands$DataManipulatorDecorator
Inconsistent inner class entries for net/minecraft/server/commands/data/DataCommands$DataManipulator!
  Old: DataManipulator abstract static MEMBER net/minecraft/server/commands/data/DataCommands$DataManipulator
  New: DataManipulator private abstract static MEMBER net/minecraft/server/commands/data/DataCommands$DataManipulatorDecorator
Inconsistent inner class entries for net/minecraft/client/gui/screens/inventory/BeaconScreen$BeaconScreenButton!
  Old: BeaconScreenButton private abstract static MEMBER net/minecraft/client/gui/screens/inventory/BeaconScreen$BeaconPowerButton
  New: BeaconScreenButton abstract static MEMBER net/minecraft/client/gui/screens/inventory/BeaconScreen$BeaconScreenButton
Inconsistent inner class entries for net/minecraft/data/models/blockstates/MultiPartGenerator$Entry!
  Old: Entry private static MEMBER net/minecraft/data/models/blockstates/MultiPartGenerator
  New: Entry static MEMBER net/minecraft/data/models/blockstates/MultiPartGenerator$Entry
Inconsistent inner class entries for net/minecraft/server/level/ServerChunkCache$MainThreadExecutor!
  Old: MainThreadExecutor private final MEMBER net/minecraft/server/level/ServerChunkCache
  New: MainThreadExecutor final MEMBER net/minecraft/server/level/ServerChunkCache$MainThreadExecutor
Inconsistent inner class entries for net/minecraft/world/entity/animal/TropicalFish$TropicalFishGroupData!
  Old: TropicalFishGroupData private static MEMBER net/minecraft/world/entity/animal/TropicalFish
  New: TropicalFishGroupData static MEMBER net/minecraft/world/entity/animal/TropicalFish$TropicalFishGroupData
Inconsistent inner class entries for net/minecraft/realms/RepeatedNarrator$Params!
  Old: Params private static MEMBER net/minecraft/realms/RepeatedNarrator
  New: Params static MEMBER net/minecraft/realms/RepeatedNarrator$Params
Inconsistent inner class entries for net/minecraft/tags/StaticTagHelper$Wrapper!
  Old: Wrapper private static MEMBER net/minecraft/tags/StaticTagHelper
  New: Wrapper static MEMBER net/minecraft/tags/StaticTagHelper$Wrapper
Inconsistent inner class entries for net/minecraft/client/renderer/RenderType$OutlineProperty!
  Old: OutlineProperty static final MEMBER net/minecraft/client/renderer/RenderType$OutlineProperty
  New: OutlineProperty private static final MEMBER net/minecraft/client/renderer/RenderType$CompositeRenderType
Inconsistent inner class entries for net/minecraft/world/entity/monster/Blaze$BlazeAttackGoal!
  Old: BlazeAttackGoal static MEMBER net/minecraft/world/entity/monster/Blaze$BlazeAttackGoal
  New: BlazeAttackGoal private static MEMBER net/minecraft/world/entity/monster/Blaze
Inconsistent inner class entries for com/mojang/blaze3d/audio/OggAudioStream$OutputConcat!
  Old: OutputConcat static MEMBER com/mojang/blaze3d/audio/OggAudioStream$OutputConcat
  New: OutputConcat private static MEMBER com/mojang/blaze3d/audio/OggAudioStream
Inconsistent inner class entries for net/minecraft/client/gui/screens/inventory/BeaconScreen$BeaconCancelButton!
  Old: BeaconCancelButton private MEMBER net/minecraft/client/gui/screens/inventory/BeaconScreen
  New: BeaconCancelButton  MEMBER net/minecraft/client/gui/screens/inventory/BeaconScreen$BeaconCancelButton
Inconsistent inner class entries for net/minecraft/client/gui/screens/inventory/BeaconScreen$BeaconSpriteScreenButton!
  Old: BeaconSpriteScreenButton abstract static MEMBER net/minecraft/client/gui/screens/inventory/BeaconScreen$BeaconSpriteScreenButton
  New: BeaconSpriteScreenButton private abstract static MEMBER net/minecraft/client/gui/screens/inventory/BeaconScreen$BeaconCancelButton
Inconsistent inner class entries for net/minecraft/world/entity/npc/VillagerTrades$ItemsForEmeralds!
  Old: ItemsForEmeralds private static MEMBER net/minecraft/world/entity/npc/VillagerTrades
  New: ItemsForEmeralds static MEMBER net/minecraft/world/entity/npc/VillagerTrades$ItemsForEmeralds
Inconsistent inner class entries for net/minecraft/world/level/block/ComposterBlock$InputContainer!
  Old: InputContainer private static MEMBER net/minecraft/world/level/block/ComposterBlock
  New: InputContainer static MEMBER net/minecraft/world/level/block/ComposterBlock$InputContainer
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$FloorRoomCollection!
  Old: FloorRoomCollection abstract static MEMBER net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$FloorRoomCollection
  New: FloorRoomCollection private abstract static MEMBER net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$SecondFloorRoomCollection
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$SecondFloorRoomCollection!
  Old: SecondFloorRoomCollection private static MEMBER net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces
  New: SecondFloorRoomCollection static MEMBER net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$SecondFloorRoomCollection
Inconsistent inner class entries for com/mojang/blaze3d/vertex/VertexFormatElement$Usage$SetupState!
  Old: SetupState abstract static MEMBER com/mojang/blaze3d/vertex/VertexFormatElement$Usage$SetupState
  New: SetupState private abstract static MEMBER com/mojang/blaze3d/vertex/VertexFormatElement$Usage
Inconsistent inner class entries for com/mojang/blaze3d/vertex/VertexFormatElement$Usage$ClearState!
  Old: ClearState abstract static MEMBER com/mojang/blaze3d/vertex/VertexFormatElement$Usage$ClearState
  New: ClearState private abstract static MEMBER com/mojang/blaze3d/vertex/VertexFormatElement$Usage
Inconsistent inner class entries for net/minecraft/server/network/ServerConnectionListener$LatencySimulator!
  Old: LatencySimulator static MEMBER net/minecraft/server/network/ServerConnectionListener$LatencySimulator
  New: LatencySimulator private static MEMBER net/minecraft/server/network/ServerConnectionListener
Inconsistent inner class entries for net/minecraft/server/network/ServerConnectionListener$LatencySimulator$DelayedMessage!
  Old: DelayedMessage static MEMBER net/minecraft/server/network/ServerConnectionListener$LatencySimulator$DelayedMessage
  New: DelayedMessage private static MEMBER net/minecraft/server/network/ServerConnectionListener
Inconsistent inner class entries for net/minecraft/world/level/biome/MultiNoiseBiomeSource$PresetInstance!
  Old: PresetInstance private static final MEMBER net/minecraft/world/level/biome/MultiNoiseBiomeSource
  New: PresetInstance static final MEMBER net/minecraft/world/level/biome/MultiNoiseBiomeSource$PresetInstance
Inconsistent inner class entries for net/minecraft/world/entity/animal/Fox$SeekShelterGoal!
  Old: SeekShelterGoal private MEMBER net/minecraft/world/entity/animal/Fox
  New: SeekShelterGoal  MEMBER net/minecraft/world/entity/animal/Fox$SeekShelterGoal
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$SimpleGrid!
  Old: SimpleGrid private static MEMBER net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces
  New: SimpleGrid static MEMBER net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$SimpleGrid
Inconsistent inner class entries for net/minecraft/client/model/geom/ModelPart$Vertex!
  Old: Vertex private static MEMBER net/minecraft/client/model/geom/ModelPart
  New: Vertex static MEMBER net/minecraft/client/model/geom/ModelPart$Vertex
Inconsistent inner class entries for net/minecraft/network/ConnectionProtocol$ProtocolBuilder!
  Old: ProtocolBuilder private static MEMBER net/minecraft/network/ConnectionProtocol
  New: ProtocolBuilder static MEMBER net/minecraft/network/ConnectionProtocol$ProtocolBuilder
Inconsistent inner class entries for net/minecraft/network/ConnectionProtocol$PacketSet!
  Old: PacketSet static MEMBER net/minecraft/network/ConnectionProtocol$PacketSet
  New: PacketSet private static MEMBER net/minecraft/network/ConnectionProtocol$ProtocolBuilder
Inconsistent inner class entries for net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen$SlotWrapper!
  Old: SlotWrapper static MEMBER net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen$SlotWrapper
  New: SlotWrapper private static MEMBER net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen
Inconsistent inner class entries for net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen$CustomCreativeSlot!
  Old: CustomCreativeSlot static MEMBER net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen$CustomCreativeSlot
  New: CustomCreativeSlot private static MEMBER net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen
Inconsistent inner class entries for net/minecraft/world/entity/monster/Evoker$EvokerCastingSpellGoal!
  Old: EvokerCastingSpellGoal private MEMBER net/minecraft/world/entity/monster/Evoker
  New: EvokerCastingSpellGoal  MEMBER net/minecraft/world/entity/monster/Evoker$EvokerCastingSpellGoal
Inconsistent inner class entries for net/minecraft/world/level/entity/TransientEntitySectionManager$Callback!
  Old: Callback  MEMBER net/minecraft/world/level/entity/TransientEntitySectionManager$Callback
  New: Callback private MEMBER net/minecraft/world/level/entity/TransientEntitySectionManager
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition!
  Old: RoomDefinition static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition
  New: RoomDefinition private static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$OceanMonumentDoubleZRoom
Inconsistent inner class entries for net/minecraft/server/commands/ExecuteCommand$CommandPredicate!
  Old: CommandPredicate private abstract static MEMBER net/minecraft/server/commands/ExecuteCommand
  New: CommandPredicate abstract static MEMBER net/minecraft/server/commands/ExecuteCommand$CommandPredicate
Inconsistent inner class entries for net/minecraft/client/renderer/block/ModelBlockRenderer$Cache!
  Old: Cache static MEMBER net/minecraft/client/renderer/block/ModelBlockRenderer$Cache
  New: Cache private static MEMBER net/minecraft/client/renderer/block/ModelBlockRenderer$AmbientOcclusionFace
Inconsistent inner class entries for net/minecraft/client/renderer/block/ModelBlockRenderer$AmbientVertexRemap!
  Old: AmbientVertexRemap static final MEMBER net/minecraft/client/renderer/block/ModelBlockRenderer$AmbientVertexRemap
  New: AmbientVertexRemap private static final MEMBER net/minecraft/client/renderer/block/ModelBlockRenderer$AmbientOcclusionFace
Inconsistent inner class entries for net/minecraft/server/players/GameProfileCache$GameProfileInfo!
  Old: GameProfileInfo static MEMBER net/minecraft/server/players/GameProfileCache$GameProfileInfo
  New: GameProfileInfo private static MEMBER net/minecraft/server/players/GameProfileCache
Inconsistent inner class entries for net/minecraft/advancements/critereon/PlayerPredicate$AdvancementDonePredicate!
  Old: AdvancementDonePredicate static MEMBER net/minecraft/advancements/critereon/PlayerPredicate$AdvancementDonePredicate
  New: AdvancementDonePredicate private static MEMBER net/minecraft/advancements/critereon/PlayerPredicate
Inconsistent inner class entries for net/minecraft/advancements/critereon/PlayerPredicate$AdvancementCriterionsPredicate!
  Old: AdvancementCriterionsPredicate static MEMBER net/minecraft/advancements/critereon/PlayerPredicate$AdvancementCriterionsPredicate
  New: AdvancementCriterionsPredicate private static MEMBER net/minecraft/advancements/critereon/PlayerPredicate
Inconsistent inner class entries for net/minecraft/advancements/critereon/PlayerPredicate$AdvancementPredicate!
  Old: AdvancementPredicate abstract static MEMBER net/minecraft/advancements/critereon/PlayerPredicate$AdvancementPredicate
  New: AdvancementPredicate private abstract static MEMBER net/minecraft/advancements/critereon/PlayerPredicate
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition!
  Old: RoomDefinition static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition
  New: RoomDefinition private static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$OceanMonumentEntryRoom
Inconsistent inner class entries for net/minecraft/world/entity/animal/Panda$PandaSitGoal!
  Old: PandaSitGoal private MEMBER net/minecraft/world/entity/animal/Panda
  New: PandaSitGoal  MEMBER net/minecraft/world/entity/animal/Panda$PandaSitGoal
Inconsistent inner class entries for net/minecraft/world/entity/ai/behavior/CrossbowAttack$CrossbowState!
  Old: CrossbowState static final MEMBER net/minecraft/world/entity/ai/behavior/CrossbowAttack$CrossbowState
  New: CrossbowState private static final MEMBER net/minecraft/world/entity/ai/behavior/CrossbowAttack
Inconsistent inner class entries for com/mojang/blaze3d/platform/GlDebug$LogEntry!
  Old: LogEntry private static MEMBER com/mojang/blaze3d/platform/GlDebug
  New: LogEntry static MEMBER com/mojang/blaze3d/platform/GlDebug$LogEntry
Inconsistent inner class entries for net/minecraft/world/entity/npc/WanderingTrader$WanderToPositionGoal!
  Old: WanderToPositionGoal  MEMBER net/minecraft/world/entity/npc/WanderingTrader$WanderToPositionGoal
  New: WanderToPositionGoal private MEMBER net/minecraft/world/entity/npc/WanderingTrader
Inconsistent inner class entries for net/minecraft/client/Options$FieldAccess!
  Old: FieldAccess abstract static MEMBER net/minecraft/client/Options$FieldAccess
  New: FieldAccess private abstract static MEMBER net/minecraft/client/Options
Inconsistent inner class entries for com/mojang/blaze3d/platform/GlStateManager$StencilFunc!
  Old: StencilFunc private static MEMBER com/mojang/blaze3d/platform/GlStateManager$StencilState
  New: StencilFunc static MEMBER com/mojang/blaze3d/platform/GlStateManager$StencilFunc
Inconsistent inner class entries for net/minecraft/world/entity/monster/Silverfish$SilverfishMergeWithStoneGoal!
  Old: SilverfishMergeWithStoneGoal private static MEMBER net/minecraft/world/entity/monster/Silverfish
  New: SilverfishMergeWithStoneGoal static MEMBER net/minecraft/world/entity/monster/Silverfish$SilverfishMergeWithStoneGoal
Inconsistent inner class entries for com/mojang/realmsclient/gui/screens/RealmsPlayerScreen$UserAction!
  Old: UserAction static final MEMBER com/mojang/realmsclient/gui/screens/RealmsPlayerScreen$UserAction
  New: UserAction private static final MEMBER com/mojang/realmsclient/gui/screens/RealmsPlayerScreen
Inconsistent inner class entries for com/mojang/realmsclient/gui/screens/RealmsPlayerScreen$InvitedObjectSelectionList!
  Old: InvitedObjectSelectionList  MEMBER com/mojang/realmsclient/gui/screens/RealmsPlayerScreen$InvitedObjectSelectionList
  New: InvitedObjectSelectionList private MEMBER com/mojang/realmsclient/gui/screens/RealmsPlayerScreen
Inconsistent inner class entries for com/mojang/realmsclient/gui/screens/RealmsPlayerScreen$Entry!
  Old: Entry  MEMBER com/mojang/realmsclient/gui/screens/RealmsPlayerScreen$Entry
  New: Entry private MEMBER com/mojang/realmsclient/gui/screens/RealmsPlayerScreen
Inconsistent inner class entries for net/minecraft/client/searchtree/ReloadableSearchTree$MergingUniqueIterator!
  Old: MergingUniqueIterator private static MEMBER net/minecraft/client/searchtree/ReloadableSearchTree
  New: MergingUniqueIterator static MEMBER net/minecraft/client/searchtree/ReloadableSearchTree$MergingUniqueIterator
Inconsistent inner class entries for net/minecraft/world/level/levelgen/feature/structures/JigsawPlacement$PieceState!
  Old: PieceState private static final MEMBER net/minecraft/world/level/levelgen/feature/structures/JigsawPlacement$Placer
  New: PieceState static final MEMBER net/minecraft/world/level/levelgen/feature/structures/JigsawPlacement$PieceState
Inconsistent inner class entries for net/minecraft/client/renderer/debug/GameEventListenerRenderer$TrackedListener!
  Old: TrackedListener private static MEMBER net/minecraft/client/renderer/debug/GameEventListenerRenderer
  New: TrackedListener static MEMBER net/minecraft/client/renderer/debug/GameEventListenerRenderer$TrackedListener
Inconsistent inner class entries for com/mojang/realmsclient/RealmsMainScreen$HoveredElement!
  Old: HoveredElement private static final MEMBER com/mojang/realmsclient/RealmsMainScreen$RealmSelectionList
  New: HoveredElement static final MEMBER com/mojang/realmsclient/RealmsMainScreen$HoveredElement
Inconsistent inner class entries for net/minecraft/client/gui/screens/inventory/BookEditScreen$Pos2i!
  Old: Pos2i static MEMBER net/minecraft/client/gui/screens/inventory/BookEditScreen$Pos2i
  New: Pos2i private static MEMBER net/minecraft/client/gui/screens/inventory/BookEditScreen
Inconsistent inner class entries for net/minecraft/client/gui/font/providers/BitmapProvider$Glyph!
  Old: Glyph static final MEMBER net/minecraft/client/gui/font/providers/BitmapProvider$Glyph
  New: Glyph private static final MEMBER net/minecraft/client/gui/font/providers/BitmapProvider
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$PlacementData!
  Old: PlacementData private static MEMBER net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces
  New: PlacementData static MEMBER net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$PlacementData
Inconsistent inner class entries for net/minecraft/network/protocol/game/ClientboundCommandsPacket$Entry!
  Old: Entry static MEMBER net/minecraft/network/protocol/game/ClientboundCommandsPacket$Entry
  New: Entry private static MEMBER net/minecraft/network/protocol/game/ClientboundCommandsPacket
Inconsistent inner class entries for net/minecraft/world/level/chunk/storage/RegionFile$CommitOp!
  Old: CommitOp private abstract static MEMBER net/minecraft/world/level/chunk/storage/RegionFile
  New: CommitOp abstract static MEMBER net/minecraft/world/level/chunk/storage/RegionFile$CommitOp
Inconsistent inner class entries for net/minecraft/world/level/storage/loot/providers/nbt/ContextNbtProvider$Getter!
  Old: Getter abstract static MEMBER net/minecraft/world/level/storage/loot/providers/nbt/ContextNbtProvider$Getter
  New: Getter private abstract static MEMBER net/minecraft/world/level/storage/loot/providers/nbt/ContextNbtProvider$InlineSerializer
Inconsistent inner class entries for net/minecraft/util/datafix/fixes/ChunkPalettedStorageFix$Section!
  Old: Section private static MEMBER net/minecraft/util/datafix/fixes/ChunkPalettedStorageFix
  New: Section static MEMBER net/minecraft/util/datafix/fixes/ChunkPalettedStorageFix$Section
Inconsistent inner class entries for net/minecraft/util/datafix/fixes/ChunkPalettedStorageFix$DataLayer!
  Old: DataLayer static MEMBER net/minecraft/util/datafix/fixes/ChunkPalettedStorageFix$DataLayer
  New: DataLayer private static MEMBER net/minecraft/util/datafix/fixes/ChunkPalettedStorageFix$Section
Inconsistent inner class entries for net/minecraft/world/entity/animal/Fox$FoxStrollThroughVillageGoal!
  Old: FoxStrollThroughVillageGoal private MEMBER net/minecraft/world/entity/animal/Fox
  New: FoxStrollThroughVillageGoal  MEMBER net/minecraft/world/entity/animal/Fox$FoxStrollThroughVillageGoal
Inconsistent inner class entries for com/mojang/realmsclient/gui/screens/RealmsBackupScreen$Entry!
  Old: Entry  MEMBER com/mojang/realmsclient/gui/screens/RealmsBackupScreen$Entry
  New: Entry private MEMBER com/mojang/realmsclient/gui/screens/RealmsBackupScreen
Inconsistent inner class entries for net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen$CustomCreativeSlot!
  Old: CustomCreativeSlot static MEMBER net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen$CustomCreativeSlot
  New: CustomCreativeSlot private static MEMBER net/minecraft/client/gui/screens/inventory/CreativeModeInventoryScreen$ItemPickerMenu
Inconsistent inner class entries for net/minecraft/client/gui/components/toasts/ToastComponent$ToastInstance!
  Old: ToastInstance  MEMBER net/minecraft/client/gui/components/toasts/ToastComponent$ToastInstance
  New: ToastInstance private MEMBER net/minecraft/client/gui/components/toasts/ToastComponent
Inconsistent inner class entries for net/minecraft/world/level/chunk/UpgradeData$BlockFixers!
  Old: BlockFixers abstract static MEMBER net/minecraft/world/level/chunk/UpgradeData$BlockFixers
  New: BlockFixers private abstract static MEMBER net/minecraft/world/level/chunk/UpgradeData$BlockFixers$1
Inconsistent inner class entries for net/minecraft/world/level/chunk/UpgradeData$BlockFixers!
  Old: BlockFixers abstract static MEMBER net/minecraft/world/level/chunk/UpgradeData$BlockFixers
  New: BlockFixers private abstract static MEMBER net/minecraft/world/level/chunk/UpgradeData$BlockFixers$5
Inconsistent inner class entries for net/minecraft/world/level/chunk/UpgradeData$BlockFixers!
  Old: BlockFixers abstract static MEMBER net/minecraft/world/level/chunk/UpgradeData$BlockFixers
  New: BlockFixers private abstract static MEMBER net/minecraft/world/level/chunk/UpgradeData$BlockFixers$4
Inconsistent inner class entries for net/minecraft/world/level/chunk/UpgradeData$BlockFixers!
  Old: BlockFixers abstract static MEMBER net/minecraft/world/level/chunk/UpgradeData$BlockFixers
  New: BlockFixers private abstract static MEMBER net/minecraft/world/level/chunk/UpgradeData$BlockFixers$3
Inconsistent inner class entries for net/minecraft/world/level/chunk/UpgradeData$BlockFixers!
  Old: BlockFixers abstract static MEMBER net/minecraft/world/level/chunk/UpgradeData$BlockFixers
  New: BlockFixers private abstract static MEMBER net/minecraft/world/level/chunk/UpgradeData$BlockFixers$2
Inconsistent inner class entries for net/minecraft/tags/TagManager$LoaderInfo!
  Old: LoaderInfo private static MEMBER net/minecraft/tags/TagManager
  New: LoaderInfo static MEMBER net/minecraft/tags/TagManager$LoaderInfo
Inconsistent inner class entries for net/minecraft/server/network/TextFilterClient$PlayerContext!
  Old: PlayerContext private MEMBER net/minecraft/server/network/TextFilterClient
  New: PlayerContext  MEMBER net/minecraft/server/network/TextFilterClient$PlayerContext
Inconsistent inner class entries for net/minecraft/advancements/critereon/EntityTypePredicate$TagPredicate!
  Old: TagPredicate static MEMBER net/minecraft/advancements/critereon/EntityTypePredicate$TagPredicate
  New: TagPredicate private static MEMBER net/minecraft/advancements/critereon/EntityTypePredicate
Inconsistent inner class entries for net/minecraft/advancements/critereon/EntityTypePredicate$TypePredicate!
  Old: TypePredicate static MEMBER net/minecraft/advancements/critereon/EntityTypePredicate$TypePredicate
  New: TypePredicate private static MEMBER net/minecraft/advancements/critereon/EntityTypePredicate
Inconsistent inner class entries for net/minecraft/client/ResourceLoadStateTracker$ReloadState!
  Old: ReloadState private static MEMBER net/minecraft/client/ResourceLoadStateTracker
  New: ReloadState static MEMBER net/minecraft/client/ResourceLoadStateTracker$ReloadState
Inconsistent inner class entries for net/minecraft/client/ResourceLoadStateTracker$RecoveryInfo!
  Old: RecoveryInfo static MEMBER net/minecraft/client/ResourceLoadStateTracker$RecoveryInfo
  New: RecoveryInfo private static MEMBER net/minecraft/client/ResourceLoadStateTracker$ReloadState
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition!
  Old: RoomDefinition static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition
  New: RoomDefinition private static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitSimpleTopRoom
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitSimpleTopRoom!
  Old: FitSimpleTopRoom private static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$MonumentBuilding
  New: FitSimpleTopRoom static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitSimpleTopRoom
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$MonumentRoomFitter!
  Old: MonumentRoomFitter abstract static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$MonumentRoomFitter
  New: MonumentRoomFitter private abstract static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$FitSimpleTopRoom
Inconsistent inner class entries for net/minecraft/client/gui/spectator/SpectatorMenu$ScrollMenuItem!
  Old: ScrollMenuItem static MEMBER net/minecraft/client/gui/spectator/SpectatorMenu$ScrollMenuItem
  New: ScrollMenuItem private static MEMBER net/minecraft/client/gui/spectator/SpectatorMenu
Inconsistent inner class entries for net/minecraft/client/Options$FieldAccess!
  Old: FieldAccess abstract static MEMBER net/minecraft/client/Options$FieldAccess
  New: FieldAccess private abstract static MEMBER net/minecraft/client/Options$3
Inconsistent inner class entries for net/minecraft/client/Options$FieldAccess!
  Old: FieldAccess abstract static MEMBER net/minecraft/client/Options$FieldAccess
  New: FieldAccess private abstract static MEMBER net/minecraft/client/Options$2
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/StrongholdPieces$StrongholdPiece!
  Old: StrongholdPiece abstract static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$StrongholdPiece
  New: StrongholdPiece private abstract static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$RightTurn
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/StrongholdPieces$SmoothStoneSelector!
  Old: SmoothStoneSelector static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$SmoothStoneSelector
  New: SmoothStoneSelector private static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$RightTurn
Inconsistent inner class entries for net/minecraft/server/ServerFunctionManager$ExecutionContext!
  Old: ExecutionContext private MEMBER net/minecraft/server/ServerFunctionManager
  New: ExecutionContext  MEMBER net/minecraft/server/ServerFunctionManager$ExecutionContext
Inconsistent inner class entries for net/minecraft/world/entity/animal/Rabbit$EvilRabbitAttackGoal!
  Old: EvilRabbitAttackGoal private static MEMBER net/minecraft/world/entity/animal/Rabbit
  New: EvilRabbitAttackGoal static MEMBER net/minecraft/world/entity/animal/Rabbit$EvilRabbitAttackGoal
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/JunglePyramidPiece$MossStoneSelector!
  Old: MossStoneSelector private static MEMBER net/minecraft/world/level/levelgen/structure/JunglePyramidPiece
  New: MossStoneSelector static MEMBER net/minecraft/world/level/levelgen/structure/JunglePyramidPiece$MossStoneSelector
Inconsistent inner class entries for net/minecraft/server/commands/CloneCommands$Mode!
  Old: Mode static final MEMBER net/minecraft/server/commands/CloneCommands$Mode
  New: Mode private static final MEMBER net/minecraft/server/commands/CloneCommands
Inconsistent inner class entries for net/minecraft/server/commands/CloneCommands$CloneBlockInfo!
  Old: CloneBlockInfo static MEMBER net/minecraft/server/commands/CloneCommands$CloneBlockInfo
  New: CloneBlockInfo private static MEMBER net/minecraft/server/commands/CloneCommands
Inconsistent inner class entries for net/minecraft/advancements/critereon/StatePropertiesPredicate$PropertyMatcher!
  Old: PropertyMatcher abstract static MEMBER net/minecraft/advancements/critereon/StatePropertiesPredicate$PropertyMatcher
  New: PropertyMatcher private abstract static MEMBER net/minecraft/advancements/critereon/StatePropertiesPredicate$RangedPropertyMatcher
Inconsistent inner class entries for net/minecraft/client/particle/DripParticle$DripHangParticle!
  Old: DripHangParticle static MEMBER net/minecraft/client/particle/DripParticle$DripHangParticle
  New: DripHangParticle private static MEMBER net/minecraft/client/particle/DripParticle$HoneyHangProvider
Inconsistent inner class entries for net/minecraft/world/entity/animal/Squid$SquidRandomMovementGoal!
  Old: SquidRandomMovementGoal private MEMBER net/minecraft/world/entity/animal/Squid
  New: SquidRandomMovementGoal  MEMBER net/minecraft/world/entity/animal/Squid$SquidRandomMovementGoal
Inconsistent inner class entries for net/minecraft/world/entity/monster/Drowned$DrownedMoveControl!
  Old: DrownedMoveControl private static MEMBER net/minecraft/world/entity/monster/Drowned
  New: DrownedMoveControl static MEMBER net/minecraft/world/entity/monster/Drowned$DrownedMoveControl
Inconsistent inner class entries for net/minecraft/server/level/DistanceManager$ChunkTicketTracker!
  Old: ChunkTicketTracker  MEMBER net/minecraft/server/level/DistanceManager$ChunkTicketTracker
  New: ChunkTicketTracker private MEMBER net/minecraft/server/level/DistanceManager
Inconsistent inner class entries for net/minecraft/server/level/DistanceManager$FixedPlayerDistanceChunkTracker!
  Old: FixedPlayerDistanceChunkTracker  MEMBER net/minecraft/server/level/DistanceManager$FixedPlayerDistanceChunkTracker
  New: FixedPlayerDistanceChunkTracker private MEMBER net/minecraft/server/level/DistanceManager
Inconsistent inner class entries for net/minecraft/server/level/DistanceManager$PlayerTicketTracker!
  Old: PlayerTicketTracker  MEMBER net/minecraft/server/level/DistanceManager$PlayerTicketTracker
  New: PlayerTicketTracker private MEMBER net/minecraft/server/level/DistanceManager
Inconsistent inner class entries for net/minecraft/server/commands/LootCommand$DropConsumer!
  Old: DropConsumer private abstract static MEMBER net/minecraft/server/commands/LootCommand$TailProvider
  New: DropConsumer abstract static MEMBER net/minecraft/server/commands/LootCommand$DropConsumer
Inconsistent inner class entries for net/minecraft/server/commands/LootCommand$Callback!
  Old: Callback abstract static MEMBER net/minecraft/server/commands/LootCommand$Callback
  New: Callback private abstract static MEMBER net/minecraft/server/commands/LootCommand$DropConsumer
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/NetherBridgePieces$PieceWeight!
  Old: PieceWeight private static MEMBER net/minecraft/world/level/levelgen/structure/NetherBridgePieces
  New: PieceWeight static MEMBER net/minecraft/world/level/levelgen/structure/NetherBridgePieces$PieceWeight
Inconsistent inner class entries for net/minecraft/world/level/levelgen/feature/LargeDripstoneFeature$LargeDripstone!
  Old: LargeDripstone private static final MEMBER net/minecraft/world/level/levelgen/feature/LargeDripstoneFeature
  New: LargeDripstone static final MEMBER net/minecraft/world/level/levelgen/feature/LargeDripstoneFeature$LargeDripstone
Inconsistent inner class entries for net/minecraft/world/level/levelgen/feature/LargeDripstoneFeature$WindOffsetter!
  Old: WindOffsetter static final MEMBER net/minecraft/world/level/levelgen/feature/LargeDripstoneFeature$WindOffsetter
  New: WindOffsetter private static final MEMBER net/minecraft/world/level/levelgen/feature/LargeDripstoneFeature$LargeDripstone
Inconsistent inner class entries for com/mojang/realmsclient/gui/screens/RealmsBackupInfoScreen$BackupInfoListEntry!
  Old: BackupInfoListEntry private MEMBER com/mojang/realmsclient/gui/screens/RealmsBackupInfoScreen$BackupInfoList
  New: BackupInfoListEntry  MEMBER com/mojang/realmsclient/gui/screens/RealmsBackupInfoScreen$BackupInfoListEntry
Inconsistent inner class entries for net/minecraft/world/entity/monster/Shulker$ShulkerAttackGoal!
  Old: ShulkerAttackGoal  MEMBER net/minecraft/world/entity/monster/Shulker$ShulkerAttackGoal
  New: ShulkerAttackGoal private MEMBER net/minecraft/world/entity/monster/Shulker
Inconsistent inner class entries for net/minecraft/world/entity/monster/Shulker$ShulkerNearestAttackGoal!
  Old: ShulkerNearestAttackGoal  MEMBER net/minecraft/world/entity/monster/Shulker$ShulkerNearestAttackGoal
  New: ShulkerNearestAttackGoal private MEMBER net/minecraft/world/entity/monster/Shulker
Inconsistent inner class entries for net/minecraft/world/entity/monster/Shulker$ShulkerDefenseAttackGoal!
  Old: ShulkerDefenseAttackGoal static MEMBER net/minecraft/world/entity/monster/Shulker$ShulkerDefenseAttackGoal
  New: ShulkerDefenseAttackGoal private static MEMBER net/minecraft/world/entity/monster/Shulker
Inconsistent inner class entries for net/minecraft/world/entity/monster/Shulker$ShulkerBodyRotationControl!
  Old: ShulkerBodyRotationControl static MEMBER net/minecraft/world/entity/monster/Shulker$ShulkerBodyRotationControl
  New: ShulkerBodyRotationControl private static MEMBER net/minecraft/world/entity/monster/Shulker
Inconsistent inner class entries for net/minecraft/world/entity/monster/Vex$VexMoveControl!
  Old: VexMoveControl  MEMBER net/minecraft/world/entity/monster/Vex$VexMoveControl
  New: VexMoveControl private MEMBER net/minecraft/world/entity/monster/Vex
Inconsistent inner class entries for net/minecraft/world/entity/monster/Vex$VexChargeAttackGoal!
  Old: VexChargeAttackGoal  MEMBER net/minecraft/world/entity/monster/Vex$VexChargeAttackGoal
  New: VexChargeAttackGoal private MEMBER net/minecraft/world/entity/monster/Vex
Inconsistent inner class entries for net/minecraft/world/entity/monster/Vex$VexRandomMoveGoal!
  Old: VexRandomMoveGoal  MEMBER net/minecraft/world/entity/monster/Vex$VexRandomMoveGoal
  New: VexRandomMoveGoal private MEMBER net/minecraft/world/entity/monster/Vex
Inconsistent inner class entries for net/minecraft/world/entity/projectile/FishingHook$OpenWaterType!
  Old: OpenWaterType private static final MEMBER net/minecraft/world/entity/projectile/FishingHook
  New: OpenWaterType static final MEMBER net/minecraft/world/entity/projectile/FishingHook$OpenWaterType
Inconsistent inner class entries for net/minecraft/nbt/NbtOps$NbtRecordBuilder!
  Old: NbtRecordBuilder  MEMBER net/minecraft/nbt/NbtOps$NbtRecordBuilder
  New: NbtRecordBuilder private MEMBER net/minecraft/nbt/NbtOps
Inconsistent inner class entries for net/minecraft/world/entity/animal/horse/Llama$LlamaHurtByTargetGoal!
  Old: LlamaHurtByTargetGoal static MEMBER net/minecraft/world/entity/animal/horse/Llama$LlamaHurtByTargetGoal
  New: LlamaHurtByTargetGoal private static MEMBER net/minecraft/world/entity/animal/horse/Llama
Inconsistent inner class entries for net/minecraft/world/entity/animal/horse/Llama$LlamaAttackWolfGoal!
  Old: LlamaAttackWolfGoal static MEMBER net/minecraft/world/entity/animal/horse/Llama$LlamaAttackWolfGoal
  New: LlamaAttackWolfGoal private static MEMBER net/minecraft/world/entity/animal/horse/Llama
Inconsistent inner class entries for net/minecraft/world/entity/animal/horse/Llama$LlamaGroupData!
  Old: LlamaGroupData static MEMBER net/minecraft/world/entity/animal/horse/Llama$LlamaGroupData
  New: LlamaGroupData private static MEMBER net/minecraft/world/entity/animal/horse/Llama
Inconsistent inner class entries for net/minecraft/nbt/ShortTag$Cache!
  Old: Cache static MEMBER net/minecraft/nbt/ShortTag$Cache
  New: Cache private static MEMBER net/minecraft/nbt/ShortTag
Inconsistent inner class entries for net/minecraft/client/particle/DripParticle$HoneyFallAndLandParticle!
  Old: HoneyFallAndLandParticle static MEMBER net/minecraft/client/particle/DripParticle$HoneyFallAndLandParticle
  New: HoneyFallAndLandParticle private static MEMBER net/minecraft/client/particle/DripParticle$HoneyFallProvider
Inconsistent inner class entries for net/minecraft/client/gui/font/providers/LegacyUnicodeBitmapsProvider$Glyph!
  Old: Glyph static MEMBER net/minecraft/client/gui/font/providers/LegacyUnicodeBitmapsProvider$Glyph
  New: Glyph private static MEMBER net/minecraft/client/gui/font/providers/LegacyUnicodeBitmapsProvider
Inconsistent inner class entries for com/mojang/blaze3d/platform/GlStateManager$BooleanState!
  Old: BooleanState static MEMBER com/mojang/blaze3d/platform/GlStateManager$BooleanState
  New: BooleanState private static MEMBER com/mojang/blaze3d/platform/GlStateManager$BlendState
Inconsistent inner class entries for com/mojang/blaze3d/platform/GlStateManager$BlendState!
  Old: BlendState private static MEMBER com/mojang/blaze3d/platform/GlStateManager
  New: BlendState static MEMBER com/mojang/blaze3d/platform/GlStateManager$BlendState
Inconsistent inner class entries for net/minecraft/client/gui/components/AbstractSelectionList$TrackedList!
  Old: TrackedList private MEMBER net/minecraft/client/gui/components/AbstractSelectionList
  New: TrackedList  MEMBER net/minecraft/client/gui/components/AbstractSelectionList$TrackedList
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate$SimplePalette!
  Old: SimplePalette private static MEMBER net/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate
  New: SimplePalette static MEMBER net/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate$SimplePalette
Inconsistent inner class entries for com/mojang/blaze3d/platform/PngInfo$StbReader!
  Old: StbReader abstract static MEMBER com/mojang/blaze3d/platform/PngInfo$StbReader
  New: StbReader private abstract static MEMBER com/mojang/blaze3d/platform/PngInfo$StbReaderBufferedChannel
Inconsistent inner class entries for com/mojang/blaze3d/platform/PngInfo$StbReaderBufferedChannel!
  Old: StbReaderBufferedChannel private static MEMBER com/mojang/blaze3d/platform/PngInfo
  New: StbReaderBufferedChannel static MEMBER com/mojang/blaze3d/platform/PngInfo$StbReaderBufferedChannel
Inconsistent inner class entries for net/minecraft/client/gui/screens/CreateFlatWorldScreen$DetailsList!
  Old: DetailsList  MEMBER net/minecraft/client/gui/screens/CreateFlatWorldScreen$DetailsList
  New: DetailsList private MEMBER net/minecraft/client/gui/screens/CreateFlatWorldScreen
Inconsistent inner class entries for net/minecraft/client/gui/screens/CreateFlatWorldScreen$DetailsList$Entry!
  Old: Entry  MEMBER net/minecraft/client/gui/screens/CreateFlatWorldScreen$DetailsList$Entry
  New: Entry private MEMBER net/minecraft/client/gui/screens/CreateFlatWorldScreen
Inconsistent inner class entries for net/minecraft/commands/arguments/NbtPathArgument$Node!
  Old: Node abstract static MEMBER net/minecraft/commands/arguments/NbtPathArgument$Node
  New: Node private abstract static MEMBER net/minecraft/commands/arguments/NbtPathArgument
Inconsistent inner class entries for net/minecraft/commands/arguments/NbtPathArgument$MatchRootObjectNode!
  Old: MatchRootObjectNode static MEMBER net/minecraft/commands/arguments/NbtPathArgument$MatchRootObjectNode
  New: MatchRootObjectNode private static MEMBER net/minecraft/commands/arguments/NbtPathArgument
Inconsistent inner class entries for net/minecraft/commands/arguments/NbtPathArgument$MatchElementNode!
  Old: MatchElementNode static MEMBER net/minecraft/commands/arguments/NbtPathArgument$MatchElementNode
  New: MatchElementNode private static MEMBER net/minecraft/commands/arguments/NbtPathArgument
Inconsistent inner class entries for net/minecraft/commands/arguments/NbtPathArgument$AllElementsNode!
  Old: AllElementsNode static MEMBER net/minecraft/commands/arguments/NbtPathArgument$AllElementsNode
  New: AllElementsNode private static MEMBER net/minecraft/commands/arguments/NbtPathArgument
Inconsistent inner class entries for net/minecraft/commands/arguments/NbtPathArgument$IndexedElementNode!
  Old: IndexedElementNode static MEMBER net/minecraft/commands/arguments/NbtPathArgument$IndexedElementNode
  New: IndexedElementNode private static MEMBER net/minecraft/commands/arguments/NbtPathArgument
Inconsistent inner class entries for net/minecraft/commands/arguments/NbtPathArgument$CompoundChildNode!
  Old: CompoundChildNode static MEMBER net/minecraft/commands/arguments/NbtPathArgument$CompoundChildNode
  New: CompoundChildNode private static MEMBER net/minecraft/commands/arguments/NbtPathArgument
Inconsistent inner class entries for net/minecraft/data/recipes/ShapedRecipeBuilder$Result!
  Old: Result private static MEMBER net/minecraft/data/recipes/ShapedRecipeBuilder
  New: Result static MEMBER net/minecraft/data/recipes/ShapedRecipeBuilder$Result
Inconsistent inner class entries for net/minecraft/world/entity/monster/Phantom$AttackPhase!
  Old: AttackPhase static final MEMBER net/minecraft/world/entity/monster/Phantom$AttackPhase
  New: AttackPhase private static final MEMBER net/minecraft/world/entity/monster/Phantom$PhantomCircleAroundAnchorGoal
Inconsistent inner class entries for net/minecraft/server/commands/AdvancementCommands$Action!
  Old: Action private abstract static MEMBER net/minecraft/server/commands/AdvancementCommands
  New: Action abstract static MEMBER net/minecraft/server/commands/AdvancementCommands$Action
Inconsistent inner class entries for com/mojang/blaze3d/audio/Library$ChannelPool!
  Old: ChannelPool private abstract static MEMBER com/mojang/blaze3d/audio/Library
  New: ChannelPool abstract static MEMBER com/mojang/blaze3d/audio/Library$ChannelPool
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition!
  Old: RoomDefinition static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition
  New: RoomDefinition private static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$OceanMonumentDoubleXRoom
Inconsistent inner class entries for net/minecraft/client/renderer/RenderStateShard$BooleanStateShard!
  Old: BooleanStateShard static MEMBER net/minecraft/client/renderer/RenderStateShard$BooleanStateShard
  New: BooleanStateShard private static MEMBER net/minecraft/client/renderer/RenderStateShard$OverlayStateShard
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/StrongholdPieces$StrongholdPiece!
  Old: StrongholdPiece abstract static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$StrongholdPiece
  New: StrongholdPiece private abstract static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$RoomCrossing
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/StrongholdPieces$SmoothStoneSelector!
  Old: SmoothStoneSelector static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$SmoothStoneSelector
  New: SmoothStoneSelector private static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$RoomCrossing
Inconsistent inner class entries for net/minecraft/network/protocol/game/ServerboundInteractPacket$InteractionAtLocationAction!
  Old: InteractionAtLocationAction private static MEMBER net/minecraft/network/protocol/game/ServerboundInteractPacket
  New: InteractionAtLocationAction static MEMBER net/minecraft/network/protocol/game/ServerboundInteractPacket$InteractionAtLocationAction
Inconsistent inner class entries for net/minecraft/network/protocol/game/ServerboundInteractPacket$Action!
  Old: Action abstract static MEMBER net/minecraft/network/protocol/game/ServerboundInteractPacket$Action
  New: Action private abstract static MEMBER net/minecraft/network/protocol/game/ServerboundInteractPacket$InteractionAtLocationAction
Inconsistent inner class entries for net/minecraft/world/entity/monster/Phantom$AttackPhase!
  Old: AttackPhase static final MEMBER net/minecraft/world/entity/monster/Phantom$AttackPhase
  New: AttackPhase private static final MEMBER net/minecraft/world/entity/monster/Phantom
Inconsistent inner class entries for net/minecraft/world/entity/monster/Phantom$PhantomMoveControl!
  Old: PhantomMoveControl  MEMBER net/minecraft/world/entity/monster/Phantom$PhantomMoveControl
  New: PhantomMoveControl private MEMBER net/minecraft/world/entity/monster/Phantom
Inconsistent inner class entries for net/minecraft/world/entity/monster/Phantom$PhantomLookControl!
  Old: PhantomLookControl  MEMBER net/minecraft/world/entity/monster/Phantom$PhantomLookControl
  New: PhantomLookControl private MEMBER net/minecraft/world/entity/monster/Phantom
Inconsistent inner class entries for net/minecraft/world/entity/monster/Phantom$PhantomBodyRotationControl!
  Old: PhantomBodyRotationControl  MEMBER net/minecraft/world/entity/monster/Phantom$PhantomBodyRotationControl
  New: PhantomBodyRotationControl private MEMBER net/minecraft/world/entity/monster/Phantom
Inconsistent inner class entries for net/minecraft/world/entity/monster/Phantom$PhantomAttackStrategyGoal!
  Old: PhantomAttackStrategyGoal  MEMBER net/minecraft/world/entity/monster/Phantom$PhantomAttackStrategyGoal
  New: PhantomAttackStrategyGoal private MEMBER net/minecraft/world/entity/monster/Phantom
Inconsistent inner class entries for net/minecraft/world/entity/monster/Phantom$PhantomSweepAttackGoal!
  Old: PhantomSweepAttackGoal  MEMBER net/minecraft/world/entity/monster/Phantom$PhantomSweepAttackGoal
  New: PhantomSweepAttackGoal private MEMBER net/minecraft/world/entity/monster/Phantom
Inconsistent inner class entries for net/minecraft/world/entity/monster/Phantom$PhantomCircleAroundAnchorGoal!
  Old: PhantomCircleAroundAnchorGoal  MEMBER net/minecraft/world/entity/monster/Phantom$PhantomCircleAroundAnchorGoal
  New: PhantomCircleAroundAnchorGoal private MEMBER net/minecraft/world/entity/monster/Phantom
Inconsistent inner class entries for net/minecraft/world/entity/monster/Phantom$PhantomAttackPlayerTargetGoal!
  Old: PhantomAttackPlayerTargetGoal  MEMBER net/minecraft/world/entity/monster/Phantom$PhantomAttackPlayerTargetGoal
  New: PhantomAttackPlayerTargetGoal private MEMBER net/minecraft/world/entity/monster/Phantom
Inconsistent inner class entries for com/mojang/blaze3d/systems/RenderSystem$AutoStorageIndexBuffer$IndexGenerator!
  Old: IndexGenerator abstract static MEMBER com/mojang/blaze3d/systems/RenderSystem$AutoStorageIndexBuffer$IndexGenerator
  New: IndexGenerator private abstract static MEMBER com/mojang/blaze3d/systems/RenderSystem$AutoStorageIndexBuffer
Inconsistent inner class entries for net/minecraft/client/gui/font/FontTexture$Node!
  Old: Node static MEMBER net/minecraft/client/gui/font/FontTexture$Node
  New: Node private static MEMBER net/minecraft/client/gui/font/FontTexture
Inconsistent inner class entries for net/minecraft/client/gui/screens/packs/PackSelectionScreen$Watcher!
  Old: Watcher private static MEMBER net/minecraft/client/gui/screens/packs/PackSelectionScreen
  New: Watcher static MEMBER net/minecraft/client/gui/screens/packs/PackSelectionScreen$Watcher
Inconsistent inner class entries for com/mojang/blaze3d/font/TrueTypeGlyphProvider$Glyph!
  Old: Glyph private MEMBER com/mojang/blaze3d/font/TrueTypeGlyphProvider
  New: Glyph  MEMBER com/mojang/blaze3d/font/TrueTypeGlyphProvider$Glyph
Inconsistent inner class entries for net/minecraft/data/models/blockstates/MultiPartGenerator$Entry!
  Old: Entry static MEMBER net/minecraft/data/models/blockstates/MultiPartGenerator$Entry
  New: Entry private static MEMBER net/minecraft/data/models/blockstates/MultiPartGenerator$ConditionalEntry
Inconsistent inner class entries for net/minecraft/data/models/blockstates/MultiPartGenerator$ConditionalEntry!
  Old: ConditionalEntry private static MEMBER net/minecraft/data/models/blockstates/MultiPartGenerator
  New: ConditionalEntry static MEMBER net/minecraft/data/models/blockstates/MultiPartGenerator$ConditionalEntry
Inconsistent inner class entries for net/minecraft/world/item/enchantment/EnchantmentHelper$EnchantmentVisitor!
  Old: EnchantmentVisitor private abstract static MEMBER net/minecraft/world/item/enchantment/EnchantmentHelper
  New: EnchantmentVisitor abstract static MEMBER net/minecraft/world/item/enchantment/EnchantmentHelper$EnchantmentVisitor
Inconsistent inner class entries for net/minecraft/client/gui/screens/recipebook/OverlayRecipeComponent$OverlaySmeltingRecipeButton!
  Old: OverlaySmeltingRecipeButton private MEMBER net/minecraft/client/gui/screens/recipebook/OverlayRecipeComponent
  New: OverlaySmeltingRecipeButton  MEMBER net/minecraft/client/gui/screens/recipebook/OverlayRecipeComponent$OverlaySmeltingRecipeButton
Inconsistent inner class entries for net/minecraft/client/gui/screens/recipebook/OverlayRecipeComponent$OverlayRecipeButton!
  Old: OverlayRecipeButton  MEMBER net/minecraft/client/gui/screens/recipebook/OverlayRecipeComponent$OverlayRecipeButton
  New: OverlayRecipeButton private MEMBER net/minecraft/client/gui/screens/recipebook/OverlayRecipeComponent$OverlaySmeltingRecipeButton
Inconsistent inner class entries for net/minecraft/world/level/storage/CommandStorage$Container!
  Old: Container static MEMBER net/minecraft/world/level/storage/CommandStorage$Container
  New: Container private static MEMBER net/minecraft/world/level/storage/CommandStorage
Inconsistent inner class entries for net/minecraft/world/level/block/state/BlockBehaviour$BlockStateBase$Cache!
  Old: Cache static final MEMBER net/minecraft/world/level/block/state/BlockBehaviour$BlockStateBase$Cache
  New: Cache private static final MEMBER net/minecraft/world/level/block/state/BlockBehaviour
Inconsistent inner class entries for net/minecraft/client/renderer/texture/TextureAtlasSprite$AnimatedTexture!
  Old: AnimatedTexture  MEMBER net/minecraft/client/renderer/texture/TextureAtlasSprite$AnimatedTexture
  New: AnimatedTexture private MEMBER net/minecraft/client/renderer/texture/TextureAtlasSprite
Inconsistent inner class entries for net/minecraft/client/renderer/texture/TextureAtlasSprite$FrameInfo!
  Old: FrameInfo static MEMBER net/minecraft/client/renderer/texture/TextureAtlasSprite$FrameInfo
  New: FrameInfo private static MEMBER net/minecraft/client/renderer/texture/TextureAtlasSprite
Inconsistent inner class entries for net/minecraft/client/renderer/texture/TextureAtlasSprite$InterpolationData!
  Old: InterpolationData final MEMBER net/minecraft/client/renderer/texture/TextureAtlasSprite$InterpolationData
  New: InterpolationData private final MEMBER net/minecraft/client/renderer/texture/TextureAtlasSprite
Inconsistent inner class entries for net/minecraft/client/renderer/block/model/ItemModelGenerator$Span!
  Old: Span static MEMBER net/minecraft/client/renderer/block/model/ItemModelGenerator$Span
  New: Span private static MEMBER net/minecraft/client/renderer/block/model/ItemModelGenerator
Inconsistent inner class entries for net/minecraft/client/renderer/texture/Stitcher$Holder!
  Old: Holder static MEMBER net/minecraft/client/renderer/texture/Stitcher$Holder
  New: Holder private static MEMBER net/minecraft/client/renderer/texture/Stitcher
Inconsistent inner class entries for com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen$Entry!
  Old: Entry  MEMBER com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen$Entry
  New: Entry private MEMBER com/mojang/realmsclient/gui/screens/RealmsPendingInvitesScreen$Entry$AcceptRowButton
Inconsistent inner class entries for net/minecraft/client/renderer/block/model/ItemModelGenerator$SpanFacing!
  Old: SpanFacing private static final MEMBER net/minecraft/client/renderer/block/model/ItemModelGenerator$1
  New: SpanFacing static final MEMBER net/minecraft/client/renderer/block/model/ItemModelGenerator$SpanFacing
Inconsistent inner class entries for net/minecraft/client/gui/screens/PresetFlatWorldScreen$PresetInfo!
  Old: PresetInfo private static MEMBER net/minecraft/client/gui/screens/PresetFlatWorldScreen
  New: PresetInfo static MEMBER net/minecraft/client/gui/screens/PresetFlatWorldScreen$PresetInfo
Inconsistent inner class entries for net/minecraft/world/entity/monster/Phantom$PhantomMoveTargetGoal!
  Old: PhantomMoveTargetGoal private abstract MEMBER net/minecraft/world/entity/monster/Phantom$PhantomSweepAttackGoal
  New: PhantomMoveTargetGoal abstract MEMBER net/minecraft/world/entity/monster/Phantom$PhantomMoveTargetGoal
Inconsistent inner class entries for net/minecraft/world/level/storage/loot/PredicateManager$CompositePredicate!
  Old: CompositePredicate static MEMBER net/minecraft/world/level/storage/loot/PredicateManager$CompositePredicate
  New: CompositePredicate private static MEMBER net/minecraft/world/level/storage/loot/PredicateManager
Inconsistent inner class entries for net/minecraft/client/StringSplitter$WidthLimitedCharSink!
  Old: WidthLimitedCharSink  MEMBER net/minecraft/client/StringSplitter$WidthLimitedCharSink
  New: WidthLimitedCharSink private MEMBER net/minecraft/client/StringSplitter
Inconsistent inner class entries for net/minecraft/client/StringSplitter$LineBreakFinder!
  Old: LineBreakFinder  MEMBER net/minecraft/client/StringSplitter$LineBreakFinder
  New: LineBreakFinder private MEMBER net/minecraft/client/StringSplitter
Inconsistent inner class entries for net/minecraft/client/StringSplitter$FlatComponents!
  Old: FlatComponents static MEMBER net/minecraft/client/StringSplitter$FlatComponents
  New: FlatComponents private static MEMBER net/minecraft/client/StringSplitter
Inconsistent inner class entries for net/minecraft/client/StringSplitter$LineComponent!
  Old: LineComponent static MEMBER net/minecraft/client/StringSplitter$LineComponent
  New: LineComponent private static MEMBER net/minecraft/client/StringSplitter
Inconsistent inner class entries for net/minecraft/client/gui/screens/worldselection/CreateWorldScreen$SelectedGameMode!
  Old: SelectedGameMode private static final MEMBER net/minecraft/client/gui/screens/worldselection/CreateWorldScreen
  New: SelectedGameMode static final MEMBER net/minecraft/client/gui/screens/worldselection/CreateWorldScreen$SelectedGameMode
Inconsistent inner class entries for net/minecraft/world/entity/monster/Drowned$DrownedTridentAttackGoal!
  Old: DrownedTridentAttackGoal private static MEMBER net/minecraft/world/entity/monster/Drowned
  New: DrownedTridentAttackGoal static MEMBER net/minecraft/world/entity/monster/Drowned$DrownedTridentAttackGoal
Inconsistent inner class entries for net/minecraft/world/entity/monster/Strider$StriderPathNavigation!
  Old: StriderPathNavigation private static MEMBER net/minecraft/world/entity/monster/Strider
  New: StriderPathNavigation static MEMBER net/minecraft/world/entity/monster/Strider$StriderPathNavigation
Inconsistent inner class entries for net/minecraft/client/sounds/LoopingAudioStream$NoCloseBuffer!
  Old: NoCloseBuffer static MEMBER net/minecraft/client/sounds/LoopingAudioStream$NoCloseBuffer
  New: NoCloseBuffer private static MEMBER net/minecraft/client/sounds/LoopingAudioStream
Inconsistent inner class entries for net/minecraft/client/gui/components/CycleButton$ValueListSupplier!
  Old: ValueListSupplier abstract static MEMBER net/minecraft/client/gui/components/CycleButton$ValueListSupplier
  New: ValueListSupplier private abstract static MEMBER net/minecraft/client/gui/components/CycleButton
Inconsistent inner class entries for net/minecraft/client/particle/DripParticle$DripHangParticle!
  Old: DripHangParticle static MEMBER net/minecraft/client/particle/DripParticle$DripHangParticle
  New: DripHangParticle private static MEMBER net/minecraft/client/particle/DripParticle$DripstoneWaterHangProvider
Inconsistent inner class entries for net/minecraft/client/gui/screens/LanguageSelectScreen$LanguageSelectionList!
  Old: LanguageSelectionList private MEMBER net/minecraft/client/gui/screens/LanguageSelectScreen$LanguageSelectionList$Entry
  New: LanguageSelectionList  MEMBER net/minecraft/client/gui/screens/LanguageSelectScreen$LanguageSelectionList
Inconsistent inner class entries for net/minecraft/client/gui/screens/inventory/MerchantScreen$TradeOfferButton!
  Old: TradeOfferButton  MEMBER net/minecraft/client/gui/screens/inventory/MerchantScreen$TradeOfferButton
  New: TradeOfferButton private MEMBER net/minecraft/client/gui/screens/inventory/MerchantScreen
Inconsistent inner class entries for net/minecraft/world/level/levelgen/Aquifer$NoiseBasedAquifer$AquiferStatus!
  Old: AquiferStatus static final MEMBER net/minecraft/world/level/levelgen/Aquifer$NoiseBasedAquifer$AquiferStatus
  New: AquiferStatus private static final MEMBER net/minecraft/world/level/levelgen/Aquifer
Inconsistent inner class entries for net/minecraft/world/level/storage/loot/functions/ApplyBonusCount$UniformBonusCount!
  Old: UniformBonusCount static final MEMBER net/minecraft/world/level/storage/loot/functions/ApplyBonusCount$UniformBonusCount
  New: UniformBonusCount private static final MEMBER net/minecraft/world/level/storage/loot/functions/ApplyBonusCount
Inconsistent inner class entries for net/minecraft/world/level/storage/loot/functions/ApplyBonusCount$OreDrops!
  Old: OreDrops static final MEMBER net/minecraft/world/level/storage/loot/functions/ApplyBonusCount$OreDrops
  New: OreDrops private static final MEMBER net/minecraft/world/level/storage/loot/functions/ApplyBonusCount
Inconsistent inner class entries for net/minecraft/world/level/storage/loot/functions/ApplyBonusCount$BinomialWithBonusCount!
  Old: BinomialWithBonusCount static final MEMBER net/minecraft/world/level/storage/loot/functions/ApplyBonusCount$BinomialWithBonusCount
  New: BinomialWithBonusCount private static final MEMBER net/minecraft/world/level/storage/loot/functions/ApplyBonusCount
Inconsistent inner class entries for net/minecraft/world/level/storage/loot/functions/ApplyBonusCount$FormulaDeserializer!
  Old: FormulaDeserializer abstract static MEMBER net/minecraft/world/level/storage/loot/functions/ApplyBonusCount$FormulaDeserializer
  New: FormulaDeserializer private abstract static MEMBER net/minecraft/world/level/storage/loot/functions/ApplyBonusCount
Inconsistent inner class entries for net/minecraft/world/entity/monster/Vex$VexCopyOwnerTargetGoal!
  Old: VexCopyOwnerTargetGoal private MEMBER net/minecraft/world/entity/monster/Vex
  New: VexCopyOwnerTargetGoal  MEMBER net/minecraft/world/entity/monster/Vex$VexCopyOwnerTargetGoal
Inconsistent inner class entries for net/minecraft/world/entity/animal/axolotl/Axolotl$AxolotlMoveControl!
  Old: AxolotlMoveControl static MEMBER net/minecraft/world/entity/animal/axolotl/Axolotl$AxolotlMoveControl
  New: AxolotlMoveControl private static MEMBER net/minecraft/world/entity/animal/axolotl/Axolotl
Inconsistent inner class entries for net/minecraft/world/entity/animal/axolotl/Axolotl$AxolotlPathNavigation!
  Old: AxolotlPathNavigation static MEMBER net/minecraft/world/entity/animal/axolotl/Axolotl$AxolotlPathNavigation
  New: AxolotlPathNavigation private static MEMBER net/minecraft/world/entity/animal/axolotl/Axolotl
Inconsistent inner class entries for com/mojang/blaze3d/audio/Library$ChannelPool!
  Old: ChannelPool abstract static MEMBER com/mojang/blaze3d/audio/Library$ChannelPool
  New: ChannelPool private abstract static MEMBER com/mojang/blaze3d/audio/Library$1
Inconsistent inner class entries for net/minecraft/world/level/newbiome/layer/Layers$Category!
  Old: Category static final MEMBER net/minecraft/world/level/newbiome/layer/Layers$Category
  New: Category private static final MEMBER net/minecraft/world/level/newbiome/layer/Layers
Inconsistent inner class entries for net/minecraft/client/gui/components/PlayerTabOverlay$PlayerInfoComparator!
  Old: PlayerInfoComparator static MEMBER net/minecraft/client/gui/components/PlayerTabOverlay$PlayerInfoComparator
  New: PlayerInfoComparator private static MEMBER net/minecraft/client/gui/components/PlayerTabOverlay
Inconsistent inner class entries for net/minecraft/data/models/BlockModelGenerators$BlockFamilyProvider!
  Old: BlockFamilyProvider private MEMBER net/minecraft/data/models/BlockModelGenerators
  New: BlockFamilyProvider  MEMBER net/minecraft/data/models/BlockModelGenerators$BlockFamilyProvider
Inconsistent inner class entries for net/minecraft/data/models/BlockModelGenerators$BlockStateGeneratorSupplier!
  Old: BlockStateGeneratorSupplier abstract static MEMBER net/minecraft/data/models/BlockModelGenerators$BlockStateGeneratorSupplier
  New: BlockStateGeneratorSupplier private abstract static MEMBER net/minecraft/data/models/BlockModelGenerators$BlockFamilyProvider
Inconsistent inner class entries for net/minecraft/world/entity/animal/axolotl/Axolotl$AxolotlLookControl!
  Old: AxolotlLookControl private MEMBER net/minecraft/world/entity/animal/axolotl/Axolotl
  New: AxolotlLookControl  MEMBER net/minecraft/world/entity/animal/axolotl/Axolotl$AxolotlLookControl
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$FloorRoomCollection!
  Old: FloorRoomCollection abstract static MEMBER net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$FloorRoomCollection
  New: FloorRoomCollection private abstract static MEMBER net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$FirstFloorRoomCollection
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$FirstFloorRoomCollection!
  Old: FirstFloorRoomCollection private static MEMBER net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces
  New: FirstFloorRoomCollection static MEMBER net/minecraft/world/level/levelgen/structure/WoodlandMansionPieces$FirstFloorRoomCollection
Inconsistent inner class entries for net/minecraft/world/entity/monster/Guardian$GuardianMoveControl!
  Old: GuardianMoveControl static MEMBER net/minecraft/world/entity/monster/Guardian$GuardianMoveControl
  New: GuardianMoveControl private static MEMBER net/minecraft/world/entity/monster/Guardian
Inconsistent inner class entries for net/minecraft/world/entity/monster/Guardian$GuardianAttackGoal!
  Old: GuardianAttackGoal static MEMBER net/minecraft/world/entity/monster/Guardian$GuardianAttackGoal
  New: GuardianAttackGoal private static MEMBER net/minecraft/world/entity/monster/Guardian
Inconsistent inner class entries for net/minecraft/world/entity/monster/Guardian$GuardianAttackSelector!
  Old: GuardianAttackSelector static MEMBER net/minecraft/world/entity/monster/Guardian$GuardianAttackSelector
  New: GuardianAttackSelector private static MEMBER net/minecraft/world/entity/monster/Guardian
Inconsistent inner class entries for net/minecraft/client/gui/screens/inventory/BookEditScreen$LineInfo!
  Old: LineInfo private static MEMBER net/minecraft/client/gui/screens/inventory/BookEditScreen
  New: LineInfo static MEMBER net/minecraft/client/gui/screens/inventory/BookEditScreen$LineInfo
Inconsistent inner class entries for net/minecraft/commands/arguments/item/ItemPredicateArgument$ItemPredicate!
  Old: ItemPredicate static MEMBER net/minecraft/commands/arguments/item/ItemPredicateArgument$ItemPredicate
  New: ItemPredicate private static MEMBER net/minecraft/commands/arguments/item/ItemPredicateArgument
Inconsistent inner class entries for net/minecraft/commands/arguments/item/ItemPredicateArgument$TagPredicate!
  Old: TagPredicate static MEMBER net/minecraft/commands/arguments/item/ItemPredicateArgument$TagPredicate
  New: TagPredicate private static MEMBER net/minecraft/commands/arguments/item/ItemPredicateArgument
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/StrongholdPieces$StrongholdPiece!
  Old: StrongholdPiece abstract static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$StrongholdPiece
  New: StrongholdPiece private abstract static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$StrongholdPiece$SmallDoorType
Inconsistent inner class entries for net/minecraft/world/level/PotentialCalculator$PointCharge!
  Old: PointCharge static MEMBER net/minecraft/world/level/PotentialCalculator$PointCharge
  New: PointCharge private static MEMBER net/minecraft/world/level/PotentialCalculator
Inconsistent inner class entries for net/minecraft/nbt/IntTag$Cache!
  Old: Cache private static MEMBER net/minecraft/nbt/IntTag
  New: Cache static MEMBER net/minecraft/nbt/IntTag$Cache
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition!
  Old: RoomDefinition static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition
  New: RoomDefinition private static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$OceanMonumentCoreRoom
Inconsistent inner class entries for net/minecraft/Util$IdentityStrategy!
  Old: IdentityStrategy private static final MEMBER net/minecraft/Util
  New: IdentityStrategy static final MEMBER net/minecraft/Util$IdentityStrategy
Inconsistent inner class entries for net/minecraft/world/item/crafting/Ingredient$Value!
  Old: Value abstract static MEMBER net/minecraft/world/item/crafting/Ingredient$Value
  New: Value private abstract static MEMBER net/minecraft/world/item/crafting/Ingredient
Inconsistent inner class entries for net/minecraft/world/item/crafting/Ingredient$TagValue!
  Old: TagValue static MEMBER net/minecraft/world/item/crafting/Ingredient$TagValue
  New: TagValue private static MEMBER net/minecraft/world/item/crafting/Ingredient
Inconsistent inner class entries for net/minecraft/world/item/crafting/Ingredient$ItemValue!
  Old: ItemValue static MEMBER net/minecraft/world/item/crafting/Ingredient$ItemValue
  New: ItemValue private static MEMBER net/minecraft/world/item/crafting/Ingredient
Inconsistent inner class entries for net/minecraft/world/entity/npc/VillagerTrades$EmeraldsForVillagerTypeItem!
  Old: EmeraldsForVillagerTypeItem private static MEMBER net/minecraft/world/entity/npc/VillagerTrades
  New: EmeraldsForVillagerTypeItem static MEMBER net/minecraft/world/entity/npc/VillagerTrades$EmeraldsForVillagerTypeItem
Inconsistent inner class entries for net/minecraft/client/renderer/RenderType$CompositeRenderType!
  Old: CompositeRenderType static final MEMBER net/minecraft/client/renderer/RenderType$CompositeRenderType
  New: CompositeRenderType private static final MEMBER net/minecraft/client/renderer/RenderType
Inconsistent inner class entries for net/minecraft/client/renderer/RenderType$OutlineProperty!
  Old: OutlineProperty static final MEMBER net/minecraft/client/renderer/RenderType$OutlineProperty
  New: OutlineProperty private static final MEMBER net/minecraft/client/renderer/RenderType
Inconsistent inner class entries for net/minecraft/client/multiplayer/ClientChunkCache$Storage!
  Old: Storage private final MEMBER net/minecraft/client/multiplayer/ClientChunkCache
  New: Storage final MEMBER net/minecraft/client/multiplayer/ClientChunkCache$Storage
Inconsistent inner class entries for net/minecraft/client/gui/screens/MenuScreens$ScreenConstructor!
  Old: ScreenConstructor abstract static MEMBER net/minecraft/client/gui/screens/MenuScreens$ScreenConstructor
  New: ScreenConstructor private abstract static MEMBER net/minecraft/client/gui/screens/MenuScreens
Inconsistent inner class entries for net/minecraft/advancements/critereon/PlayerPredicate$AdvancementDonePredicate!
  Old: AdvancementDonePredicate static MEMBER net/minecraft/advancements/critereon/PlayerPredicate$AdvancementDonePredicate
  New: AdvancementDonePredicate private static MEMBER net/minecraft/advancements/critereon/PlayerPredicate$Builder
Inconsistent inner class entries for net/minecraft/advancements/critereon/PlayerPredicate$AdvancementCriterionsPredicate!
  Old: AdvancementCriterionsPredicate static MEMBER net/minecraft/advancements/critereon/PlayerPredicate$AdvancementCriterionsPredicate
  New: AdvancementCriterionsPredicate private static MEMBER net/minecraft/advancements/critereon/PlayerPredicate$Builder
Inconsistent inner class entries for net/minecraft/advancements/critereon/PlayerPredicate$AdvancementPredicate!
  Old: AdvancementPredicate abstract static MEMBER net/minecraft/advancements/critereon/PlayerPredicate$AdvancementPredicate
  New: AdvancementPredicate private abstract static MEMBER net/minecraft/advancements/critereon/PlayerPredicate$Builder
Inconsistent inner class entries for net/minecraft/network/protocol/game/ServerboundInteractPacket$ActionType!
  Old: ActionType private static final MEMBER net/minecraft/network/protocol/game/ServerboundInteractPacket$InteractionAction
  New: ActionType static final MEMBER net/minecraft/network/protocol/game/ServerboundInteractPacket$ActionType
Inconsistent inner class entries for net/minecraft/network/protocol/game/ServerboundInteractPacket$Action!
  Old: Action abstract static MEMBER net/minecraft/network/protocol/game/ServerboundInteractPacket$Action
  New: Action private abstract static MEMBER net/minecraft/network/protocol/game/ServerboundInteractPacket$ActionType
Inconsistent inner class entries for net/minecraft/network/protocol/game/ServerboundInteractPacket$InteractionAction!
  Old: InteractionAction static MEMBER net/minecraft/network/protocol/game/ServerboundInteractPacket$InteractionAction
  New: InteractionAction private static MEMBER net/minecraft/network/protocol/game/ServerboundInteractPacket$ActionType
Inconsistent inner class entries for net/minecraft/network/protocol/game/ServerboundInteractPacket$InteractionAtLocationAction!
  Old: InteractionAtLocationAction static MEMBER net/minecraft/network/protocol/game/ServerboundInteractPacket$InteractionAtLocationAction
  New: InteractionAtLocationAction private static MEMBER net/minecraft/network/protocol/game/ServerboundInteractPacket$ActionType
Inconsistent inner class entries for net/minecraft/world/entity/ai/goal/RangedCrossbowAttackGoal$CrossbowState!
  Old: CrossbowState static final MEMBER net/minecraft/world/entity/ai/goal/RangedCrossbowAttackGoal$CrossbowState
  New: CrossbowState private static final MEMBER net/minecraft/world/entity/ai/goal/RangedCrossbowAttackGoal
Inconsistent inner class entries for net/minecraft/world/entity/animal/goat/Goat$GoatNodeEvaluator!
  Old: GoatNodeEvaluator private static MEMBER net/minecraft/world/entity/animal/goat/Goat
  New: GoatNodeEvaluator static MEMBER net/minecraft/world/entity/animal/goat/Goat$GoatNodeEvaluator
Inconsistent inner class entries for net/minecraft/network/Connection$PacketHolder!
  Old: PacketHolder static MEMBER net/minecraft/network/Connection$PacketHolder
  New: PacketHolder private static MEMBER net/minecraft/network/Connection
Inconsistent inner class entries for net/minecraft/world/entity/animal/Turtle$TurtleMoveControl!
  Old: TurtleMoveControl static MEMBER net/minecraft/world/entity/animal/Turtle$TurtleMoveControl
  New: TurtleMoveControl private static MEMBER net/minecraft/world/entity/animal/Turtle
Inconsistent inner class entries for net/minecraft/world/entity/animal/Turtle$TurtleBreedGoal!
  Old: TurtleBreedGoal static MEMBER net/minecraft/world/entity/animal/Turtle$TurtleBreedGoal
  New: TurtleBreedGoal private static MEMBER net/minecraft/world/entity/animal/Turtle
Inconsistent inner class entries for net/minecraft/world/entity/animal/Turtle$TurtleLayEggGoal!
  Old: TurtleLayEggGoal static MEMBER net/minecraft/world/entity/animal/Turtle$TurtleLayEggGoal
  New: TurtleLayEggGoal private static MEMBER net/minecraft/world/entity/animal/Turtle
Inconsistent inner class entries for net/minecraft/world/entity/animal/Turtle$TurtleGoToWaterGoal!
  Old: TurtleGoToWaterGoal static MEMBER net/minecraft/world/entity/animal/Turtle$TurtleGoToWaterGoal
  New: TurtleGoToWaterGoal private static MEMBER net/minecraft/world/entity/animal/Turtle
Inconsistent inner class entries for net/minecraft/world/entity/animal/Turtle$TurtleGoHomeGoal!
  Old: TurtleGoHomeGoal static MEMBER net/minecraft/world/entity/animal/Turtle$TurtleGoHomeGoal
  New: TurtleGoHomeGoal private static MEMBER net/minecraft/world/entity/animal/Turtle
Inconsistent inner class entries for net/minecraft/world/entity/animal/Turtle$TurtleTravelGoal!
  Old: TurtleTravelGoal static MEMBER net/minecraft/world/entity/animal/Turtle$TurtleTravelGoal
  New: TurtleTravelGoal private static MEMBER net/minecraft/world/entity/animal/Turtle
Inconsistent inner class entries for net/minecraft/world/entity/animal/Turtle$TurtleRandomStrollGoal!
  Old: TurtleRandomStrollGoal static MEMBER net/minecraft/world/entity/animal/Turtle$TurtleRandomStrollGoal
  New: TurtleRandomStrollGoal private static MEMBER net/minecraft/world/entity/animal/Turtle
Inconsistent inner class entries for net/minecraft/commands/arguments/selector/options/EntitySelectorOptions$Option!
  Old: Option static MEMBER net/minecraft/commands/arguments/selector/options/EntitySelectorOptions$Option
  New: Option private static MEMBER net/minecraft/commands/arguments/selector/options/EntitySelectorOptions
Inconsistent inner class entries for net/minecraft/world/entity/npc/VillagerTrades$TippedArrowForItemsAndEmeralds!
  Old: TippedArrowForItemsAndEmeralds private static MEMBER net/minecraft/world/entity/npc/VillagerTrades
  New: TippedArrowForItemsAndEmeralds static MEMBER net/minecraft/world/entity/npc/VillagerTrades$TippedArrowForItemsAndEmeralds
Inconsistent inner class entries for net/minecraft/client/gui/screens/LoadingOverlay$LogoTexture!
  Old: LogoTexture private static MEMBER net/minecraft/client/gui/screens/LoadingOverlay
  New: LogoTexture static MEMBER net/minecraft/client/gui/screens/LoadingOverlay$LogoTexture
Inconsistent inner class entries for net/minecraft/world/entity/animal/Bee$BaseBeeGoal!
  Old: BaseBeeGoal private abstract MEMBER net/minecraft/world/entity/animal/Bee$BeeEnterHiveGoal
  New: BaseBeeGoal abstract MEMBER net/minecraft/world/entity/animal/Bee$BaseBeeGoal
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/NetherBridgePieces$PieceWeight!
  Old: PieceWeight static MEMBER net/minecraft/world/level/levelgen/structure/NetherBridgePieces$PieceWeight
  New: PieceWeight private static MEMBER net/minecraft/world/level/levelgen/structure/NetherBridgePieces$NetherBridgePiece
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/NetherBridgePieces$NetherBridgePiece!
  Old: NetherBridgePiece private abstract static MEMBER net/minecraft/world/level/levelgen/structure/NetherBridgePieces$CastleCorridorTBalconyPiece
  New: NetherBridgePiece abstract static MEMBER net/minecraft/world/level/levelgen/structure/NetherBridgePieces$NetherBridgePiece
Inconsistent inner class entries for net/minecraft/world/entity/raid/Raid$RaidStatus!
  Old: RaidStatus static final MEMBER net/minecraft/world/entity/raid/Raid$RaidStatus
  New: RaidStatus private static final MEMBER net/minecraft/world/entity/raid/Raid
Inconsistent inner class entries for net/minecraft/world/entity/raid/Raid$RaiderType!
  Old: RaiderType static final MEMBER net/minecraft/world/entity/raid/Raid$RaiderType
  New: RaiderType private static final MEMBER net/minecraft/world/entity/raid/Raid
Inconsistent inner class entries for net/minecraft/server/commands/TeleportCommand$LookAt!
  Old: LookAt private static MEMBER net/minecraft/server/commands/TeleportCommand
  New: LookAt static MEMBER net/minecraft/server/commands/TeleportCommand$LookAt
Inconsistent inner class entries for net/minecraft/client/gui/screens/worldselection/EditGameRulesScreen$EntryFactory!
  Old: EntryFactory abstract static MEMBER net/minecraft/client/gui/screens/worldselection/EditGameRulesScreen$EntryFactory
  New: EntryFactory private abstract static MEMBER net/minecraft/client/gui/screens/worldselection/EditGameRulesScreen$RuleList$1
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition!
  Old: RoomDefinition static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$RoomDefinition
  New: RoomDefinition private static MEMBER net/minecraft/world/level/levelgen/structure/OceanMonumentPieces$OceanMonumentDoubleYZRoom
Inconsistent inner class entries for net/minecraft/client/gui/screens/achievement/StatsScreen$GeneralStatisticsList!
  Old: GeneralStatisticsList private MEMBER net/minecraft/client/gui/screens/achievement/StatsScreen$GeneralStatisticsList$Entry
  New: GeneralStatisticsList  MEMBER net/minecraft/client/gui/screens/achievement/StatsScreen$GeneralStatisticsList
Inconsistent inner class entries for net/minecraft/client/gui/screens/achievement/StatsScreen$GeneralStatisticsList$Entry!
  Old: Entry  MEMBER net/minecraft/client/gui/screens/achievement/StatsScreen$GeneralStatisticsList$Entry
  New: Entry private MEMBER net/minecraft/client/gui/screens/achievement/StatsScreen$GeneralStatisticsList
Inconsistent inner class entries for net/minecraft/world/entity/animal/Turtle$TurtlePanicGoal!
  Old: TurtlePanicGoal private static MEMBER net/minecraft/world/entity/animal/Turtle
  New: TurtlePanicGoal static MEMBER net/minecraft/world/entity/animal/Turtle$TurtlePanicGoal
Inconsistent inner class entries for net/minecraft/server/commands/DebugCommand$Tracer!
  Old: Tracer private static MEMBER net/minecraft/server/commands/DebugCommand
  New: Tracer static MEMBER net/minecraft/server/commands/DebugCommand$Tracer
Inconsistent inner class entries for net/minecraft/client/renderer/chunk/ChunkRenderDispatcher$RenderChunk$ChunkCompileTask!
  Old: ChunkCompileTask private abstract MEMBER net/minecraft/client/renderer/chunk/ChunkRenderDispatcher$RenderChunk
  New: ChunkCompileTask abstract MEMBER net/minecraft/client/renderer/chunk/ChunkRenderDispatcher$RenderChunk$ChunkCompileTask
Inconsistent inner class entries for net/minecraft/client/renderer/chunk/ChunkRenderDispatcher$ChunkTaskResult!
  Old: ChunkTaskResult static final MEMBER net/minecraft/client/renderer/chunk/ChunkRenderDispatcher$ChunkTaskResult
  New: ChunkTaskResult private static final MEMBER net/minecraft/client/renderer/chunk/ChunkRenderDispatcher$RenderChunk$ChunkCompileTask
Inconsistent inner class entries for net/minecraft/world/entity/ai/village/poi/PoiManager$DistanceTracker!
  Old: DistanceTracker private final MEMBER net/minecraft/world/entity/ai/village/poi/PoiManager
  New: DistanceTracker final MEMBER net/minecraft/world/entity/ai/village/poi/PoiManager$DistanceTracker
Inconsistent inner class entries for net/minecraft/client/gui/screens/achievement/StatsScreen$MobsStatisticsList!
  Old: MobsStatisticsList  MEMBER net/minecraft/client/gui/screens/achievement/StatsScreen$MobsStatisticsList
  New: MobsStatisticsList private MEMBER net/minecraft/client/gui/screens/achievement/StatsScreen$MobsStatisticsList$MobRow
Inconsistent inner class entries for net/minecraft/client/gui/screens/achievement/StatsScreen$MobsStatisticsList$MobRow!
  Old: MobRow private MEMBER net/minecraft/client/gui/screens/achievement/StatsScreen$MobsStatisticsList
  New: MobRow  MEMBER net/minecraft/client/gui/screens/achievement/StatsScreen$MobsStatisticsList$MobRow
Inconsistent inner class entries for net/minecraft/client/gui/components/LockIconButton$Icon!
  Old: Icon static final MEMBER net/minecraft/client/gui/components/LockIconButton$Icon
  New: Icon private static final MEMBER net/minecraft/client/gui/components/LockIconButton
Inconsistent inner class entries for net/minecraft/client/gui/spectator/SpectatorMenu$CloseSpectatorItem!
  Old: CloseSpectatorItem private static MEMBER net/minecraft/client/gui/spectator/SpectatorMenu
  New: CloseSpectatorItem static MEMBER net/minecraft/client/gui/spectator/SpectatorMenu$CloseSpectatorItem
Inconsistent inner class entries for net/minecraft/client/gui/MapRenderer$MapInstance!
  Old: MapInstance private MEMBER net/minecraft/client/gui/MapRenderer
  New: MapInstance  MEMBER net/minecraft/client/gui/MapRenderer$MapInstance
Inconsistent inner class entries for net/minecraft/world/entity/npc/VillagerTrades$EnchantBookForEmeralds!
  Old: EnchantBookForEmeralds private static MEMBER net/minecraft/world/entity/npc/VillagerTrades
  New: EnchantBookForEmeralds static MEMBER net/minecraft/world/entity/npc/VillagerTrades$EnchantBookForEmeralds
Inconsistent inner class entries for net/minecraft/world/level/storage/loot/entries/LootPoolSingletonContainer$DummyBuilder!
  Old: DummyBuilder private static MEMBER net/minecraft/world/level/storage/loot/entries/LootPoolSingletonContainer
  New: DummyBuilder static MEMBER net/minecraft/world/level/storage/loot/entries/LootPoolSingletonContainer$DummyBuilder
Inconsistent inner class entries for net/minecraft/client/gui/screens/recipebook/OverlayRecipeComponent$OverlayRecipeButton!
  Old: OverlayRecipeButton  MEMBER net/minecraft/client/gui/screens/recipebook/OverlayRecipeComponent$OverlayRecipeButton
  New: OverlayRecipeButton private MEMBER net/minecraft/client/gui/screens/recipebook/OverlayRecipeComponent$OverlayRecipeButton$Pos
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/NetherBridgePieces$NetherBridgePiece!
  Old: NetherBridgePiece abstract static MEMBER net/minecraft/world/level/levelgen/structure/NetherBridgePieces$NetherBridgePiece
  New: NetherBridgePiece private abstract static MEMBER net/minecraft/world/level/levelgen/structure/NetherBridgePieces$CastleEntrance
Inconsistent inner class entries for com/mojang/realmsclient/gui/screens/RealmsSelectFileToUploadScreen$Entry!
  Old: Entry private MEMBER com/mojang/realmsclient/gui/screens/RealmsSelectFileToUploadScreen
  New: Entry  MEMBER com/mojang/realmsclient/gui/screens/RealmsSelectFileToUploadScreen$Entry
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/NetherBridgePieces$NetherBridgePiece!
  Old: NetherBridgePiece abstract static MEMBER net/minecraft/world/level/levelgen/structure/NetherBridgePieces$NetherBridgePiece
  New: NetherBridgePiece private abstract static MEMBER net/minecraft/world/level/levelgen/structure/NetherBridgePieces$RoomCrossing
Inconsistent inner class entries for net/minecraft/client/gui/screens/inventory/BookEditScreen$DisplayCache!
  Old: DisplayCache private static MEMBER net/minecraft/client/gui/screens/inventory/BookEditScreen
  New: DisplayCache static MEMBER net/minecraft/client/gui/screens/inventory/BookEditScreen$DisplayCache
Inconsistent inner class entries for net/minecraft/client/gui/screens/inventory/BookEditScreen$Pos2i!
  Old: Pos2i static MEMBER net/minecraft/client/gui/screens/inventory/BookEditScreen$Pos2i
  New: Pos2i private static MEMBER net/minecraft/client/gui/screens/inventory/BookEditScreen$DisplayCache
Inconsistent inner class entries for net/minecraft/client/gui/screens/inventory/BookEditScreen$LineInfo!
  Old: LineInfo static MEMBER net/minecraft/client/gui/screens/inventory/BookEditScreen$LineInfo
  New: LineInfo private static MEMBER net/minecraft/client/gui/screens/inventory/BookEditScreen$DisplayCache
Inconsistent inner class entries for net/minecraft/server/commands/LootCommand$TailProvider!
  Old: TailProvider abstract static MEMBER net/minecraft/server/commands/LootCommand$TailProvider
  New: TailProvider private abstract static MEMBER net/minecraft/server/commands/LootCommand
Inconsistent inner class entries for net/minecraft/server/commands/LootCommand$DropConsumer!
  Old: DropConsumer abstract static MEMBER net/minecraft/server/commands/LootCommand$DropConsumer
  New: DropConsumer private abstract static MEMBER net/minecraft/server/commands/LootCommand
Inconsistent inner class entries for net/minecraft/server/commands/LootCommand$Callback!
  Old: Callback abstract static MEMBER net/minecraft/server/commands/LootCommand$Callback
  New: Callback private abstract static MEMBER net/minecraft/server/commands/LootCommand
Inconsistent inner class entries for net/minecraft/world/level/storage/loot/functions/ApplyBonusCount$Formula!
  Old: Formula private abstract static MEMBER net/minecraft/world/level/storage/loot/functions/ApplyBonusCount$Serializer
  New: Formula abstract static MEMBER net/minecraft/world/level/storage/loot/functions/ApplyBonusCount$Formula
Inconsistent inner class entries for net/minecraft/world/level/entity/PersistentEntitySectionManager$ChunkLoadStatus!
  Old: ChunkLoadStatus private static final MEMBER net/minecraft/world/level/entity/PersistentEntitySectionManager
  New: ChunkLoadStatus static final MEMBER net/minecraft/world/level/entity/PersistentEntitySectionManager$ChunkLoadStatus
Inconsistent inner class entries for net/minecraft/world/level/ChunkTickList$ScheduledTick!
  Old: ScheduledTick static MEMBER net/minecraft/world/level/ChunkTickList$ScheduledTick
  New: ScheduledTick private static MEMBER net/minecraft/world/level/ChunkTickList
Inconsistent inner class entries for net/minecraft/world/entity/monster/EnderMan$EndermanFreezeWhenLookedAt!
  Old: EndermanFreezeWhenLookedAt static MEMBER net/minecraft/world/entity/monster/EnderMan$EndermanFreezeWhenLookedAt
  New: EndermanFreezeWhenLookedAt private static MEMBER net/minecraft/world/entity/monster/EnderMan
Inconsistent inner class entries for net/minecraft/world/entity/monster/EnderMan$EndermanLeaveBlockGoal!
  Old: EndermanLeaveBlockGoal static MEMBER net/minecraft/world/entity/monster/EnderMan$EndermanLeaveBlockGoal
  New: EndermanLeaveBlockGoal private static MEMBER net/minecraft/world/entity/monster/EnderMan
Inconsistent inner class entries for net/minecraft/world/entity/monster/EnderMan$EndermanTakeBlockGoal!
  Old: EndermanTakeBlockGoal static MEMBER net/minecraft/world/entity/monster/EnderMan$EndermanTakeBlockGoal
  New: EndermanTakeBlockGoal private static MEMBER net/minecraft/world/entity/monster/EnderMan
Inconsistent inner class entries for net/minecraft/world/entity/monster/EnderMan$EndermanLookForPlayerGoal!
  Old: EndermanLookForPlayerGoal static MEMBER net/minecraft/world/entity/monster/EnderMan$EndermanLookForPlayerGoal
  New: EndermanLookForPlayerGoal private static MEMBER net/minecraft/world/entity/monster/EnderMan
Inconsistent inner class entries for net/minecraft/world/entity/animal/Dolphin$PlayWithItemsGoal!
  Old: PlayWithItemsGoal private MEMBER net/minecraft/world/entity/animal/Dolphin
  New: PlayWithItemsGoal  MEMBER net/minecraft/world/entity/animal/Dolphin$PlayWithItemsGoal
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/StrongholdPieces$PieceWeight!
  Old: PieceWeight static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$PieceWeight
  New: PieceWeight private static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/StrongholdPieces$StrongholdPiece!
  Old: StrongholdPiece abstract static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$StrongholdPiece
  New: StrongholdPiece private abstract static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/StrongholdPieces$SmoothStoneSelector!
  Old: SmoothStoneSelector static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$SmoothStoneSelector
  New: SmoothStoneSelector private static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces
Inconsistent inner class entries for net/minecraft/client/multiplayer/ClientLevel$EntityCallbacks!
  Old: EntityCallbacks final MEMBER net/minecraft/client/multiplayer/ClientLevel$EntityCallbacks
  New: EntityCallbacks private final MEMBER net/minecraft/client/multiplayer/ClientLevel
Inconsistent inner class entries for net/minecraft/client/multiplayer/ClientLevel$MarkerParticleStatus!
  Old: MarkerParticleStatus static final MEMBER net/minecraft/client/multiplayer/ClientLevel$MarkerParticleStatus
  New: MarkerParticleStatus private static final MEMBER net/minecraft/client/multiplayer/ClientLevel
Inconsistent inner class entries for net/minecraft/client/Game$Metrics!
  Old: Metrics static MEMBER net/minecraft/client/Game$Metrics
  New: Metrics private static MEMBER net/minecraft/client/Game
Inconsistent inner class entries for net/minecraft/commands/arguments/NbtPathArgument$MatchObjectNode!
  Old: MatchObjectNode private static MEMBER net/minecraft/commands/arguments/NbtPathArgument
  New: MatchObjectNode static MEMBER net/minecraft/commands/arguments/NbtPathArgument$MatchObjectNode
Inconsistent inner class entries for net/minecraft/commands/arguments/NbtPathArgument$Node!
  Old: Node abstract static MEMBER net/minecraft/commands/arguments/NbtPathArgument$Node
  New: Node private abstract static MEMBER net/minecraft/commands/arguments/NbtPathArgument$MatchObjectNode
Inconsistent inner class entries for net/minecraft/world/level/chunk/EmptyLevelChunk$EmptyChunkBiomeContainer!
  Old: EmptyChunkBiomeContainer private static MEMBER net/minecraft/world/level/chunk/EmptyLevelChunk
  New: EmptyChunkBiomeContainer static MEMBER net/minecraft/world/level/chunk/EmptyLevelChunk$EmptyChunkBiomeContainer
Inconsistent inner class entries for net/minecraft/world/entity/animal/Ocelot$OcelotTemptGoal!
  Old: OcelotTemptGoal static MEMBER net/minecraft/world/entity/animal/Ocelot$OcelotTemptGoal
  New: OcelotTemptGoal private static MEMBER net/minecraft/world/entity/animal/Ocelot
Inconsistent inner class entries for net/minecraft/world/entity/animal/Ocelot$OcelotAvoidEntityGoal!
  Old: OcelotAvoidEntityGoal static MEMBER net/minecraft/world/entity/animal/Ocelot$OcelotAvoidEntityGoal
  New: OcelotAvoidEntityGoal private static MEMBER net/minecraft/world/entity/animal/Ocelot
Inconsistent inner class entries for net/minecraft/world/level/biome/Biome$ClimateSettings!
  Old: ClimateSettings static MEMBER net/minecraft/world/level/biome/Biome$ClimateSettings
  New: ClimateSettings private static MEMBER net/minecraft/world/level/biome/Biome$BiomeBuilder
Inconsistent inner class entries for net/minecraft/world/level/chunk/storage/RegionFile$ChunkBuffer!
  Old: ChunkBuffer private MEMBER net/minecraft/world/level/chunk/storage/RegionFile
  New: ChunkBuffer  MEMBER net/minecraft/world/level/chunk/storage/RegionFile$ChunkBuffer
Inconsistent inner class entries for net/minecraft/world/level/block/entity/BlockEntityType$BlockEntitySupplier!
  Old: BlockEntitySupplier private abstract static MEMBER net/minecraft/world/level/block/entity/BlockEntityType
  New: BlockEntitySupplier abstract static MEMBER net/minecraft/world/level/block/entity/BlockEntityType$BlockEntitySupplier
Inconsistent inner class entries for net/minecraft/world/entity/animal/Turtle$TurtlePathNavigation!
  Old: TurtlePathNavigation private static MEMBER net/minecraft/world/entity/animal/Turtle
  New: TurtlePathNavigation static MEMBER net/minecraft/world/entity/animal/Turtle$TurtlePathNavigation
Inconsistent inner class entries for net/minecraft/world/item/ItemCooldowns$CooldownInstance!
  Old: CooldownInstance private MEMBER net/minecraft/world/item/ItemCooldowns
  New: CooldownInstance  MEMBER net/minecraft/world/item/ItemCooldowns$CooldownInstance
Inconsistent inner class entries for com/mojang/realmsclient/gui/screens/RealmsSelectFileToUploadScreen$WorldSelectionList!
  Old: WorldSelectionList private MEMBER com/mojang/realmsclient/gui/screens/RealmsSelectFileToUploadScreen
  New: WorldSelectionList  MEMBER com/mojang/realmsclient/gui/screens/RealmsSelectFileToUploadScreen$WorldSelectionList
Inconsistent inner class entries for com/mojang/realmsclient/gui/screens/RealmsSelectFileToUploadScreen$Entry!
  Old: Entry  MEMBER com/mojang/realmsclient/gui/screens/RealmsSelectFileToUploadScreen$Entry
  New: Entry private MEMBER com/mojang/realmsclient/gui/screens/RealmsSelectFileToUploadScreen$WorldSelectionList
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/StrongholdPieces$StrongholdPiece!
  Old: StrongholdPiece abstract static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$StrongholdPiece
  New: StrongholdPiece private abstract static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$StraightStairsDown
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/StrongholdPieces$SmoothStoneSelector!
  Old: SmoothStoneSelector static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$SmoothStoneSelector
  New: SmoothStoneSelector private static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$StraightStairsDown
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/StrongholdPieces$PieceWeight!
  Old: PieceWeight static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$PieceWeight
  New: PieceWeight private static MEMBER net/minecraft/world/level/levelgen/structure/StrongholdPieces$StartPiece
Inconsistent inner class entries for net/minecraft/world/level/GameRules$VisitorCaller!
  Old: VisitorCaller abstract static MEMBER net/minecraft/world/level/GameRules$VisitorCaller
  New: VisitorCaller private abstract static MEMBER net/minecraft/world/level/GameRules$Type
Inconsistent inner class entries for net/minecraft/world/entity/monster/Shulker$ShulkerPeekGoal!
  Old: ShulkerPeekGoal private MEMBER net/minecraft/world/entity/monster/Shulker
  New: ShulkerPeekGoal  MEMBER net/minecraft/world/entity/monster/Shulker$ShulkerPeekGoal
Inconsistent inner class entries for net/minecraft/server/commands/ExperienceCommand$Type!
  Old: Type static final MEMBER net/minecraft/server/commands/ExperienceCommand$Type
  New: Type private static final MEMBER net/minecraft/server/commands/ExperienceCommand
Inconsistent inner class entries for net/minecraft/world/entity/animal/Fox$SleepGoal!
  Old: SleepGoal private MEMBER net/minecraft/world/entity/animal/Fox
  New: SleepGoal  MEMBER net/minecraft/world/entity/animal/Fox$SleepGoal
Inconsistent inner class entries for net/minecraft/world/entity/animal/Fox$FoxBehaviorGoal!
  Old: FoxBehaviorGoal abstract MEMBER net/minecraft/world/entity/animal/Fox$FoxBehaviorGoal
  New: FoxBehaviorGoal private abstract MEMBER net/minecraft/world/entity/animal/Fox$SleepGoal
Inconsistent inner class entries for net/minecraft/world/entity/ai/Brain$MemoryValue!
  Old: MemoryValue private static final MEMBER net/minecraft/world/entity/ai/Brain$1
  New: MemoryValue static final MEMBER net/minecraft/world/entity/ai/Brain$MemoryValue
Inconsistent inner class entries for net/minecraft/world/entity/raid/Raider$RaiderMoveThroughVillageGoal!
  Old: RaiderMoveThroughVillageGoal private static MEMBER net/minecraft/world/entity/raid/Raider
  New: RaiderMoveThroughVillageGoal static MEMBER net/minecraft/world/entity/raid/Raider$RaiderMoveThroughVillageGoal
Inconsistent inner class entries for net/minecraft/world/level/levelgen/Aquifer$NoiseBasedAquifer$AquiferStatus!
  Old: AquiferStatus static final MEMBER net/minecraft/world/level/levelgen/Aquifer$NoiseBasedAquifer$AquiferStatus
  New: AquiferStatus private static final MEMBER net/minecraft/world/level/levelgen/Aquifer$NoiseBasedAquifer
Inconsistent inner class entries for net/minecraft/advancements/critereon/StatePropertiesPredicate$ExactPropertyMatcher!
  Old: ExactPropertyMatcher static MEMBER net/minecraft/advancements/critereon/StatePropertiesPredicate$ExactPropertyMatcher
  New: ExactPropertyMatcher private static MEMBER net/minecraft/advancements/critereon/StatePropertiesPredicate
Inconsistent inner class entries for net/minecraft/advancements/critereon/StatePropertiesPredicate$RangedPropertyMatcher!
  Old: RangedPropertyMatcher static MEMBER net/minecraft/advancements/critereon/StatePropertiesPredicate$RangedPropertyMatcher
  New: RangedPropertyMatcher private static MEMBER net/minecraft/advancements/critereon/StatePropertiesPredicate
Inconsistent inner class entries for net/minecraft/advancements/critereon/StatePropertiesPredicate$PropertyMatcher!
  Old: PropertyMatcher abstract static MEMBER net/minecraft/advancements/critereon/StatePropertiesPredicate$PropertyMatcher
  New: PropertyMatcher private abstract static MEMBER net/minecraft/advancements/critereon/StatePropertiesPredicate
Inconsistent inner class entries for net/minecraft/world/entity/monster/Ravager$RavagerNodeEvaluator!
  Old: RavagerNodeEvaluator static MEMBER net/minecraft/world/entity/monster/Ravager$RavagerNodeEvaluator
  New: RavagerNodeEvaluator private static MEMBER net/minecraft/world/entity/monster/Ravager$RavagerNavigation
Inconsistent inner class entries for net/minecraft/world/entity/monster/Ravager$RavagerNavigation!
  Old: RavagerNavigation private static MEMBER net/minecraft/world/entity/monster/Ravager
  New: RavagerNavigation static MEMBER net/minecraft/world/entity/monster/Ravager$RavagerNavigation
Inconsistent inner class entries for net/minecraft/server/commands/SpreadPlayersCommand$Position!
  Old: Position private static MEMBER net/minecraft/server/commands/SpreadPlayersCommand
  New: Position static MEMBER net/minecraft/server/commands/SpreadPlayersCommand$Position
Inconsistent inner class entries for net/minecraft/client/particle/DripParticle$DripstoneFallAndLandParticle!
  Old: DripstoneFallAndLandParticle static MEMBER net/minecraft/client/particle/DripParticle$DripstoneFallAndLandParticle
  New: DripstoneFallAndLandParticle private static MEMBER net/minecraft/client/particle/DripParticle$DripstoneWaterFallProvider
Inconsistent inner class entries for net/minecraft/client/gui/screens/PresetFlatWorldScreen$PresetsList!
  Old: PresetsList private MEMBER net/minecraft/client/gui/screens/PresetFlatWorldScreen
  New: PresetsList  MEMBER net/minecraft/client/gui/screens/PresetFlatWorldScreen$PresetsList
Inconsistent inner class entries for net/minecraft/client/gui/screens/PresetFlatWorldScreen$PresetInfo!
  Old: PresetInfo static MEMBER net/minecraft/client/gui/screens/PresetFlatWorldScreen$PresetInfo
  New: PresetInfo private static MEMBER net/minecraft/client/gui/screens/PresetFlatWorldScreen$PresetsList
Inconsistent inner class entries for net/minecraft/world/inventory/MenuType$MenuSupplier!
  Old: MenuSupplier private abstract static MEMBER net/minecraft/world/inventory/MenuType
  New: MenuSupplier abstract static MEMBER net/minecraft/world/inventory/MenuType$MenuSupplier
Inconsistent inner class entries for net/minecraft/network/protocol/game/ClientboundBossEventPacket$UpdateNameOperation!
  Old: UpdateNameOperation private static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$OperationType
  New: UpdateNameOperation static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$UpdateNameOperation
Inconsistent inner class entries for net/minecraft/network/protocol/game/ClientboundBossEventPacket$OperationType!
  Old: OperationType static final MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$OperationType
  New: OperationType private static final MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$UpdateNameOperation
Inconsistent inner class entries for net/minecraft/network/protocol/game/ClientboundBossEventPacket$Operation!
  Old: Operation abstract static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$Operation
  New: Operation private abstract static MEMBER net/minecraft/network/protocol/game/ClientboundBossEventPacket$UpdateNameOperation
Inconsistent inner class entries for net/minecraft/client/renderer/block/ModelBlockRenderer$AmbientOcclusionFace!
  Old: AmbientOcclusionFace  MEMBER net/minecraft/client/renderer/block/ModelBlockRenderer$AmbientOcclusionFace
  New: AmbientOcclusionFace private MEMBER net/minecraft/client/renderer/block/ModelBlockRenderer
Inconsistent inner class entries for net/minecraft/client/renderer/block/ModelBlockRenderer$Cache!
  Old: Cache static MEMBER net/minecraft/client/renderer/block/ModelBlockRenderer$Cache
  New: Cache private static MEMBER net/minecraft/client/renderer/block/ModelBlockRenderer
Inconsistent inner class entries for net/minecraft/client/renderer/block/ModelBlockRenderer$AmbientVertexRemap!
  Old: AmbientVertexRemap static final MEMBER net/minecraft/client/renderer/block/ModelBlockRenderer$AmbientVertexRemap
  New: AmbientVertexRemap private static final MEMBER net/minecraft/client/renderer/block/ModelBlockRenderer
Inconsistent inner class entries for net/minecraft/world/level/storage/loot/functions/SetAttributesFunction$Modifier!
  Old: Modifier static MEMBER net/minecraft/world/level/storage/loot/functions/SetAttributesFunction$Modifier
  New: Modifier private static MEMBER net/minecraft/world/level/storage/loot/functions/SetAttributesFunction$ModifierBuilder
Inconsistent inner class entries for net/minecraft/world/entity/raid/Raid$RaiderType!
  Old: RaiderType static final MEMBER net/minecraft/world/entity/raid/Raid$RaiderType
  New: RaiderType private static final MEMBER net/minecraft/world/entity/raid/Raid$1
Inconsistent inner class entries for net/minecraft/client/gui/screens/packs/PackSelectionModel$UnselectedPackEntry!
  Old: UnselectedPackEntry private MEMBER net/minecraft/client/gui/screens/packs/PackSelectionModel
  New: UnselectedPackEntry  MEMBER net/minecraft/client/gui/screens/packs/PackSelectionModel$UnselectedPackEntry
Inconsistent inner class entries for net/minecraft/client/gui/screens/packs/PackSelectionModel$EntryBase!
  Old: EntryBase abstract MEMBER net/minecraft/client/gui/screens/packs/PackSelectionModel$EntryBase
  New: EntryBase private abstract MEMBER net/minecraft/client/gui/screens/packs/PackSelectionModel$UnselectedPackEntry
Inconsistent inner class entries for net/minecraft/data/structures/SnbtToNbt$TaskResult!
  Old: TaskResult static MEMBER net/minecraft/data/structures/SnbtToNbt$TaskResult
  New: TaskResult private static MEMBER net/minecraft/data/structures/SnbtToNbt
Inconsistent inner class entries for net/minecraft/data/structures/SnbtToNbt$StructureConversionException!
  Old: StructureConversionException static MEMBER net/minecraft/data/structures/SnbtToNbt$StructureConversionException
  New: StructureConversionException private static MEMBER net/minecraft/data/structures/SnbtToNbt
Inconsistent inner class entries for net/minecraft/world/entity/animal/Wolf$WolfAvoidEntityGoal!
  Old: WolfAvoidEntityGoal private MEMBER net/minecraft/world/entity/animal/Wolf
  New: WolfAvoidEntityGoal  MEMBER net/minecraft/world/entity/animal/Wolf$WolfAvoidEntityGoal
Inconsistent inner class entries for com/mojang/realmsclient/gui/screens/RealmsBackupScreen$BackupObjectSelectionList!
  Old: BackupObjectSelectionList private MEMBER com/mojang/realmsclient/gui/screens/RealmsBackupScreen$1
  New: BackupObjectSelectionList  MEMBER com/mojang/realmsclient/gui/screens/RealmsBackupScreen$BackupObjectSelectionList
Inconsistent inner class entries for com/mojang/realmsclient/gui/screens/RealmsBackupScreen$Entry!
  Old: Entry  MEMBER com/mojang/realmsclient/gui/screens/RealmsBackupScreen$Entry
  New: Entry private MEMBER com/mojang/realmsclient/gui/screens/RealmsBackupScreen$BackupObjectSelectionList
Inconsistent inner class entries for net/minecraft/server/level/ChunkMap$DistanceManager!
  Old: DistanceManager  MEMBER net/minecraft/server/level/ChunkMap$DistanceManager
  New: DistanceManager private MEMBER net/minecraft/server/level/ChunkMap
Inconsistent inner class entries for net/minecraft/server/level/ChunkMap$TrackedEntity!
  Old: TrackedEntity  MEMBER net/minecraft/server/level/ChunkMap$TrackedEntity
  New: TrackedEntity private MEMBER net/minecraft/server/level/ChunkMap
Inconsistent inner class entries for net/minecraft/world/level/GameRules$VisitorCaller!
  Old: VisitorCaller abstract static MEMBER net/minecraft/world/level/GameRules$VisitorCaller
  New: VisitorCaller private abstract static MEMBER net/minecraft/world/level/GameRules$IntegerValue
Inconsistent inner class entries for net/minecraft/world/level/border/WorldBorder$StaticBorderExtent!
  Old: StaticBorderExtent  MEMBER net/minecraft/world/level/border/WorldBorder$StaticBorderExtent
  New: StaticBorderExtent private MEMBER net/minecraft/world/level/border/WorldBorder
Inconsistent inner class entries for net/minecraft/world/level/border/WorldBorder$BorderExtent!
  Old: BorderExtent abstract static MEMBER net/minecraft/world/level/border/WorldBorder$BorderExtent
  New: BorderExtent private abstract static MEMBER net/minecraft/world/level/border/WorldBorder
Inconsistent inner class entries for net/minecraft/world/level/border/WorldBorder$MovingBorderExtent!
  Old: MovingBorderExtent  MEMBER net/minecraft/world/level/border/WorldBorder$MovingBorderExtent
  New: MovingBorderExtent private MEMBER net/minecraft/world/level/border/WorldBorder
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/MineShaftPieces$MineShaftPiece!
  Old: MineShaftPiece private abstract static MEMBER net/minecraft/world/level/levelgen/structure/MineShaftPieces$MineShaftStairs
  New: MineShaftPiece abstract static MEMBER net/minecraft/world/level/levelgen/structure/MineShaftPieces$MineShaftPiece
Inconsistent inner class entries for net/minecraft/world/level/levelgen/structure/MineShaftPieces$MineShaftPiece!
  Old: MineShaftPiece abstract static MEMBER net/minecraft/world/level/levelgen/structure/MineShaftPieces$MineShaftPiece
  New: MineShaftPiece private abstract static MEMBER net/minecraft/world/level/levelgen/structure/MineShaftPieces$MineShaftRoom
Inconsistent inner class entries for net/minecraft/nbt/LongTag$Cache!
  Old: Cache static MEMBER net/minecraft/nbt/LongTag$Cache
  New: Cache private static MEMBER net/minecraft/nbt/LongTag
Inconsistent inner class entries for net/minecraft/client/renderer/debug/GameEventListenerRenderer$TrackedGameEvent!
  Old: TrackedGameEvent private static MEMBER net/minecraft/client/renderer/debug/GameEventListenerRenderer
  New: TrackedGameEvent static MEMBER net/minecraft/client/renderer/debug/GameEventListenerRenderer$TrackedGameEvent
Inconsistent inner class entries for net/minecraft/world/level/block/ComposterBlock$OutputContainer!
  Old: OutputContainer private static MEMBER net/minecraft/world/level/block/ComposterBlock
  New: OutputContainer static MEMBER net/minecraft/world/level/block/ComposterBlock$OutputContainer
Inconsistent inner class entries for net/minecraft/util/ExtraCodecs$XorCodec!
  Old: XorCodec private static final MEMBER net/minecraft/util/ExtraCodecs
  New: XorCodec static final MEMBER net/minecraft/util/ExtraCodecs$XorCodec
Inconsistent inner class entries for net/minecraft/server/level/ChunkHolder$ChunkSaveDebug!
  Old: ChunkSaveDebug static final MEMBER net/minecraft/server/level/ChunkHolder$ChunkSaveDebug
  New: ChunkSaveDebug private static final MEMBER net/minecraft/server/level/ChunkHolder
```
