### PR TITLE
Fix checking whether an inner class is static or not when finding generics from parameters

### DIFF
--- a/FernFlower-Patches/0028-Improve-inferred-generic-types.patch
+++ b/FernFlower-Patches/0028-Improve-inferred-generic-types.patch
@@ -264,7 +264,7 @@ index a735a13e50d76c15800b14d0dd589d2db6947b6e..45a83c38eabb72eb26a618e7b7f8a528
    public void getBytecodeRange(BitSet values) {
      measureBytecode(values, lstOperands);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index dd3cde1a35d189ad7ea847c9f5de2531e4177a1b..0533ef866afdfd90e5bec78866cbd47d8a799ec2 100644
+index dd3cde1a35d189ad7ea847c9f5de2531e4177a1b..ae78c8ccbdb5240c2e72a2700f63e3734d8650cb 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -52,6 +52,7 @@ public class InvocationExprent extends Exprent {
@@ -457,7 +457,7 @@ index dd3cde1a35d189ad7ea847c9f5de2531e4177a1b..0533ef866afdfd90e5bec78866cbd47d
 +              mask = ExprUtil.getSyntheticParametersMask(newNode, stringDescriptor, parameters.size());
 +              start = newNode.classStruct.hasModifier(CodeConstants.ACC_ENUM) ? 2 : 0;
 +            } else if (!newNode.enclosingClasses.isEmpty()) {
-+              start = !newNode.classStruct.hasModifier(CodeConstants.ACC_STATIC) ? 1 : 0;
++              start = (newNode.access & CodeConstants.ACC_STATIC) == 0 ? 1 : 0;
 +            }
 +          }
 +

--- a/FernFlower-Patches/0029-Improve-stack-var-processor-output.patch
+++ b/FernFlower-Patches/0029-Improve-stack-var-processor-output.patch
@@ -318,7 +318,7 @@ index d8fd9bdf784704836e69cfdd1596ae29b2732232..139ccdb55347a5d66627c1489ee73910
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 0533ef866afdfd90e5bec78866cbd47d8a799ec2..571323649ebe3bab51f946ce423aa66a72f86327 100644
+index ae78c8ccbdb5240c2e72a2700f63e3734d8650cb..5890904d54f0049853e1b2fb47cdd399c24c4ddd 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -168,6 +168,11 @@ public class InvocationExprent extends Exprent {

--- a/FernFlower-Patches/0032-Add-explicit-cast-to-invocations-of-java-nio-Buffer-.patch
+++ b/FernFlower-Patches/0032-Add-explicit-cast-to-invocations-of-java-nio-Buffer-.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Add explicit cast to invocations of java/nio/Buffer
 Java 9+ added overrides to these functions to return the specific subclass, however, when there is a compiler "bug" that when targeting release * or below, it will still reference these new methods, causing exceptions at runtime on Java 8.
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 571323649ebe3bab51f946ce423aa66a72f86327..122e7ad0ebcaa9fe20263b674887b51bd6044fd0 100644
+index 5890904d54f0049853e1b2fb47cdd399c24c4ddd..1fa32c08a5ba4998fb2e530185e3ec266e435c24 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -46,6 +46,8 @@ public class InvocationExprent extends Exprent {

--- a/FernFlower-Patches/0046-Reduce-allocations-in-getAllExprents.patch
+++ b/FernFlower-Patches/0046-Reduce-allocations-in-getAllExprents.patch
@@ -196,7 +196,7 @@ index 36e528ae73df7a893d4f50dd2bc8660b803953d8..ca13e1610450ff0228de2e5d3c5ac70d
      return lst;
    }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 122e7ad0ebcaa9fe20263b674887b51bd6044fd0..6a90becad21cbc1994f39b14211fbc493b27064b 100644
+index 1fa32c08a5ba4998fb2e530185e3ec266e435c24..f8dc47a28c53160b89fc21744bcfece4016a6607 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -475,8 +475,7 @@ public class InvocationExprent extends Exprent {


### PR DESCRIPTION
When it tries to find generics from parameters if the class being referenced is an inner class it would check the `StructClass` which only contains the access flags from the inner class which doesn't include whether the inner class is static or not so it would always skip the first parameter. This replaces it with a check on the access flags using `ClassNode` which takes the access flags from the inner class entry which do contain whether the inner class is static or not.

22w45a diff: https://gist.github.com/coehlrich/1aca58aecd998880b4908c10ba1e5b8a