### PR TITLE
Remove the default keyword from private interface methods

### DIFF
--- a/FernFlower-Patches/0045-Remove-default-keyword-from-private-interface-method.patch
+++ b/FernFlower-Patches/0045-Remove-default-keyword-from-private-interface-method.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: coehlrich <coehlrich@users.noreply.github.com>
+Date: Tue, 16 Nov 2021 18:22:31 +1300
+Subject: [PATCH] Remove default keyword from private interface methods
+
+
+diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
+index 1cf01714f6c93e87c7efea321e460f655c497c07..d7294ac46709a2d429389b2d310c6dff82041795 100644
+--- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
++++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
+@@ -827,7 +827,7 @@ public class ClassWriter {
+ 
+       appendModifiers(buffer, flags, METHOD_ALLOWED, isInterface, METHOD_EXCLUDED);
+ 
+-      if (isInterface && !mt.hasModifier(CodeConstants.ACC_STATIC) && mt.containsCode()) {
++      if (isInterface && !mt.hasModifier(CodeConstants.ACC_STATIC) && !mt.hasModifier(CodeConstants.ACC_PRIVATE) && mt.containsCode()) {
+         // 'default' modifier (Java 8)
+         buffer.append("default ");
+       }


### PR DESCRIPTION
Removes the default keyword from private interface methods since private interface methods just use `private` instead of `private default`

1.18 Pre Release 1 diff:
```diff
diff --git a/net/minecraft/world/level/CollisionGetter.java b/net/minecraft/world/level/CollisionGetter.java
index 68894da..76dd14b 100644
--- a/net/minecraft/world/level/CollisionGetter.java
+++ b/net/minecraft/world/level/CollisionGetter.java
@@ -75,7 +75,7 @@ public interface CollisionGetter extends BlockGetter {
    }

    @Nullable
-   private default VoxelShape m_186440_(Entity p_186441_, AABB p_186442_) {
+   private VoxelShape m_186440_(Entity p_186441_, AABB p_186442_) {
       WorldBorder worldborder = this.m_6857_();
       return worldborder.m_187566_(p_186441_, p_186442_) ? worldborder.m_61946_() : null;
    }
diff --git a/net/minecraft/world/level/LevelAccessor.java b/net/minecraft/world/level/LevelAccessor.java
index 1811d4e..1c80224 100644
--- a/net/minecraft/world/level/LevelAccessor.java
+++ b/net/minecraft/world/level/LevelAccessor.java
@@ -29,11 +29,11 @@ public interface LevelAccessor extends CommonLevelAccessor, LevelTimeAccess {

    LevelTickAccess<Block> m_183326_();

-   private default <T> ScheduledTick<T> m_186482_(BlockPos p_186483_, T p_186484_, int p_186485_, TickPriority p_186486_) {
+   private <T> ScheduledTick<T> m_186482_(BlockPos p_186483_, T p_186484_, int p_186485_, TickPriority p_186486_) {
       return new ScheduledTick(p_186484_, p_186483_, this.m_6106_().m_6793_() + (long)p_186485_, p_186486_, this.m_183596_());
    }

-   private default <T> ScheduledTick<T> m_186478_(BlockPos p_186479_, T p_186480_, int p_186481_) {
+   private <T> ScheduledTick<T> m_186478_(BlockPos p_186479_, T p_186480_, int p_186481_) {
       return new ScheduledTick(p_186480_, p_186479_, this.m_6106_().m_6793_() + (long)p_186481_, this.m_183596_());
    }
```