### PR TITLE
Simplify threaded output handling/stabilize output

### DIFF
--- a/FernFlower-Patches/0005-Fix-output-discrepancies-to-produce-stable-output.patch
+++ b/FernFlower-Patches/0005-Fix-output-discrepancies-to-produce-stable-output.patch
@@ -1,8 +1,10 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: LexManos <LexManos@gmail.com>
 Date: Wed, 12 Apr 2017 10:08:10 -0700
-Subject: [PATCH] Fix output discrepancies based on running JVM
+Subject: [PATCH] Fix output discrepancies to produce stable output
 
+Running JVM and timestamp result in output varying between
+environments and runs.
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 index a45067feeedaece4546ae2dbc5148fbf9b2c0309..7db5b328969a6dac49054e57b5c00c672ca4ea85 100644
@@ -38,6 +40,70 @@ index a45067feeedaece4546ae2dbc5148fbf9b2c0309..7db5b328969a6dac49054e57b5c00c67
      public static class LambdaInformation {
        public String method_name;
        public String method_descriptor;
+diff --git a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
+index 75d4d0937f1e39fe630b1318a4ad531de7fbd644..d0ae9a7c3b20de44cb202390cc0dfd4d690fee64 100644
+--- a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
++++ b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
+@@ -11,7 +11,7 @@ import org.jetbrains.java.decompiler.util.InterpreterUtil;
+ import java.io.*;
+ import java.nio.charset.StandardCharsets;
+ import java.util.*;
+-import java.util.jar.JarOutputStream;
++import java.util.jar.JarFile;
+ import java.util.jar.Manifest;
+ import java.util.zip.ZipEntry;
+ import java.util.zip.ZipFile;
+@@ -189,7 +189,14 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
+       }
+ 
+       FileOutputStream fileStream = new FileOutputStream(file);
+-      ZipOutputStream zipStream = manifest != null ? new JarOutputStream(fileStream, manifest) : new ZipOutputStream(fileStream);
++      ZipOutputStream zipStream = new ZipOutputStream(fileStream);
++      if (manifest != null) {
++        final ZipEntry manifestEntry = new ZipEntry(JarFile.MANIFEST_NAME);
++        manifestEntry.setTime(STABLE_ZIP_TIMESTAMP);
++        zipStream.putNextEntry(manifestEntry);
++        manifest.write(zipStream);
++        zipStream.closeEntry();
++      }
+       mapArchiveStreams.put(file.getPath(), zipStream);
+     }
+     catch (IOException ex) {
+@@ -215,7 +222,9 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
+       if (entry != null) {
+         try (InputStream in = srcArchive.getInputStream(entry)) {
+           ZipOutputStream out = mapArchiveStreams.get(file);
+-          out.putNextEntry(new ZipEntry(entryName));
++          final ZipEntry newEntry = new ZipEntry(entryName);
++          newEntry.setTime(entry.getTime());
++          out.putNextEntry(newEntry);
+           InterpreterUtil.copyStream(in, out);
+         }
+       }
+@@ -236,7 +245,9 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
+ 
+     try {
+       ZipOutputStream out = mapArchiveStreams.get(file);
+-      out.putNextEntry(new ZipEntry(entryName));
++      ZipEntry entry = new ZipEntry(entryName);
++      entry.setTime(STABLE_ZIP_TIMESTAMP);
++      out.putNextEntry(entry);
+       if (content != null) {
+         out.write(content.getBytes(StandardCharsets.UTF_8));
+       }
+diff --git a/src/org/jetbrains/java/decompiler/main/extern/IResultSaver.java b/src/org/jetbrains/java/decompiler/main/extern/IResultSaver.java
+index fad1ddcfb9d2e43720b4cd3acaa165ba86e94892..cf03900654e427bd435ba6dc2d5a0cec8c8708e4 100644
+--- a/src/org/jetbrains/java/decompiler/main/extern/IResultSaver.java
++++ b/src/org/jetbrains/java/decompiler/main/extern/IResultSaver.java
+@@ -4,6 +4,8 @@ package org.jetbrains.java.decompiler.main.extern;
+ import java.util.jar.Manifest;
+ 
+ public interface IResultSaver {
++  long STABLE_ZIP_TIMESTAMP = 0x386D4380; // 01/01/2000 00:00:00 java 8 breaks when using 0.
++
+   void saveFolder(String path);
+ 
+   void copyFile(String source, String path, String entryName);
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/LambdaProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/LambdaProcessor.java
 index 05e6e2d720aa5812ef12c4741eab06b8ea477e0f..f9c8c6a0334512699c545c881207194745427c96 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/LambdaProcessor.java

--- a/FernFlower-Patches/0019-Add-cfg-argument-Used-to-specify-a-text-file-with-ad.patch
+++ b/FernFlower-Patches/0019-Add-cfg-argument-Used-to-specify-a-text-file-with-ad.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Add -cfg argument Used to specify a text file with additional
 Our use case is specifying a ton of external libraries. It will read a text file and replace the -cfg entry with those lines.
 
 diff --git a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
-index 75d4d0937f1e39fe630b1318a4ad531de7fbd644..06e362987a3917976627fc1f0b6aad302c4ea650 100644
+index d0ae9a7c3b20de44cb202390cc0dfd4d690fee64..aefae5f232c84700c16721643eab4499e319f61a 100644
 --- a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
 +++ b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
 @@ -10,9 +10,13 @@ import org.jetbrains.java.decompiler.util.InterpreterUtil;
@@ -18,7 +18,7 @@ index 75d4d0937f1e39fe630b1318a4ad531de7fbd644..06e362987a3917976627fc1f0b6aad30
 +import java.nio.file.Path;
 +import java.nio.file.Paths;
  import java.util.*;
- import java.util.jar.JarOutputStream;
+ import java.util.jar.JarFile;
  import java.util.jar.Manifest;
 +import java.util.stream.Stream;
  import java.util.zip.ZipEntry;
@@ -63,7 +63,7 @@ index 75d4d0937f1e39fe630b1318a4ad531de7fbd644..06e362987a3917976627fc1f0b6aad30
      if (args.length < 2) {
        System.out.println(
          "Usage: java -jar fernflower.jar [-<option>=<value>]* [<source>]+ <destination>\n" +
-@@ -269,4 +305,4 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
+@@ -280,4 +316,4 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
        DecompilerContext.getLogger().writeMessage("Cannot close " + file, IFernflowerLogger.Severity.WARN);
      }
    }

--- a/FernFlower-Patches/0020-Add-support-for-destination-to-be-a-zip-file-if-ther.patch
+++ b/FernFlower-Patches/0020-Add-support-for-destination-to-be-a-zip-file-if-ther.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add support for destination to be a zip file if there is only
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
-index 06e362987a3917976627fc1f0b6aad302c4ea650..5393ddec202efa7e1f6bb3f7740fa83a70ea48fd 100644
+index aefae5f232c84700c16721643eab4499e319f61a..e8f65944e62c64cc5b2168c363d4c03d9d0a2fb3 100644
 --- a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
 +++ b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
 @@ -100,7 +100,7 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
@@ -29,10 +29,10 @@ index 06e362987a3917976627fc1f0b6aad302c4ea650..5393ddec202efa7e1f6bb3f7740fa83a
    public void addSource(File source) {
 diff --git a/src/org/jetbrains/java/decompiler/main/decompiler/SingleFileSaver.java b/src/org/jetbrains/java/decompiler/main/decompiler/SingleFileSaver.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..8775e47858f45abaac925543be718bf3cc97a1bf
+index 0000000000000000000000000000000000000000..9b35ab03a71f7dda64589c88dc8dd1480c5d9cf1
 --- /dev/null
 +++ b/src/org/jetbrains/java/decompiler/main/decompiler/SingleFileSaver.java
-@@ -0,0 +1,118 @@
+@@ -0,0 +1,129 @@
 +package org.jetbrains.java.decompiler.main.decompiler;
 +
 +import java.io.File;
@@ -41,7 +41,7 @@ index 0000000000000000000000000000000000000000..8775e47858f45abaac925543be718bf3
 +import java.io.InputStream;
 +import java.util.HashSet;
 +import java.util.Set;
-+import java.util.jar.JarOutputStream;
++import java.util.jar.JarFile;
 +import java.util.jar.Manifest;
 +import java.util.zip.ZipEntry;
 +import java.util.zip.ZipFile;
@@ -83,7 +83,14 @@ index 0000000000000000000000000000000000000000..8775e47858f45abaac925543be718bf3
 +      throw new UnsupportedOperationException("Attempted to write multiple archives at the same time");
 +    try {
 +      FileOutputStream stream = new FileOutputStream(target);
-+      output = manifest != null ? new JarOutputStream(stream, manifest) : new ZipOutputStream(stream);
++      output = new ZipOutputStream(stream);
++      if (manifest != null) {
++        final ZipEntry manifestEntry = new ZipEntry(JarFile.MANIFEST_NAME);
++        manifestEntry.setTime(STABLE_ZIP_TIMESTAMP);
++        output.putNextEntry(manifestEntry);
++        manifest.write(output);
++        output.closeEntry();
++      }
 +    } catch (IOException e) {
 +      DecompilerContext.getLogger().writeMessage("Cannot create archive " + target, e);
 +    }
@@ -103,7 +110,9 @@ index 0000000000000000000000000000000000000000..8775e47858f45abaac925543be718bf3
 +      ZipEntry entry = srcArchive.getEntry(entryName);
 +      if (entry != null) {
 +        try (InputStream in = srcArchive.getInputStream(entry)) {
-+          output.putNextEntry(new ZipEntry(entryName));
++          final ZipEntry newEntry = new ZipEntry(entryName);
++          newEntry.setTime(entry.getTime());
++          output.putNextEntry(newEntry);
 +          InterpreterUtil.copyStream(in, output);
 +        }
 +      }
@@ -120,7 +129,9 @@ index 0000000000000000000000000000000000000000..8775e47858f45abaac925543be718bf3
 +        return;
 +
 +    try {
-+      output.putNextEntry(new ZipEntry(entryName));
++      ZipEntry entry = new ZipEntry(entryName);
++      entry.setTime(STABLE_ZIP_TIMESTAMP);
++      output.putNextEntry(entry);
 +      if (content != null)
 +          output.write(content.getBytes("UTF-8"));
 +    }

--- a/FernFlower-Patches/0034-Add-only-argument-It-will-filter-what-classes-are-de.patch
+++ b/FernFlower-Patches/0034-Add-only-argument-It-will-filter-what-classes-are-de.patch
@@ -82,7 +82,7 @@ index ab8c1a60acfdef8c6ffb3082efbfbc1315d2c0bc..469b313a958cf8aca35fe98fc809880d
      }
      else if (converter != null) {
 diff --git a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
-index 5393ddec202efa7e1f6bb3f7740fa83a70ea48fd..2b6e9ed5d2cf8e3781c9b33b1489fee9447d8181 100644
+index e8f65944e62c64cc5b2168c363d4c03d9d0a2fb3..92e27999009de17e1ba1e6475b1fac1b13ecc337 100644
 --- a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
 +++ b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
 @@ -66,6 +66,7 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {

--- a/FernFlower-Patches/0038-Make-decomp-threaded.patch
+++ b/FernFlower-Patches/0038-Make-decomp-threaded.patch
@@ -241,7 +241,7 @@ index 469b313a958cf8aca35fe98fc809880d12db671e..eefcf79cedb6148f5c02b8077914a467
    public String getClassContent(StructClass cl) {
      try {
 diff --git a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
-index 2b6e9ed5d2cf8e3781c9b33b1489fee9447d8181..b26c6639f8998fdf895b49e532e07f526f0dc4cc 100644
+index 92e27999009de17e1ba1e6475b1fac1b13ecc337..0b607e86f96bef987c949612fa9410d0dfc3aa02 100644
 --- a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
 +++ b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
 @@ -109,7 +109,7 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
@@ -293,10 +293,10 @@ index ff3b9b3dd27f5f07ebc80f6ca4ac3c632c93c83d..4398128ff456563af17a51479e563bb9
      if (accepts(Severity.INFO)) {
 diff --git a/src/org/jetbrains/java/decompiler/main/decompiler/ThreadSafeResultSaver.java b/src/org/jetbrains/java/decompiler/main/decompiler/ThreadSafeResultSaver.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..7a66c0eb7e99cfa03220b8d8735fffe17741a1f0
+index 0000000000000000000000000000000000000000..f76d2c1611ec48375c25d489d9713bd876ffcb83
 --- /dev/null
 +++ b/src/org/jetbrains/java/decompiler/main/decompiler/ThreadSafeResultSaver.java
-@@ -0,0 +1,202 @@
+@@ -0,0 +1,213 @@
 +// Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 +package org.jetbrains.java.decompiler.main.decompiler;
 +
@@ -311,7 +311,7 @@ index 0000000000000000000000000000000000000000..7a66c0eb7e99cfa03220b8d8735fffe1
 +import java.util.HashSet;
 +import java.util.Map;
 +import java.util.Set;
-+import java.util.jar.JarOutputStream;
++import java.util.jar.JarFile;
 +import java.util.jar.Manifest;
 +import java.util.zip.ZipEntry;
 +import java.util.zip.ZipFile;
@@ -355,7 +355,14 @@ index 0000000000000000000000000000000000000000..7a66c0eb7e99cfa03220b8d8735fffe1
 +        throw new IOException("Cannot create file " + file);
 +      }
 +      FileOutputStream fos = new FileOutputStream(file);
-+      ZipOutputStream zos = manifest != null ? new JarOutputStream(fos, manifest) : new ZipOutputStream(fos);
++      ZipOutputStream zos = new ZipOutputStream(fos);
++      if (manifest != null) {
++        final ZipEntry manifestEntry = new ZipEntry(JarFile.MANIFEST_NAME);
++        manifestEntry.setTime(STABLE_ZIP_TIMESTAMP);
++        zos.putNextEntry(manifestEntry);
++        manifest.write(zos);
++        zos.closeEntry();
++      }
 +      ctx = new ArchiveContext(file, zos);
 +      if (archiveMode) {
 +        singeArchiveCtx = ctx;
@@ -386,7 +393,9 @@ index 0000000000000000000000000000000000000000..7a66c0eb7e99cfa03220b8d8735fffe1
 +      ZipEntry entry = srcArchive.getEntry(entryName);
 +      if (entry != null) {
 +        try (InputStream in = srcArchive.getInputStream(entry)) {
-+          ctx.stream.putNextEntry(new ZipEntry(entryName));
++          final ZipEntry newEntry = new ZipEntry(entryName);
++          newEntry.setTime(entry.getTime());
++          ctx.stream.putNextEntry(newEntry);
 +          InterpreterUtil.copyStream(in, ctx.stream);
 +        }
 +      }
@@ -406,7 +415,9 @@ index 0000000000000000000000000000000000000000..7a66c0eb7e99cfa03220b8d8735fffe1
 +      return;
 +    }
 +    try {
-+      ctx.stream.putNextEntry(new ZipEntry(entryName));
++      ZipEntry entry = new ZipEntry(entryName);
++      entry.setTime(STABLE_ZIP_TIMESTAMP);
++      ctx.stream.putNextEntry(entry);
 +      if (content != null) {
 +        ctx.stream.write(content.getBytes(StandardCharsets.UTF_8));
 +      }

--- a/FernFlower-Patches/0038-Make-decomp-threaded.patch
+++ b/FernFlower-Patches/0038-Make-decomp-threaded.patch
@@ -185,21 +185,35 @@ index bb7b5b4e4a590219939a8f7e883b9c259c1adf73..458d119056f3fa7eceec7215fa577018
      return getCurrentContext().logger;
    }
 diff --git a/src/org/jetbrains/java/decompiler/main/Fernflower.java b/src/org/jetbrains/java/decompiler/main/Fernflower.java
-index 469b313a958cf8aca35fe98fc809880d12db671e..22cb517d3ab2901bb7d88e38802eb2825584b78d 100644
+index 469b313a958cf8aca35fe98fc809880d12db671e..eefcf79cedb6148f5c02b8077914a467f3d58b64 100644
 --- a/src/org/jetbrains/java/decompiler/main/Fernflower.java
 +++ b/src/org/jetbrains/java/decompiler/main/Fernflower.java
-@@ -26,6 +26,10 @@ public class Fernflower implements IDecompiledData {
+@@ -25,7 +25,24 @@ public class Fernflower implements IDecompiledData {
+   private final IIdentifierRenamer helper;
    private final IdentifierConverter converter;
  
++  private static int getThreads(Map<String, Object> options, final String def) {
++    String thr = options != null ? (String) options.getOrDefault(IFernflowerPreferences.THREADS, def) : def;
++    if ("AUTO".equals(thr)) {
++      return Runtime.getRuntime().availableProcessors();
++    } else {
++      try {
++        return Integer.parseInt(thr);
++      } catch (NumberFormatException e) {
++        throw new RuntimeException("Malformed threads option: " + thr);
++      }
++    }
++  }
++
    public Fernflower(IBytecodeProvider provider, IResultSaver saver, Map<String, Object> customProperties, IFernflowerLogger logger) {
-+    this(provider, saver, customProperties, logger, 0);
++    this(provider, saver, customProperties, logger, getThreads(customProperties, "AUTO"));
 +  }
 +
 +  public Fernflower(IBytecodeProvider provider, IResultSaver saver, Map<String, Object> customProperties, IFernflowerLogger logger, int threads) {
      Map<String, Object> properties = new HashMap<>(IFernflowerPreferences.DEFAULTS);
      if (customProperties != null) {
        properties.putAll(customProperties);
-@@ -70,7 +74,7 @@ public class Fernflower implements IDecompiledData {
+@@ -70,7 +87,7 @@ public class Fernflower implements IDecompiledData {
        }
      }
  
@@ -208,7 +222,7 @@ index 469b313a958cf8aca35fe98fc809880d12db671e..22cb517d3ab2901bb7d88e38802eb282
      DecompilerContext.setCurrentContext(context);
  
      String vendor = System.getProperty("java.vendor", "missing vendor");
-@@ -138,6 +142,17 @@ public class Fernflower implements IDecompiledData {
+@@ -138,6 +155,17 @@ public class Fernflower implements IDecompiledData {
      }
    }
  
@@ -227,18 +241,10 @@ index 469b313a958cf8aca35fe98fc809880d12db671e..22cb517d3ab2901bb7d88e38802eb282
    public String getClassContent(StructClass cl) {
      try {
 diff --git a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
-index 2b6e9ed5d2cf8e3781c9b33b1489fee9447d8181..ac1fc2f7588fb23b9d0232e675492f3d7c5c10fc 100644
+index 2b6e9ed5d2cf8e3781c9b33b1489fee9447d8181..b26c6639f8998fdf895b49e532e07f526f0dc4cc 100644
 --- a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
 +++ b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
-@@ -5,6 +5,7 @@ import org.jetbrains.java.decompiler.main.DecompilerContext;
- import org.jetbrains.java.decompiler.main.Fernflower;
- import org.jetbrains.java.decompiler.main.extern.IBytecodeProvider;
- import org.jetbrains.java.decompiler.main.extern.IFernflowerLogger;
-+import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
- import org.jetbrains.java.decompiler.main.extern.IResultSaver;
- import org.jetbrains.java.decompiler.util.InterpreterUtil;
- 
-@@ -109,7 +110,7 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
+@@ -109,7 +109,7 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
        return;
      }
  
@@ -247,30 +253,14 @@ index 2b6e9ed5d2cf8e3781c9b33b1489fee9447d8181..ac1fc2f7588fb23b9d0232e675492f3d
      ConsoleDecompiler decompiler = new ConsoleDecompiler(destination, mapOptions, logger);
  
      for (File library : libraries) {
-@@ -147,7 +148,25 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
+@@ -147,7 +147,9 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
  
    protected ConsoleDecompiler(File destination, Map<String, Object> options, IFernflowerLogger logger) {
      root = destination;
 -    engine = new Fernflower(this, root.isDirectory() ? this : new SingleFileSaver(destination), options, logger);
 +
-+    String thr = options != null ? (String) options.getOrDefault(IFernflowerPreferences.THREADS, "AUTO") : "AUTO";
-+    int threads;
-+    if ("AUTO".equals(thr)) {
-+      threads = Runtime.getRuntime().availableProcessors();
-+    } else {
-+      try {
-+        threads = Integer.parseInt(thr);
-+      } catch (NumberFormatException e) {
-+        throw new RuntimeException("Malformed threads option: " + thr);
-+      }
-+    }
-+
 +    IResultSaver saver = root.isDirectory() ? this : new SingleFileSaver(destination);
-+    if (threads > 1) {
-+      saver = new ThreadSafeResultSaver(root);
-+    }
-+
-+    engine = new Fernflower(this, saver, options, logger, threads);
++    engine = new Fernflower(this, saver, options, logger);
    }
  
    public void addSource(File source) {
@@ -303,10 +293,10 @@ index ff3b9b3dd27f5f07ebc80f6ca4ac3c632c93c83d..4398128ff456563af17a51479e563bb9
      if (accepts(Severity.INFO)) {
 diff --git a/src/org/jetbrains/java/decompiler/main/decompiler/ThreadSafeResultSaver.java b/src/org/jetbrains/java/decompiler/main/decompiler/ThreadSafeResultSaver.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..f434fc92661e1337acfd2ebc7576fbd43f15622f
+index 0000000000000000000000000000000000000000..7a66c0eb7e99cfa03220b8d8735fffe17741a1f0
 --- /dev/null
 +++ b/src/org/jetbrains/java/decompiler/main/decompiler/ThreadSafeResultSaver.java
-@@ -0,0 +1,227 @@
+@@ -0,0 +1,202 @@
 +// Copyright 2000-2020 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
 +package org.jetbrains.java.decompiler.main.decompiler;
 +
@@ -321,10 +311,6 @@ index 0000000000000000000000000000000000000000..f434fc92661e1337acfd2ebc7576fbd4
 +import java.util.HashSet;
 +import java.util.Map;
 +import java.util.Set;
-+import java.util.concurrent.ExecutionException;
-+import java.util.concurrent.ExecutorService;
-+import java.util.concurrent.Executors;
-+import java.util.concurrent.Future;
 +import java.util.jar.JarOutputStream;
 +import java.util.jar.Manifest;
 +import java.util.zip.ZipEntry;
@@ -393,22 +379,20 @@ index 0000000000000000000000000000000000000000..f434fc92661e1337acfd2ebc7576fbd4
 +    if (ctx == null) {
 +      throw new RuntimeException("Archive closed and tried to copy entry '" + entryName + "' from '" + source + "' to '" + file + "'.");
 +    }
-+    ctx.submit(() -> {
-+      if (!ctx.addEntry(entryName)) {
-+        return;
-+      }
-+      try (ZipFile srcArchive = new ZipFile(new File(source))) {
-+        ZipEntry entry = srcArchive.getEntry(entryName);
-+        if (entry != null) {
-+          try (InputStream in = srcArchive.getInputStream(entry)) {
-+            ctx.stream.putNextEntry(new ZipEntry(entryName));
-+            InterpreterUtil.copyStream(in, ctx.stream);
-+          }
++    if (!ctx.addEntry(entryName)) {
++      return;
++    }
++    try (ZipFile srcArchive = new ZipFile(new File(source))) {
++      ZipEntry entry = srcArchive.getEntry(entryName);
++      if (entry != null) {
++        try (InputStream in = srcArchive.getInputStream(entry)) {
++          ctx.stream.putNextEntry(new ZipEntry(entryName));
++          InterpreterUtil.copyStream(in, ctx.stream);
 +        }
-+      } catch (IOException e) {
-+        DecompilerContext.getLogger().writeMessage("Cannot copy entry " + entryName + " from " + source + " to " + file, e);
 +      }
-+    });
++    } catch (IOException e) {
++      DecompilerContext.getLogger().writeMessage("Cannot copy entry " + entryName + " from " + source + " to " + file, e);
++    }
 +  }
 +
 +  @Override
@@ -418,19 +402,17 @@ index 0000000000000000000000000000000000000000..f434fc92661e1337acfd2ebc7576fbd4
 +    if (ctx == null) {
 +      throw new RuntimeException("Archive closed and tried to write entry '" + entryName + "' to '" + file + "'.");
 +    }
-+    ctx.submit(() -> {
-+      if (!ctx.addEntry(entryName)) {
-+        return;
++    if (!ctx.addEntry(entryName)) {
++      return;
++    }
++    try {
++      ctx.stream.putNextEntry(new ZipEntry(entryName));
++      if (content != null) {
++        ctx.stream.write(content.getBytes(StandardCharsets.UTF_8));
 +      }
-+      try {
-+        ctx.stream.putNextEntry(new ZipEntry(entryName));
-+        if (content != null) {
-+          ctx.stream.write(content.getBytes(StandardCharsets.UTF_8));
-+        }
-+      } catch (IOException e) {
-+        DecompilerContext.getLogger().writeMessage("Cannot write entry " + entryName + " to " + file, e);
-+      }
-+    });
++    } catch (IOException e) {
++      DecompilerContext.getLogger().writeMessage("Cannot write entry " + entryName + " to " + file, e);
++    }
 +  }
 +
 +  @Override
@@ -440,24 +422,12 @@ index 0000000000000000000000000000000000000000..f434fc92661e1337acfd2ebc7576fbd4
 +    if (ctx == null) {
 +      throw new RuntimeException("Tried to close closed archive '" + file + "'.");
 +    }
-+    //Submit a job at the end of the executor.
-+    Future<?> closeFuture = ctx.submit(() -> {
-+      try {
-+        ctx.stream.close();
-+      } catch (IOException e) {
-+        DecompilerContext.getLogger().writeMessage("Cannot close " + file, IFernflowerLogger.Severity.WARN, e);
-+      }
-+    });
-+
-+    //Ask the executor to shutdown gracefully.
-+    ctx.executor.shutdown();
-+
 +    try {
-+      //Wait for our future to execute.
-+      closeFuture.get();
-+    } catch (InterruptedException | ExecutionException e) {
-+      throw new RuntimeException(e);
++      ctx.stream.close();
++    } catch (IOException e) {
++      DecompilerContext.getLogger().writeMessage("Cannot close " + file, IFernflowerLogger.Severity.WARN, e);
 +    }
++
 +    if (archiveMode) {
 +      singeArchiveCtx = null;
 +    } else {
@@ -513,16 +483,11 @@ index 0000000000000000000000000000000000000000..f434fc92661e1337acfd2ebc7576fbd4
 +
 +    public final File file;
 +    public final ZipOutputStream stream;
-+    public final ExecutorService executor = Executors.newSingleThreadExecutor();
 +    public final Set<String> savedEntries = new HashSet<>();
 +
 +    private ArchiveContext(File file, ZipOutputStream stream) {
 +      this.file = file;
 +      this.stream = stream;
-+    }
-+
-+    public Future<?> submit(Runnable runnable) {
-+      return executor.submit(runnable);
 +    }
 +
 +    public boolean addEntry(String entryName) {
@@ -690,7 +655,7 @@ index 86fd580e52b9534c2750139512ba84739308eead..7bcb5652188642db925a5915f8b743fd
      defaults.put(LOG_LEVEL, IFernflowerLogger.Severity.INFO.name());
      defaults.put(MAX_PROCESSING_METHOD, "0");
 diff --git a/src/org/jetbrains/java/decompiler/struct/ContextUnit.java b/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
-index c33a9aa83f61a22940b1864d6bbfcdd7ba78e38d..9eb1e3b71ee54001c902f11f6fa6c132c5a670fc 100644
+index c33a9aa83f61a22940b1864d6bbfcdd7ba78e38d..4e64b70da8fe886801e027a7ae6c0e59f94cf62a 100644
 --- a/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
 +++ b/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
 @@ -14,8 +14,14 @@ import java.io.IOException;
@@ -720,79 +685,65 @@ index c33a9aa83f61a22940b1864d6bbfcdd7ba78e38d..9eb1e3b71ee54001c902f11f6fa6c132
              if (content != null) {
                int[] mapping = null;
                if (DecompilerContext.getOption(IFernflowerPreferences.BYTECODE_SOURCE_MAPPING)) {
-@@ -152,13 +161,64 @@ public class ContextUnit {
+@@ -152,13 +161,51 @@ public class ContextUnit {
            }
          }
  
--        // classes
++        //Whooo threads!
++        int threads = DecompilerContext.getThreads();
++        DecompilerContext rootContext = DecompilerContext.getCurrentContext();
++        ExecutorService executor = threads > 0 ? Executors.newFixedThreadPool(threads) : Executors.newSingleThreadExecutor();
++
++        //Compute the classes we need to decomp.
++        List<ClassContext> toProcess = IntStream.range(0, classes.size()).parallel()
++          .mapToObj(i -> {
++            StructClass cl = classes.get(i);
++            return new ClassContext(cl, decompiledData.getClassEntryName(cl, classEntries.get(i)));
++          })
++          .filter(e -> e.entryName != null)
++          .collect(Collectors.toList());
++        List<Future<?>> futures = new ArrayList<>(toProcess.size());
++
++        //Submit preprocessor jobs.
++        for (ClassContext clCtx : toProcess) {
++          futures.add(executor.submit(() -> {
++            DecompilerContext.cloneContext(rootContext);
++            clCtx.ctx = DecompilerContext.getCurrentContext();
++            clCtx.shouldContinue = decompiledData.processClass(clCtx.cl);
++            DecompilerContext.setCurrentContext(null);
++          }));
++        }
++
++        //Ask the executor to shutdown
++        waitForAll(futures);
++        futures.clear();
++
+         // classes
 -        for (int i = 0; i < classes.size(); i++) {
 -          StructClass cl = classes.get(i);
 -          String entryName = decompiledData.getClassEntryName(cl, classEntries.get(i));
 -          if (entryName != null) {
 -            String content = decompiledData.getClassContent(cl);
 -            resultSaver.saveClassEntry(archivePath, filename, cl.qualifiedName, entryName, content);
-+        //Whooo threads!
-+        int threads = DecompilerContext.getThreads();
-+        if (threads > 1) {
-+
-+          DecompilerContext rootContext = DecompilerContext.getCurrentContext();
-+          ExecutorService executor = Executors.newFixedThreadPool(threads);
-+
-+          //Compute the classes we need to decomp.
-+          List<ClassContext> toProcess = IntStream.range(0, classes.size()).parallel()
-+            .mapToObj(i -> {
-+              StructClass cl = classes.get(i);
-+              return new ClassContext(cl, decompiledData.getClassEntryName(cl, classEntries.get(i)));
-+            })
-+            .filter(e -> e.entryName != null)
-+            .collect(Collectors.toList());
-+          List<Future<?>> futures = new ArrayList<>(toProcess.size());
-+
-+          //Submit preprocessor jobs.
-+          for (ClassContext clCtx : toProcess) {
++        for (ClassContext clCtx : toProcess) {
++          if (clCtx.shouldContinue) {
 +            futures.add(executor.submit(() -> {
-+              DecompilerContext.cloneContext(rootContext);
-+              clCtx.ctx = DecompilerContext.getCurrentContext();
-+              clCtx.shouldContinue = decompiledData.processClass(clCtx.cl);
++              DecompilerContext.setCurrentContext(clCtx.ctx);
++              clCtx.classContent = decompiledData.getClassContent(clCtx.cl);
 +              DecompilerContext.setCurrentContext(null);
 +            }));
 +          }
++        }
++        executor.shutdown();
++        waitForAll(futures);
 +
-+          //Ask the executor to shutdown
-+          executor.shutdown();
-+          waitForAll(futures);
-+          futures.clear();
-+
-+          executor = Executors.newFixedThreadPool(threads);
-+
-+          // classes
-+          for (ClassContext clCtx : toProcess) {
-+            if (clCtx.shouldContinue) {
-+              futures.add(executor.submit(() -> {
-+                DecompilerContext.setCurrentContext(clCtx.ctx);
-+                String content = decompiledData.getClassContent(clCtx.cl);
-+                resultSaver.saveClassEntry(archivePath, filename, clCtx.cl.qualifiedName, clCtx.entryName, content);
-+                DecompilerContext.setCurrentContext(null);
-+              }));
-+            }
-+          }
-+          executor.shutdown();
-+          waitForAll(futures);
-+        } else {
-+          // classes
-+          for (int i = 0; i < classes.size(); i++) {
-+            StructClass cl = classes.get(i);
-+            String entryName = decompiledData.getClassEntryName(cl, classEntries.get(i));
-+            if (entryName != null) {
-+              if (decompiledData.processClass(cl)) {
-+                String content = decompiledData.getClassContent(cl);
-+                resultSaver.saveClassEntry(archivePath, filename, cl.qualifiedName, entryName, content);
-+              }
-+            }
++        for (final ClassContext clCtx : toProcess) {
++          if (clCtx.shouldContinue) {
++            resultSaver.saveClassEntry(archivePath, filename, clCtx.cl.qualifiedName, clCtx.entryName, clCtx.classContent);
            }
          }
  
-@@ -166,6 +226,16 @@ public class ContextUnit {
+@@ -166,6 +213,16 @@ public class ContextUnit {
      }
    }
  
@@ -809,7 +760,7 @@ index c33a9aa83f61a22940b1864d6bbfcdd7ba78e38d..9eb1e3b71ee54001c902f11f6fa6c132
    public void setManifest(Manifest manifest) {
      this.manifest = manifest;
    }
-@@ -177,4 +247,17 @@ public class ContextUnit {
+@@ -177,4 +234,18 @@ public class ContextUnit {
    public List<StructClass> getClasses() {
      return classes;
    }
@@ -819,6 +770,7 @@ index c33a9aa83f61a22940b1864d6bbfcdd7ba78e38d..9eb1e3b71ee54001c902f11f6fa6c132
 +    public final String entryName;
 +    public boolean shouldContinue;
 +    public DecompilerContext ctx;
++    String classContent;
 +
 +    private ClassContext(StructClass cl, String entryName) {
 +      this.cl = cl;

--- a/FernFlower-Patches/0039-Expose-line-mapping-information-in-archive-mode.patch
+++ b/FernFlower-Patches/0039-Expose-line-mapping-information-in-archive-mode.patch
@@ -10,10 +10,10 @@ Add -dcl {dump code lines} to dump this line data to a file in the output archiv
 This will allow external projects to do this remapping as well.
 
 diff --git a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
-index ac1fc2f7588fb23b9d0232e675492f3d7c5c10fc..bd3535557b78014919d34c3ee5d17c34ea523e2d 100644
+index b26c6639f8998fdf895b49e532e07f526f0dc4cc..2e4a101f737214786db13fb343b80e5d1a674e28 100644
 --- a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
 +++ b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
-@@ -265,7 +265,7 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
+@@ -248,7 +248,7 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
  
    @Override
    public void saveDirEntry(String path, String archiveName, String entryName) {
@@ -22,7 +22,7 @@ index ac1fc2f7588fb23b9d0232e675492f3d7c5c10fc..bd3535557b78014919d34c3ee5d17c34
    }
  
    @Override
-@@ -293,7 +293,11 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
+@@ -276,7 +276,11 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
    }
  
    @Override
@@ -35,7 +35,7 @@ index ac1fc2f7588fb23b9d0232e675492f3d7c5c10fc..bd3535557b78014919d34c3ee5d17c34
      String file = new File(getAbsolutePath(path), archiveName).getPath();
  
      if (!checkEntry(entryName, file)) {
-@@ -302,9 +306,13 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
+@@ -285,9 +289,13 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
  
      try {
        ZipOutputStream out = mapArchiveStreams.get(file);
@@ -98,10 +98,10 @@ index 8775e47858f45abaac925543be718bf3cc97a1bf..8e37643c54c6e961c317d9bc2c1ed555
      catch (IOException ex) {
        String message = "Cannot write entry " + entryName + " to " + target;
 diff --git a/src/org/jetbrains/java/decompiler/main/decompiler/ThreadSafeResultSaver.java b/src/org/jetbrains/java/decompiler/main/decompiler/ThreadSafeResultSaver.java
-index f434fc92661e1337acfd2ebc7576fbd43f15622f..585494c81bda9c2bde5ea284fb8851df3c1b072b 100644
+index 7a66c0eb7e99cfa03220b8d8735fffe17741a1f0..e5c4b23725c500a5d8490deaa0006b9324937d42 100644
 --- a/src/org/jetbrains/java/decompiler/main/decompiler/ThreadSafeResultSaver.java
 +++ b/src/org/jetbrains/java/decompiler/main/decompiler/ThreadSafeResultSaver.java
-@@ -74,7 +74,7 @@ public class ThreadSafeResultSaver implements IResultSaver {
+@@ -70,7 +70,7 @@ public class ThreadSafeResultSaver implements IResultSaver {
  
    @Override
    public void saveDirEntry(String path, String archiveName, String entryName) {
@@ -110,7 +110,7 @@ index f434fc92661e1337acfd2ebc7576fbd43f15622f..585494c81bda9c2bde5ea284fb8851df
    }
  
    @Override
-@@ -103,7 +103,11 @@ public class ThreadSafeResultSaver implements IResultSaver {
+@@ -97,7 +97,11 @@ public class ThreadSafeResultSaver implements IResultSaver {
    }
  
    @Override
@@ -123,22 +123,22 @@ index f434fc92661e1337acfd2ebc7576fbd43f15622f..585494c81bda9c2bde5ea284fb8851df
      String file = new File(getAbsolutePath(path), archiveName).getPath();
      ArchiveContext ctx = getCtx(file);
      if (ctx == null) {
-@@ -114,9 +118,13 @@ public class ThreadSafeResultSaver implements IResultSaver {
-         return;
+@@ -107,9 +111,13 @@ public class ThreadSafeResultSaver implements IResultSaver {
+       return;
+     }
+     try {
+-      ctx.stream.putNextEntry(new ZipEntry(entryName));
++      ZipEntry entry = new ZipEntry(entryName);
++      if (extra != null) {
++        entry.setExtra(extra);
++      }
++      ctx.stream.putNextEntry(entry);
+       if (content != null) {
+-        ctx.stream.write(content.getBytes(StandardCharsets.UTF_8));
++        ctx.stream.write(content);
        }
-       try {
--        ctx.stream.putNextEntry(new ZipEntry(entryName));
-+        ZipEntry entry = new ZipEntry(entryName);
-+        if (extra != null) {
-+          entry.setExtra(extra);
-+        }
-+        ctx.stream.putNextEntry(entry);
-         if (content != null) {
--          ctx.stream.write(content.getBytes(StandardCharsets.UTF_8));
-+          ctx.stream.write(content);
-         }
-       } catch (IOException e) {
-         DecompilerContext.getLogger().writeMessage("Cannot write entry " + entryName + " to " + file, e);
+     } catch (IOException e) {
+       DecompilerContext.getLogger().writeMessage("Cannot write entry " + entryName + " to " + file, e);
 diff --git a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java b/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
 index 7bcb5652188642db925a5915f8b743fd14b0e328..698020bbb42ba78718b5a332ca4e9a3f3660e9e9 100644
 --- a/src/org/jetbrains/java/decompiler/main/extern/IFernflowerPreferences.java
@@ -213,35 +213,36 @@ index fad1ddcfb9d2e43720b4cd3acaa165ba86e94892..e16c60301264feaeaabfaf281495807d
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/struct/ContextUnit.java b/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
-index 9eb1e3b71ee54001c902f11f6fa6c132c5a670fc..5e119e5030efab2bccc1bd96601075c081056339 100644
+index 4e64b70da8fe886801e027a7ae6c0e59f94cf62a..5b669d8b71d9601769988c41f64650926cadfc5f 100644
 --- a/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
 +++ b/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
-@@ -201,7 +201,11 @@ public class ContextUnit {
-               futures.add(executor.submit(() -> {
-                 DecompilerContext.setCurrentContext(clCtx.ctx);
-                 String content = decompiledData.getClassContent(clCtx.cl);
--                resultSaver.saveClassEntry(archivePath, filename, clCtx.cl.qualifiedName, clCtx.entryName, content);
-+                int[] mapping = null;
-+                if (DecompilerContext.getOption(IFernflowerPreferences.BYTECODE_SOURCE_MAPPING)) {
-+                  mapping = DecompilerContext.getBytecodeSourceMapper().getOriginalLinesMapping();
-+                }
-+                resultSaver.saveClassEntry(archivePath, filename, clCtx.cl.qualifiedName, clCtx.entryName, content, mapping);
-                 DecompilerContext.setCurrentContext(null);
-               }));
-             }
-@@ -216,7 +220,11 @@ public class ContextUnit {
-             if (entryName != null) {
-               if (decompiledData.processClass(cl)) {
-                 String content = decompiledData.getClassContent(cl);
--                resultSaver.saveClassEntry(archivePath, filename, cl.qualifiedName, entryName, content);
-+                int[] mapping = null;
-+                if (DecompilerContext.getOption(IFernflowerPreferences.BYTECODE_SOURCE_MAPPING)) {
-+                  mapping = DecompilerContext.getBytecodeSourceMapper().getOriginalLinesMapping();
-+                }
-+                resultSaver.saveClassEntry(archivePath, filename, cl.qualifiedName, entryName, content, mapping);
-               }
-             }
+@@ -196,6 +196,9 @@ public class ContextUnit {
+             futures.add(executor.submit(() -> {
+               DecompilerContext.setCurrentContext(clCtx.ctx);
+               clCtx.classContent = decompiledData.getClassContent(clCtx.cl);
++              if (DecompilerContext.getOption(IFernflowerPreferences.BYTECODE_SOURCE_MAPPING)) {
++                clCtx.mapping = DecompilerContext.getBytecodeSourceMapper().getOriginalLinesMapping();
++              }
+               DecompilerContext.setCurrentContext(null);
+             }));
            }
+@@ -205,7 +208,7 @@ public class ContextUnit {
+ 
+         for (final ClassContext clCtx : toProcess) {
+           if (clCtx.shouldContinue) {
+-            resultSaver.saveClassEntry(archivePath, filename, clCtx.cl.qualifiedName, clCtx.entryName, clCtx.classContent);
++            resultSaver.saveClassEntry(archivePath, filename, clCtx.cl.qualifiedName, clCtx.entryName, clCtx.classContent, clCtx.mapping);
+           }
+         }
+ 
+@@ -241,6 +244,7 @@ public class ContextUnit {
+     public boolean shouldContinue;
+     public DecompilerContext ctx;
+     String classContent;
++    int[] mapping;
+ 
+     private ClassContext(StructClass cl, String entryName) {
+       this.cl = cl;
 diff --git a/test/org/jetbrains/java/decompiler/MinecraftTest.java b/test/org/jetbrains/java/decompiler/MinecraftTest.java
 index 8ec8c36234a30e76b7f75d54220f771afe58e264..b5f5d82ee5a62234932d8527cdc1a9ae0ec38e8a 100644
 --- a/test/org/jetbrains/java/decompiler/MinecraftTest.java

--- a/FernFlower-Patches/0039-Expose-line-mapping-information-in-archive-mode.patch
+++ b/FernFlower-Patches/0039-Expose-line-mapping-information-in-archive-mode.patch
@@ -10,10 +10,10 @@ Add -dcl {dump code lines} to dump this line data to a file in the output archiv
 This will allow external projects to do this remapping as well.
 
 diff --git a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
-index b26c6639f8998fdf895b49e532e07f526f0dc4cc..2e4a101f737214786db13fb343b80e5d1a674e28 100644
+index 0b607e86f96bef987c949612fa9410d0dfc3aa02..cab48267cfe9a4b6c1f7f63449340cf6d446bd92 100644
 --- a/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
 +++ b/src/org/jetbrains/java/decompiler/main/decompiler/ConsoleDecompiler.java
-@@ -248,7 +248,7 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
+@@ -255,7 +255,7 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
  
    @Override
    public void saveDirEntry(String path, String archiveName, String entryName) {
@@ -22,7 +22,7 @@ index b26c6639f8998fdf895b49e532e07f526f0dc4cc..2e4a101f737214786db13fb343b80e5d
    }
  
    @Override
-@@ -276,7 +276,11 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
+@@ -285,7 +285,11 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
    }
  
    @Override
@@ -35,16 +35,14 @@ index b26c6639f8998fdf895b49e532e07f526f0dc4cc..2e4a101f737214786db13fb343b80e5d
      String file = new File(getAbsolutePath(path), archiveName).getPath();
  
      if (!checkEntry(entryName, file)) {
-@@ -285,9 +289,13 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
- 
-     try {
+@@ -296,9 +300,12 @@ public class ConsoleDecompiler implements IBytecodeProvider, IResultSaver {
        ZipOutputStream out = mapArchiveStreams.get(file);
--      out.putNextEntry(new ZipEntry(entryName));
-+      ZipEntry entry = new ZipEntry(entryName);
+       ZipEntry entry = new ZipEntry(entryName);
+       entry.setTime(STABLE_ZIP_TIMESTAMP);
 +      if (extra != null) {
 +        entry.setExtra(extra);
 +      }
-+      out.putNextEntry(entry);
+       out.putNextEntry(entry);
        if (content != null) {
 -        out.write(content.getBytes(StandardCharsets.UTF_8));
 +        out.write(content);
@@ -52,7 +50,7 @@ index b26c6639f8998fdf895b49e532e07f526f0dc4cc..2e4a101f737214786db13fb343b80e5d
      }
      catch (IOException ex) {
 diff --git a/src/org/jetbrains/java/decompiler/main/decompiler/SingleFileSaver.java b/src/org/jetbrains/java/decompiler/main/decompiler/SingleFileSaver.java
-index 8775e47858f45abaac925543be718bf3cc97a1bf..8e37643c54c6e961c317d9bc2c1ed5556e0b4179 100644
+index 9b35ab03a71f7dda64589c88dc8dd1480c5d9cf1..164cd142118f37d33375c19b8903d61658d3a07a 100644
 --- a/src/org/jetbrains/java/decompiler/main/decompiler/SingleFileSaver.java
 +++ b/src/org/jetbrains/java/decompiler/main/decompiler/SingleFileSaver.java
 @@ -4,6 +4,7 @@ import java.io.File;
@@ -62,8 +60,8 @@ index 8775e47858f45abaac925543be718bf3cc97a1bf..8e37643c54c6e961c317d9bc2c1ed555
 +import java.nio.charset.StandardCharsets;
  import java.util.HashSet;
  import java.util.Set;
- import java.util.jar.JarOutputStream;
-@@ -56,7 +57,7 @@ public class SingleFileSaver implements IResultSaver {
+ import java.util.jar.JarFile;
+@@ -63,7 +64,7 @@ public class SingleFileSaver implements IResultSaver {
  
    @Override
    public void saveDirEntry(String path, String archiveName, String entryName) {
@@ -72,7 +70,7 @@ index 8775e47858f45abaac925543be718bf3cc97a1bf..8e37643c54c6e961c317d9bc2c1ed555
    }
  
    @Override
-@@ -80,14 +81,21 @@ public class SingleFileSaver implements IResultSaver {
+@@ -89,16 +90,22 @@ public class SingleFileSaver implements IResultSaver {
    }
  
    @Override
@@ -86,11 +84,11 @@ index 8775e47858f45abaac925543be718bf3cc97a1bf..8e37643c54c6e961c317d9bc2c1ed555
          return;
  
      try {
--      output.putNextEntry(new ZipEntry(entryName));
-+      ZipEntry entry = new ZipEntry(entryName);
+       ZipEntry entry = new ZipEntry(entryName);
+       entry.setTime(STABLE_ZIP_TIMESTAMP);
 +      if (extra != null)
 +        entry.setExtra(extra);
-+      output.putNextEntry(entry);
+       output.putNextEntry(entry);
        if (content != null)
 -          output.write(content.getBytes("UTF-8"));
 +        output.write(content);
@@ -98,10 +96,10 @@ index 8775e47858f45abaac925543be718bf3cc97a1bf..8e37643c54c6e961c317d9bc2c1ed555
      catch (IOException ex) {
        String message = "Cannot write entry " + entryName + " to " + target;
 diff --git a/src/org/jetbrains/java/decompiler/main/decompiler/ThreadSafeResultSaver.java b/src/org/jetbrains/java/decompiler/main/decompiler/ThreadSafeResultSaver.java
-index 7a66c0eb7e99cfa03220b8d8735fffe17741a1f0..e5c4b23725c500a5d8490deaa0006b9324937d42 100644
+index f76d2c1611ec48375c25d489d9713bd876ffcb83..81cd12ba302af00d66c3f699804651d940f06a5a 100644
 --- a/src/org/jetbrains/java/decompiler/main/decompiler/ThreadSafeResultSaver.java
 +++ b/src/org/jetbrains/java/decompiler/main/decompiler/ThreadSafeResultSaver.java
-@@ -70,7 +70,7 @@ public class ThreadSafeResultSaver implements IResultSaver {
+@@ -77,7 +77,7 @@ public class ThreadSafeResultSaver implements IResultSaver {
  
    @Override
    public void saveDirEntry(String path, String archiveName, String entryName) {
@@ -110,7 +108,7 @@ index 7a66c0eb7e99cfa03220b8d8735fffe17741a1f0..e5c4b23725c500a5d8490deaa0006b93
    }
  
    @Override
-@@ -97,7 +97,11 @@ public class ThreadSafeResultSaver implements IResultSaver {
+@@ -106,7 +106,11 @@ public class ThreadSafeResultSaver implements IResultSaver {
    }
  
    @Override
@@ -123,16 +121,14 @@ index 7a66c0eb7e99cfa03220b8d8735fffe17741a1f0..e5c4b23725c500a5d8490deaa0006b93
      String file = new File(getAbsolutePath(path), archiveName).getPath();
      ArchiveContext ctx = getCtx(file);
      if (ctx == null) {
-@@ -107,9 +111,13 @@ public class ThreadSafeResultSaver implements IResultSaver {
-       return;
-     }
+@@ -118,9 +122,12 @@ public class ThreadSafeResultSaver implements IResultSaver {
      try {
--      ctx.stream.putNextEntry(new ZipEntry(entryName));
-+      ZipEntry entry = new ZipEntry(entryName);
+       ZipEntry entry = new ZipEntry(entryName);
+       entry.setTime(STABLE_ZIP_TIMESTAMP);
 +      if (extra != null) {
 +        entry.setExtra(extra);
 +      }
-+      ctx.stream.putNextEntry(entry);
+       ctx.stream.putNextEntry(entry);
        if (content != null) {
 -        ctx.stream.write(content.getBytes(StandardCharsets.UTF_8));
 +        ctx.stream.write(content);
@@ -161,7 +157,7 @@ index 7bcb5652188642db925a5915f8b743fd14b0e328..698020bbb42ba78718b5a332ca4e9a3f
      return Collections.unmodifiableMap(defaults);
    }
 diff --git a/src/org/jetbrains/java/decompiler/main/extern/IResultSaver.java b/src/org/jetbrains/java/decompiler/main/extern/IResultSaver.java
-index fad1ddcfb9d2e43720b4cd3acaa165ba86e94892..e16c60301264feaeaabfaf281495807d888456db 100644
+index cf03900654e427bd435ba6dc2d5a0cec8c8708e4..23d9500ce885a6ba36c25be48400df6e4e380a90 100644
 --- a/src/org/jetbrains/java/decompiler/main/extern/IResultSaver.java
 +++ b/src/org/jetbrains/java/decompiler/main/extern/IResultSaver.java
 @@ -1,6 +1,8 @@
@@ -173,7 +169,7 @@ index fad1ddcfb9d2e43720b4cd3acaa165ba86e94892..e16c60301264feaeaabfaf281495807d
  import java.util.jar.Manifest;
  
  public interface IResultSaver {
-@@ -8,6 +10,7 @@ public interface IResultSaver {
+@@ -10,6 +12,7 @@ public interface IResultSaver {
  
    void copyFile(String source, String path, String entryName);
  
@@ -181,7 +177,7 @@ index fad1ddcfb9d2e43720b4cd3acaa165ba86e94892..e16c60301264feaeaabfaf281495807d
    void saveClassFile(String path, String qualifiedName, String entryName, String content, int[] mapping);
  
    void createArchive(String path, String archiveName, Manifest manifest);
-@@ -16,7 +19,29 @@ public interface IResultSaver {
+@@ -18,7 +21,29 @@ public interface IResultSaver {
  
    void copyEntry(String source, String path, String archiveName, String entry);
  

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,0 @@
-org.gradle.logging.level=info
-org.gradle.logging.stacktrace=all


### PR DESCRIPTION
This removes a variety of executor rebuilding, and the queueing logic in
ThreadSafeResultSaver, in favor of queueing output with the existing
class context list.

This has the benefit of simplifying any IResultSaver implementation, and
allows preserving archive order when generating output.

The Fernflower constructor has been modified to ensure all Fernflower
instances follow similar argument parsing logic, rather than just
ConsoleDecompiler instances.