### PR TITLE
Reduce allocations in getAllExprents

### DIFF
--- a/FernFlower-Patches/0048-Reduce-allocations-in-getAllExprents.patch
+++ b/FernFlower-Patches/0048-Reduce-allocations-in-getAllExprents.patch
@@ -1,0 +1,269 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperCoder79 <25208576+SuperCoder7979@users.noreply.github.com>
+Date: Sun, 21 Nov 2021 17:33:09 -0500
+Subject: [PATCH] Reduce allocations in getAllExprents
+
+
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AnnotationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AnnotationExprent.java
+index a6601eee39bde738f840f01806a13b907583af50..df0898d64a1201d56643673a3da752ed13b56c3d 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AnnotationExprent.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AnnotationExprent.java
+@@ -28,6 +28,13 @@ public class AnnotationExprent extends Exprent {
+     this.parValues = parValues;
+   }
+ 
++  @Override
++  protected List<Exprent> getAllExprents(List<Exprent> list) {
++    list.addAll(this.parValues);
++
++    return list;
++  }
++
+   @Override
+   public TextBuffer toJava(int indent, BytecodeMappingTracer tracer) {
+     TextBuffer buffer = new TextBuffer();
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ArrayExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ArrayExprent.java
+index 9fd3f0547c17ca6c52cb725ebf1f90771c5ad456..ecdbdc6dfc70072edd75ecdc14957112b2826f9d 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ArrayExprent.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ArrayExprent.java
+@@ -67,8 +67,7 @@ public class ArrayExprent extends Exprent {
+   }
+ 
+   @Override
+-  public List<Exprent> getAllExprents() {
+-    List<Exprent> lst = new ArrayList<>();
++  public List<Exprent> getAllExprents(List<Exprent> lst) {
+     lst.add(array);
+     lst.add(index);
+     return lst;
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssertExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssertExprent.java
+index 097c10a32ed819368c48efa51866420c01584395..34d99a13692ca6a7cedc59b7d4d9de4ede6a0358 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssertExprent.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssertExprent.java
+@@ -18,6 +18,12 @@ public class AssertExprent extends Exprent {
+     this.parameters = parameters;
+   }
+ 
++  @Override
++  protected List<Exprent> getAllExprents(List<Exprent> list) {
++    list.addAll(this.parameters);
++    return list;
++  }
++
+   @Override
+   public TextBuffer toJava(int indent, BytecodeMappingTracer tracer) {
+     TextBuffer buffer = new TextBuffer();
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssignmentExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssignmentExprent.java
+index 0f5411be3e790faa5a9f28d1eab3152851944e48..c43a4ea06ca4e5c4761ba34a2b90e1a6b5d8198b 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssignmentExprent.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/AssignmentExprent.java
+@@ -79,8 +79,7 @@ public class AssignmentExprent extends Exprent {
+   }
+ 
+   @Override
+-  public List<Exprent> getAllExprents() {
+-    List<Exprent> lst = new ArrayList<>();
++  public List<Exprent> getAllExprents(List<Exprent> lst) {
+     lst.add(left);
+     lst.add(right);
+     return lst;
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
+index 6ed64f77930f44a9c6bd17d2eca51de97a6cbbcf..805e0ee518123d6578abcd60d2c297d2f437bec0 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
+@@ -164,8 +164,8 @@ public class ConstExprent extends Exprent {
+   }
+ 
+   @Override
+-  public List<Exprent> getAllExprents() {
+-    return new ArrayList<>();
++  public List<Exprent> getAllExprents(List<Exprent> list) {
++    return list;
+   }
+ 
+   @Override
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ExitExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ExitExprent.java
+index 996eb3c3fe5388f7fde11df8937a09d01843f89d..0de6ad2cfa8f7dde5b9142a10525b58853f0549a 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ExitExprent.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ExitExprent.java
+@@ -59,8 +59,7 @@ public class ExitExprent extends Exprent {
+   }
+ 
+   @Override
+-  public List<Exprent> getAllExprents() {
+-    List<Exprent> lst = new ArrayList<>();
++  public List<Exprent> getAllExprents(List<Exprent> lst) {
+     if (value != null) {
+       lst.add(value);
+     }
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
+index 8074782862f3842a95050212df0ac5d778f20091..4a696f53b52d3a577b7a1258c37e40996952b576 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
+@@ -99,14 +99,25 @@ public abstract class Exprent implements IMatchable {
+     return false;
+   }
+ 
+-  public List<Exprent> getAllExprents(boolean recursive) {
+-    List<Exprent> lst = getAllExprents();
++  public final List<Exprent> getAllExprents(boolean recursive) {
++    List<Exprent> lst = new ArrayList<>();
++    getAllExprents(recursive, lst);
++
++    return lst;
++  }
++
++  private List<Exprent> getAllExprents(boolean recursive, List<Exprent> list) {
++    int start = list.size();
++    getAllExprents(list);
++    int end = list.size();
++
+     if (recursive) {
+-      for (int i = lst.size() - 1; i >= 0; i--) {
+-        lst.addAll(lst.get(i).getAllExprents(true));
++      for (int i = end - 1; i >= start; i--) {
++        list.get(i).getAllExprents(true, list);
+       }
+     }
+-    return lst;
++
++    return list;
+   }
+ 
+   public Set<VarVersionPair> getAllVariables() {
+@@ -122,10 +133,17 @@ public abstract class Exprent implements IMatchable {
+     return set;
+   }
+ 
+-  public List<Exprent> getAllExprents() {
+-    throw new RuntimeException("not implemented");
++  public final List<Exprent> getAllExprents() {
++    List<Exprent> list = new ArrayList<>();
++    getAllExprents(list);
++
++    return list;
+   }
+ 
++  // Get all the exprents contained within the current one
++  // Preconditions: this list must never be removed from! Only added to!
++  protected abstract List<Exprent> getAllExprents(List<Exprent> list);
++
+   public Exprent copy() {
+     throw new RuntimeException("not implemented");
+   }
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
+index fe98a67593856bc9358faf468afcd7bde986b520..05c06d88383a5c74496837dd0da61c36ef7631c6 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FieldExprent.java
+@@ -117,8 +117,7 @@ public class FieldExprent extends Exprent {
+   }
+ 
+   @Override
+-  public List<Exprent> getAllExprents() {
+-    List<Exprent> lst = new ArrayList<>();
++  public List<Exprent> getAllExprents(List<Exprent> lst) {
+     if (instance != null) {
+       lst.add(instance);
+     }
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
+index 1f27ed6c5ab25460b0e67c728c7fdcaa23e6c268..16c0279e2aaa1dd5ba1d1db7b844b347502079c8 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
+@@ -453,8 +453,9 @@ public class FunctionExprent extends Exprent {
+   }
+ 
+   @Override
+-  public List<Exprent> getAllExprents() {
+-    return new ArrayList<>(lstOperands);
++  public List<Exprent> getAllExprents(List<Exprent> lst) {
++    lst.addAll(this.lstOperands);
++    return lst;
+   }
+ 
+   @Override
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/IfExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/IfExprent.java
+index f9177d5f5f7991637bb793cdf479b6af63dcf414..f48f20934e3abd19bcdb0f9e52eb58578abd5b13 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/IfExprent.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/IfExprent.java
+@@ -96,8 +96,7 @@ public class IfExprent extends Exprent {
+   }
+ 
+   @Override
+-  public List<Exprent> getAllExprents() {
+-    List<Exprent> lst = new ArrayList<>();
++  public List<Exprent> getAllExprents(List<Exprent> lst) {
+     lst.add(condition);
+     return lst;
+   }
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
+index dfd8078b728c0439a6a0accb6d9f17b7eb2979fb..79782777a705f87d145522ee160103659e0aaea3 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
+@@ -473,8 +473,7 @@ public class InvocationExprent extends Exprent {
+   }
+ 
+   @Override
+-  public List<Exprent> getAllExprents() {
+-    List<Exprent> lst = new ArrayList<>();
++  public List<Exprent> getAllExprents(List<Exprent> lst) {
+     if (instance != null) {
+       lst.add(instance);
+     }
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/MonitorExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/MonitorExprent.java
+index 380f47a9de0e1b9d342d5c8557175d7e5a6b1e8a..5d312499ded2b8ed035b092cfce27bd758c39894 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/MonitorExprent.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/MonitorExprent.java
+@@ -33,8 +33,7 @@ public class MonitorExprent extends Exprent {
+   }
+ 
+   @Override
+-  public List<Exprent> getAllExprents() {
+-    List<Exprent> lst = new ArrayList<>();
++  public List<Exprent> getAllExprents(List<Exprent> lst) {
+     lst.add(value);
+     return lst;
+   }
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
+index 2bf3ce1584a2926a628318b7dacb21290803108b..7f82d46f96dc4873aa2ba41b8824d5cf4284aa12 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/NewExprent.java
+@@ -278,9 +278,7 @@ public class NewExprent extends Exprent {
+   }
+ 
+   @Override
+-  public List<Exprent> getAllExprents() {
+-    List<Exprent> lst = new ArrayList<>();
+-
++  public List<Exprent> getAllExprents(List<Exprent> lst) {
+     if (newType.arrayDim != 0) {
+       lst.addAll(lstDims);
+       lst.addAll(lstArrayElements);
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/SwitchExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/SwitchExprent.java
+index 81f7546312493c244636b50fa972c0a3817b9aed..303a1c53c26c9764120f2ce50fad0a1ca8933de8 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/SwitchExprent.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/SwitchExprent.java
+@@ -67,8 +67,7 @@ public class SwitchExprent extends Exprent {
+   }
+ 
+   @Override
+-  public List<Exprent> getAllExprents() {
+-    List<Exprent> lst = new ArrayList<>();
++  public List<Exprent> getAllExprents(List<Exprent> lst) {
+     lst.add(value);
+     return lst;
+   }
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
+index a7bf7eb3b499d623d11914bcca98702328e57329..abe36c09953b0e2656e43be18ecdeec2c5f6393d 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
+@@ -89,8 +89,8 @@ public class VarExprent extends Exprent {
+   }
+ 
+   @Override
+-  public List<Exprent> getAllExprents() {
+-    return new ArrayList<>();
++  public List<Exprent> getAllExprents(List<Exprent> lst) {
++    return lst;
+   }
+ 
+   @Override


### PR DESCRIPTION
This PR improves Exprent#getAllExprents by making it not allocate more than once. Previously, every single exprent in the tree would allocate it's own arraylist, which means a lot of unused arraylists were allocated, as the lists are only used to add onto the existing list. This reduces the garbage collector stress and reduces the garbage created by decompiling Minecraft by a couple gigabytes.