### PR TITLE
Fix compound assignments not being generated in some instances

### DIFF
--- a/FernFlower-Patches/0043-Fix-compound-assignments.patch
+++ b/FernFlower-Patches/0043-Fix-compound-assignments.patch
@@ -1,0 +1,625 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperCoder79 <25208576+SuperCoder7979@users.noreply.github.com>
+Date: Fri, 18 Jun 2021 20:52:17 -0400
+Subject: [PATCH] Fix compound assignments
+
+
+diff --git a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
+index 795cc200b44c547862cfb8742b216b1c7032f2e8..1de3ccd0d3966f82bd07d0b45e1692f6c22348db 100644
+--- a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
++++ b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
+@@ -222,6 +222,8 @@ public class MethodProcessorRunnable implements Runnable {
+ 
+     varProc.setVarDefinitions(root);
+ 
++    SecondaryFunctionsHelper.updateAssignments(root);
++
+     // must be the last invocation, because it makes the statement structure inconsistent
+     // FIXME: new edge type needed
+     LabelHelper.replaceContinueWithBreak(root);
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/SecondaryFunctionsHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/SecondaryFunctionsHelper.java
+index beaa6c260a1e85e939556705f38b0bb16280a29d..e4056c4ae81eff96d2c4e84b86c81148ae732e05 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/SecondaryFunctionsHelper.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SecondaryFunctionsHelper.java
+@@ -431,4 +431,46 @@ public final class SecondaryFunctionsHelper {
+ 
+     return null;
+   }
++
++  // Updates assignments to make them compound assignments if possible
++  public static void updateAssignments(Statement stat) {
++    List<Object> objects = new ArrayList<>(stat.getExprents() == null ? stat.getSequentialObjects() : stat.getExprents());
++
++    for (Object obj : objects) {
++      if (obj instanceof Statement) {
++        updateAssignments((Statement) obj);
++      } else if (obj instanceof Exprent) {
++        Exprent exprent = (Exprent) obj;
++
++        if (exprent.type == Exprent.EXPRENT_ASSIGNMENT) {
++          AssignmentExprent assignment = (AssignmentExprent) exprent;
++
++          List<Exprent> params = exprent.getAllExprents();
++
++          Exprent lhs = params.get(0);
++          Exprent rhs = params.get(1);
++
++          // Check for expressions that are standard assignments where the left hand side is a variable and the right hand side is a function
++          if (assignment.getCondType() == -1 && lhs.type == Exprent.EXPRENT_VAR && rhs.type == Exprent.EXPRENT_FUNCTION) {
++            VarExprent lhsVar = (VarExprent) lhs;
++            FunctionExprent rhsFunc = (FunctionExprent) rhs;
++
++            List<Exprent> funcParams = rhsFunc.getAllExprents();
++
++            // Make sure that the function is a mathematical or bitwise function and function's lhs is a variable
++            if (rhsFunc.getFuncType() <= FunctionExprent.FUNCTION_USHR && funcParams.get(0).type == Exprent.EXPRENT_VAR) {
++              VarExprent lhsVarFunc = (VarExprent) funcParams.get(0);
++
++              // Check if the left hand side of the assignment and the left hand side of the function are the same variable
++              if (lhsVar.getIndex() == lhsVarFunc.getIndex()) {
++                // If all the checks succeed, set the assignment to be a compound assignment and set the right to the right hand side of the function
++                assignment.setCondType(rhsFunc.getFuncType());
++                assignment.setRight(funcParams.get(1));
++              }
++            }
++          }
++        }
++      }
++    }
++  }
+ }
+diff --git a/test/org/jetbrains/java/decompiler/SingleClassesTest.java b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+index 381a1ecc559e59b38c28a6a10df465384cd40d0e..ee57e305da26b7678fb605f61e16f61f35e112c4 100644
+--- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
++++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
+@@ -122,4 +122,5 @@ public class SingleClassesTest extends SingleClassesTestBase {
+   @Test public void testRecordGenericVararg() { doTest("records/TestRecordGenericVararg"); }
+   @Test public void testRecordAnno() { doTest("records/TestRecordAnno"); }
+   @Test public void testTryWithResources() { doTest("pkg/TestTryWithResources"); }
++  @Test public void testCompoundAssignment() { doTest("pkg/TestCompoundAssignment"); }
+ }
+diff --git a/testData/classes/pkg/TestCompoundAssignment.class b/testData/classes/pkg/TestCompoundAssignment.class
+new file mode 100644
+index 0000000000000000000000000000000000000000..8a940dae3be9898b8044cb4c670134f2fd640381
+GIT binary patch
+literal 1407
+zcmdUuOHUI~7>3_dIvp+LY73Q_@e)xBN-<vWR#B`XMYNbUF2KbMFexo`+Duym#t`B!
+zaBJeixY30hS0*luYkw5_o}Ox$q<_FRXXgFBb9%n#yY$z=_a6YRBN;^x5;{h7j0!|D
+zWv|?v73fJ#JQoOOYa6b>z*5<BpSG%Nu3vQ4w&{sB-A1!euGXcYrE<B6oItO1W^2;9
+z!>j0RyN3?BmmS~r8Uni9Z0`;q+AX@i=lHt<N7~yf^3uLS(^=no;?z5l+d<}h-`UOA
+z)xlMDQM6EN`Rnd{St1$54oa=%ZOk<q<&sx*y=J=NymVp+LlYRQZ<VII9}^gq2dB3k
+zuQZ)stGMe;oJNR+lAj1z7-)P(Xjyy<zO~735ML>nT;~w@10v!mpYmv>bH$`#+8M*#
+z;M(Nc=Gx=h=X%5Siff1Kb;kJe@4hs8sWk?U@J1amJ_mVo98n~>XVP;DeHceSQruyS
+z=v8s|$PwnRXARS`Wn{~iu`OFhw`>{TvL%6KO9so96qYSHEL)OTb{Cd7NfL}Yf?<r3
+zA&C<>&iG@Pgn>&WnqhG=I7x~a$rQ_bvS?&^A#Y8DHx&+rBBD@G6pD*Np;0J03I#}^
+z7%3DcMHkXDtkXCt&ywpL)p<;@Ml+beU9v9V0-oU_R*)uRKL!-3_)JpSwU0(Zdk5Y8
+z1l{8O1P<8b4%oyG*vukeGns(RoB}pe3)svsU^CHx-N`r9o;o!pm)ZX-oQA9H!ZqAu
+zrpx@J+qi)`Zeky|@D{i60e5%~_=)(U_$`yw5fbtvUyuJE7yC8D?*5%GtutR!iLkkv
+zXS<YOpOj#OlwfC+U`v!>FO*;tlwkFhVA+-EGGB9?ulpp(a=spLz8-SE=2`VeoUa9b
+SbDXb5&eswdkFnw*#Qy+u$=<90
+
+literal 0
+HcmV?d00001
+
+diff --git a/testData/results/TestCompoundAssignment.dec b/testData/results/TestCompoundAssignment.dec
+new file mode 100644
+index 0000000000000000000000000000000000000000..ef6bd4a14465342f35ec718df5fa47754b187ad9
+--- /dev/null
++++ b/testData/results/TestCompoundAssignment.dec
+@@ -0,0 +1,432 @@
++package pkg;
++
++public class TestCompoundAssignment {
++   public int testSimple(int var1, int var2) {
++      var1 += var2;// 5
++      var1 -= var2;// 6
++      var1 *= var2;// 7
++      var1 /= var2;// 8
++      var1 &= var2;// 9
++      var1 |= var2;// 10
++      var1 ^= var2;// 11
++      var1 >>= var2;// 12
++      var1 <<= var2;// 13
++      return var1 >>> var2;// 14 16
++   }
++
++   public int testComplex(int var1, int var2, int var3) {
++      var1 += var2 + var3;// 20
++      var1 -= var2 + var3;// 21
++      var1 *= var2 + var3;// 22
++      var1 /= var2 + var3;// 23
++      var1 &= var2 + var3;// 24
++      var1 |= var2 + var3;// 25
++      var1 ^= var2 + var3;// 26
++      var1 >>= var2 + var3;// 27
++      var1 <<= var2 + var3;// 28
++      return var1 >>> var2 + var3;// 29 31
++   }
++
++   public int testComplexParens(int var1, int var2, int var3, int var4) {
++      var1 += (var2 + var3) * var4;// 35
++      var1 -= (var2 + var3) * var4;// 36
++      var1 *= (var2 + var3) * var4;// 37
++      var1 /= (var2 + var3) * var4;// 38
++      var1 &= (var2 + var3) * var4;// 39
++      var1 |= (var2 + var3) * var4;// 40
++      var1 ^= (var2 + var3) * var4;// 41
++      var1 >>= (var2 + var3) * var4;// 42
++      var1 <<= (var2 + var3) * var4;// 43
++      return var1 >>> (var2 + var3) * var4;// 44 46
++   }
++
++   public int testComplexTernary(int var1, int var2, int var3, int var4, boolean var5) {
++      var1 += var5 ? var2 : var3 * var4;// 50
++      var1 -= var5 ? var2 : var3 * var4;// 51
++      var1 *= var5 ? var2 : var3 * var4;// 52
++      var1 /= var5 ? var2 : var3 * var4;// 53
++      var1 &= var5 ? var2 : var3 * var4;// 54
++      var1 |= var5 ? var2 : var3 * var4;// 55
++      var1 ^= var5 ? var2 : var3 * var4;// 56
++      var1 >>= var5 ? var2 : var3 * var4;// 57
++      var1 <<= var5 ? var2 : var3 * var4;// 58
++      return var1 >>> (var5 ? var2 : var3 * var4);// 59 61
++   }
++
++   public int testArrayOp(int var1, int var2, int[] var3, int var4) {
++      var1 += var3[var4] = var2;// 65
++      var1 -= var3[var4] = var2;// 66
++      var1 *= var3[var4] = var2;// 67
++      var1 /= var3[var4] = var2;// 68
++      var1 &= var3[var4] = var2;// 69
++      var1 |= var3[var4] = var2;// 70
++      var1 ^= var3[var4] = var2;// 71
++      var1 >>= var3[var4] = var2;// 72
++      var1 <<= var3[var4] = var2;// 73
++      return var1 >>> (var3[var4] = var2);// 74 76
++   }
++}
++
++class 'pkg/TestCompoundAssignment' {
++   method 'testSimple (II)I' {
++      1      4
++      3      4
++      5      5
++      7      5
++      9      6
++      b      6
++      d      7
++      f      7
++      11      8
++      13      8
++      15      9
++      17      9
++      19      10
++      1b      10
++      1d      11
++      1f      11
++      21      12
++      23      12
++      24      13
++      25      13
++      26      13
++      29      13
++   }
++
++   method 'testComplex (III)I' {
++      1      17
++      2      17
++      3      17
++      5      17
++      7      18
++      8      18
++      9      18
++      b      18
++      d      19
++      e      19
++      f      19
++      11      19
++      13      20
++      14      20
++      15      20
++      17      20
++      19      21
++      1a      21
++      1b      21
++      1d      21
++      1f      22
++      20      22
++      21      22
++      23      22
++      25      23
++      26      23
++      27      23
++      29      23
++      2b      24
++      2c      24
++      2d      24
++      2f      24
++      31      25
++      32      25
++      33      25
++      35      25
++      36      26
++      37      26
++      38      26
++      39      26
++      3a      26
++      3d      26
++   }
++
++   method 'testComplexParens (IIII)I' {
++      1      30
++      2      30
++      3      30
++      4      30
++      5      30
++      6      30
++      8      30
++      a      31
++      b      31
++      c      31
++      d      31
++      e      31
++      f      31
++      11      31
++      13      32
++      14      32
++      15      32
++      16      32
++      17      32
++      18      32
++      1a      32
++      1c      33
++      1d      33
++      1e      33
++      1f      33
++      20      33
++      21      33
++      23      33
++      25      34
++      26      34
++      27      34
++      28      34
++      29      34
++      2a      34
++      2c      34
++      2e      35
++      2f      35
++      30      35
++      31      35
++      32      35
++      33      35
++      35      35
++      37      36
++      38      36
++      39      36
++      3a      36
++      3b      36
++      3c      36
++      3e      36
++      40      37
++      41      37
++      42      37
++      43      37
++      44      37
++      45      37
++      47      37
++      49      38
++      4a      38
++      4b      38
++      4c      38
++      4d      38
++      4e      38
++      50      38
++      51      39
++      52      39
++      53      39
++      54      39
++      55      39
++      56      39
++      57      39
++      58      39
++      5b      39
++   }
++
++   method 'testComplexTernary (IIIIZ)I' {
++      1      43
++      2      43
++      3      43
++      6      43
++      a      43
++      b      43
++      c      43
++      d      43
++      f      43
++      11      44
++      12      44
++      13      44
++      16      44
++      1a      44
++      1b      44
++      1c      44
++      1d      44
++      1f      44
++      21      45
++      22      45
++      23      45
++      26      45
++      2a      45
++      2b      45
++      2c      45
++      2d      45
++      2f      45
++      31      46
++      32      46
++      33      46
++      36      46
++      3a      46
++      3b      46
++      3c      46
++      3d      46
++      3f      46
++      41      47
++      42      47
++      43      47
++      46      47
++      4a      47
++      4b      47
++      4c      47
++      4d      47
++      4f      47
++      51      48
++      52      48
++      53      48
++      56      48
++      5a      48
++      5b      48
++      5c      48
++      5d      48
++      5f      48
++      61      49
++      62      49
++      63      49
++      66      49
++      6a      49
++      6b      49
++      6c      49
++      6d      49
++      6f      49
++      71      50
++      72      50
++      73      50
++      76      50
++      7a      50
++      7b      50
++      7c      50
++      7d      50
++      7f      50
++      81      51
++      82      51
++      83      51
++      86      51
++      8a      51
++      8b      51
++      8c      51
++      8d      51
++      8f      51
++      90      52
++      91      52
++      92      52
++      93      52
++      96      52
++      9a      52
++      9b      52
++      9c      52
++      9d      52
++      9e      52
++      a1      52
++   }
++
++   method 'testArrayOp (II[II)I' {
++      1      56
++      2      56
++      3      56
++      4      56
++      6      56
++      8      56
++      a      57
++      b      57
++      c      57
++      d      57
++      f      57
++      11      57
++      13      58
++      14      58
++      15      58
++      16      58
++      18      58
++      1a      58
++      1c      59
++      1d      59
++      1e      59
++      1f      59
++      21      59
++      23      59
++      25      60
++      26      60
++      27      60
++      28      60
++      2a      60
++      2c      60
++      2e      61
++      2f      61
++      30      61
++      31      61
++      33      61
++      35      61
++      37      62
++      38      62
++      39      62
++      3a      62
++      3c      62
++      3e      62
++      40      63
++      41      63
++      42      63
++      43      63
++      45      63
++      47      63
++      49      64
++      4a      64
++      4b      64
++      4c      64
++      4e      64
++      50      64
++      51      65
++      52      65
++      53      65
++      54      65
++      55      65
++      57      65
++      58      65
++      5b      65
++   }
++}
++
++Lines mapping:
++5 <-> 5
++6 <-> 6
++7 <-> 7
++8 <-> 8
++9 <-> 9
++10 <-> 10
++11 <-> 11
++12 <-> 12
++13 <-> 13
++14 <-> 14
++16 <-> 14
++20 <-> 18
++21 <-> 19
++22 <-> 20
++23 <-> 21
++24 <-> 22
++25 <-> 23
++26 <-> 24
++27 <-> 25
++28 <-> 26
++29 <-> 27
++31 <-> 27
++35 <-> 31
++36 <-> 32
++37 <-> 33
++38 <-> 34
++39 <-> 35
++40 <-> 36
++41 <-> 37
++42 <-> 38
++43 <-> 39
++44 <-> 40
++46 <-> 40
++50 <-> 44
++51 <-> 45
++52 <-> 46
++53 <-> 47
++54 <-> 48
++55 <-> 49
++56 <-> 50
++57 <-> 51
++58 <-> 52
++59 <-> 53
++61 <-> 53
++65 <-> 57
++66 <-> 58
++67 <-> 59
++68 <-> 60
++69 <-> 61
++70 <-> 62
++71 <-> 63
++72 <-> 64
++73 <-> 65
++74 <-> 66
++76 <-> 66
+diff --git a/testData/src/pkg/TestCompoundAssignment.java b/testData/src/pkg/TestCompoundAssignment.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..e356c63affc489c36e01a7bb8404c98bf432ac7e
+--- /dev/null
++++ b/testData/src/pkg/TestCompoundAssignment.java
+@@ -0,0 +1,78 @@
++package pkg;
++
++public class TestCompoundAssignment {
++    public int testSimple(int i, int j) {
++        i += j;
++        i -= j;
++        i *= j;
++        i /= j;
++        i &= j;
++        i |= j;
++        i ^= j;
++        i >>= j;
++        i <<= j;
++        i >>>= j;
++        
++        return i;
++    }
++
++    public int testComplex(int i, int j, int k) {
++        i += j + k;
++        i -= j + k;
++        i *= j + k;
++        i /= j + k;
++        i &= j + k;
++        i |= j + k;
++        i ^= j + k;
++        i >>= j + k;
++        i <<= j + k;
++        i >>>= j + k;
++
++        return i;
++    }
++
++    public int testComplexParens(int i, int j, int k, int m) {
++        i += (j + k) * m;
++        i -= (j + k) * m;
++        i *= (j + k) * m;
++        i /= (j + k) * m;
++        i &= (j + k) * m;
++        i |= (j + k) * m;
++        i ^= (j + k) * m;
++        i >>= (j + k) * m;
++        i <<= (j + k) * m;
++        i >>>= (j + k) * m;
++
++        return i;
++    }
++
++    public int testComplexTernary(int i, int j, int k, int m, boolean b) {
++        i += b ? j : k * m;
++        i -= b ? j : k * m;
++        i *= b ? j : k * m;
++        i /= b ? j : k * m;
++        i &= b ? j : k * m;
++        i |= b ? j : k * m;
++        i ^= b ? j : k * m;
++        i >>= b ? j : k * m;
++        i <<= b ? j : k * m;
++        i >>>= b ? j : k * m;
++
++        return i;
++    }
++
++    public int testArrayOp(int i, int j, int[] a, int b) {
++        i += a[b] = j;
++        i -= a[b] = j;
++        i *= a[b] = j;
++        i /= a[b] = j;
++        i &= a[b] = j;
++        i |= a[b] = j;
++        i ^= a[b] = j;
++        i >>= a[b] = j;
++        i <<= a[b] = j;
++        i >>>= a[b] = j;
++
++        return i;
++    }
++}


### PR DESCRIPTION
This PR fixes compound assignment operations (+=, *=, etc.) not being created in some cases. It seems like compound assignments were originally created by `VarVersionsProcessor.simpleMerge`, but it's commented out in `VarVersionsProcessor#setVarVersions`. From my testing that method has quite a few side effects, so I've opted to manually process the assignments to check for compound assignments instead, to improve readability of the generated code. I've also included a test case to prevent future regressions.

Diff: https://gist.github.com/SuperCoder7979/fc4c5bc343f910b17e4ccb7158691910