### PR TITLE
Fix exception when class that lambda references is not on classpath

### DIFF
--- a/FernFlower-Patches/0028-Improve-inferred-generic-types.patch
+++ b/FernFlower-Patches/0028-Improve-inferred-generic-types.patch
@@ -264,7 +264,7 @@ index a735a13e50d76c15800b14d0dd589d2db6947b6e..45a83c38eabb72eb26a618e7b7f8a528
    public void getBytecodeRange(BitSet values) {
      measureBytecode(values, lstOperands);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index dd3cde1a35d189ad7ea847c9f5de2531e4177a1b..055e2fcaf6bc9d211f5b4745bf40dc605983e3f7 100644
+index dd3cde1a35d189ad7ea847c9f5de2531e4177a1b..05a2cf408023e24a209a0a5b691b1eeb8302b1c8 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -32,6 +32,7 @@ import org.jetbrains.java.decompiler.util.TextUtil;
@@ -292,7 +292,7 @@ index dd3cde1a35d189ad7ea847c9f5de2531e4177a1b..055e2fcaf6bc9d211f5b4745bf40dc60
    private boolean forceBoxing = false;
    private boolean forceUnboxing = false;
    private boolean isSyntheticNullCheck = false;
-@@ -175,45 +179,324 @@ public class InvocationExprent extends Exprent {
+@@ -175,45 +179,326 @@ public class InvocationExprent extends Exprent {
  
    @Override
    public VarType getInferredExprType(VarType upperBound) {
@@ -485,12 +485,14 @@ index dd3cde1a35d189ad7ea847c9f5de2531e4177a1b..055e2fcaf6bc9d211f5b4745bf40dc60
 +                    int potentialMethodCount = Integer.MAX_VALUE;
 +                    if (node.lambdaInformation.is_method_reference) {
 +                      StructClass content = (StructClass) DecompilerContext.getStructContext().getClass(node.lambdaInformation.content_class_name);
-+                      StructClass currentCls = (StructClass) DecompilerContext.getProperty(DecompilerContext.CURRENT_CLASS);
-+                      potentialMethodCount = (int) content.getMethods().stream()
-+                          .filter((method) -> canAccess(currentCls, method))
-+                          .map(StructMethod::getName)
-+                          .filter(node.lambdaInformation.content_method_name::equals)
-+                          .count();
++                      if (content != null) {
++                        StructClass currentCls = (StructClass) DecompilerContext.getProperty(DecompilerContext.CURRENT_CLASS);
++                        potentialMethodCount = (int) content.getMethods().stream()
++                            .filter((method) -> canAccess(currentCls, method))
++                            .map(StructMethod::getName)
++                            .filter(node.lambdaInformation.content_method_name::equals)
++                            .count();
++                      }
 +                    }
 +                    if (potentialMethodCount > 1) {
 +                      StructClass base = DecompilerContext.getStructContext().getClass(newExprent.getExprType().getValue());
@@ -639,7 +641,7 @@ index dd3cde1a35d189ad7ea847c9f5de2531e4177a1b..055e2fcaf6bc9d211f5b4745bf40dc60
        }
      }
  
-@@ -316,7 +599,19 @@ public class InvocationExprent extends Exprent {
+@@ -316,7 +601,19 @@ public class InvocationExprent extends Exprent {
            TextUtil.writeQualifiedSuper(buf, super_qualifier);
          }
          else if (instance != null) {
@@ -659,7 +661,7 @@ index dd3cde1a35d189ad7ea847c9f5de2531e4177a1b..055e2fcaf6bc9d211f5b4745bf40dc60
            if (isUnboxingCall() && !forceUnboxing) {
              // we don't print the unboxing call - no need to bother with the instance wrapping / casting
              if (instance.type == Exprent.EXPRENT_FUNCTION) {
-@@ -345,7 +640,8 @@ public class InvocationExprent extends Exprent {
+@@ -345,7 +642,8 @@ public class InvocationExprent extends Exprent {
  
            TextBuffer res = instance.toJava(indent, tracer);
  
@@ -669,7 +671,7 @@ index dd3cde1a35d189ad7ea847c9f5de2531e4177a1b..055e2fcaf6bc9d211f5b4745bf40dc60
  
            if (rightType.equals(VarType.VARTYPE_OBJECT) && !leftType.equals(rightType)) {
              buf.append("((").append(ExprProcessor.getCastTypeName(leftType, Collections.emptyList())).append(")");
-@@ -355,7 +651,7 @@ public class InvocationExprent extends Exprent {
+@@ -355,7 +653,7 @@ public class InvocationExprent extends Exprent {
              }
              buf.append(res).append(")");
            }
@@ -678,7 +680,7 @@ index dd3cde1a35d189ad7ea847c9f5de2531e4177a1b..055e2fcaf6bc9d211f5b4745bf40dc60
              buf.append("(").append(res).append(")");
            }
            else {
-@@ -401,6 +697,12 @@ public class InvocationExprent extends Exprent {
+@@ -401,6 +699,12 @@ public class InvocationExprent extends Exprent {
          }
      }
  
@@ -691,7 +693,7 @@ index dd3cde1a35d189ad7ea847c9f5de2531e4177a1b..055e2fcaf6bc9d211f5b4745bf40dc60
      List<VarVersionPair> mask = null;
      boolean isEnum = false;
      if (funcType == TYPE_INIT) {
-@@ -413,28 +715,6 @@ public class InvocationExprent extends Exprent {
+@@ -413,28 +717,6 @@ public class InvocationExprent extends Exprent {
      ClassNode currCls = ((ClassNode)DecompilerContext.getProperty(DecompilerContext.CURRENT_CLASS_NODE));
      List<StructMethod> matches = getMatchedDescriptors();
      BitSet setAmbiguousParameters = getAmbiguousParameters(matches);
@@ -720,7 +722,7 @@ index dd3cde1a35d189ad7ea847c9f5de2531e4177a1b..055e2fcaf6bc9d211f5b4745bf40dc60
  
      // omit 'new Type[] {}' for the last parameter of a vararg method call
      if (parameters.size() == descriptor.params.length && isVarArgCall()) {
-@@ -523,20 +803,32 @@ public class InvocationExprent extends Exprent {
+@@ -523,20 +805,32 @@ public class InvocationExprent extends Exprent {
        }
      }
  
@@ -766,7 +768,7 @@ index dd3cde1a35d189ad7ea847c9f5de2531e4177a1b..055e2fcaf6bc9d211f5b4745bf40dc60
      }
  
  
-@@ -574,6 +866,10 @@ public class InvocationExprent extends Exprent {
+@@ -574,6 +868,10 @@ public class InvocationExprent extends Exprent {
          }
          */
  
@@ -777,7 +779,7 @@ index dd3cde1a35d189ad7ea847c9f5de2531e4177a1b..055e2fcaf6bc9d211f5b4745bf40dc60
          // 'byte' and 'short' literals need an explicit narrowing type cast when used as a parameter
          ExprProcessor.getCastedExprent(this.parameters.get(i), types[i], buff, indent, true, ambiguous, true, true, tracer);
  
-@@ -589,8 +885,6 @@ public class InvocationExprent extends Exprent {
+@@ -589,8 +887,6 @@ public class InvocationExprent extends Exprent {
        }
      }
  
@@ -786,7 +788,7 @@ index dd3cde1a35d189ad7ea847c9f5de2531e4177a1b..055e2fcaf6bc9d211f5b4745bf40dc60
      return buf;
    }
  
-@@ -889,6 +1183,162 @@ public class InvocationExprent extends Exprent {
+@@ -889,6 +1185,162 @@ public class InvocationExprent extends Exprent {
      return ambiguous;
    }
  
@@ -949,7 +951,7 @@ index dd3cde1a35d189ad7ea847c9f5de2531e4177a1b..055e2fcaf6bc9d211f5b4745bf40dc60
    @Override
    public void replaceExprent(Exprent oldExpr, Exprent newExpr) {
      if (oldExpr == instance) {
-@@ -1001,6 +1451,18 @@ public class InvocationExprent extends Exprent {
+@@ -1001,6 +1453,18 @@ public class InvocationExprent extends Exprent {
      return isSyntheticNullCheck;
    }
  

--- a/FernFlower-Patches/0029-Improve-stack-var-processor-output.patch
+++ b/FernFlower-Patches/0029-Improve-stack-var-processor-output.patch
@@ -318,7 +318,7 @@ index d8fd9bdf784704836e69cfdd1596ae29b2732232..139ccdb55347a5d66627c1489ee73910
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 055e2fcaf6bc9d211f5b4745bf40dc605983e3f7..31b8d0684dc3bd870caa8001d3b9da28a97c5d7f 100644
+index 05a2cf408023e24a209a0a5b691b1eeb8302b1c8..5a9f38b6363480f0b9c10747e65d911bacda6a59 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -169,6 +169,11 @@ public class InvocationExprent extends Exprent {

--- a/FernFlower-Patches/0032-Add-explicit-cast-to-invocations-of-java-nio-Buffer-.patch
+++ b/FernFlower-Patches/0032-Add-explicit-cast-to-invocations-of-java-nio-Buffer-.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Add explicit cast to invocations of java/nio/Buffer
 Java 9+ added overrides to these functions to return the specific subclass, however, when there is a compiler "bug" that when targeting release * or below, it will still reference these new methods, causing exceptions at runtime on Java 8.
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 31b8d0684dc3bd870caa8001d3b9da28a97c5d7f..3ed696fb39f022dc588750f118ec8fca6b862637 100644
+index 5a9f38b6363480f0b9c10747e65d911bacda6a59..a0313fda58b6f6cf7bbef6386bad4c44054e5c74 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -47,6 +47,8 @@ public class InvocationExprent extends Exprent {
@@ -19,7 +19,7 @@ index 31b8d0684dc3bd870caa8001d3b9da28a97c5d7f..3ed696fb39f022dc588750f118ec8fca
    private String name;
    private String className;
    private boolean isStatic;
-@@ -659,6 +661,12 @@ public class InvocationExprent extends Exprent {
+@@ -661,6 +663,12 @@ public class InvocationExprent extends Exprent {
            else if (instance.getPrecedence() > getPrecedence() && !skippedCast) {
              buf.append("(").append(res).append(")");
            }

--- a/FernFlower-Patches/0046-Reduce-allocations-in-getAllExprents.patch
+++ b/FernFlower-Patches/0046-Reduce-allocations-in-getAllExprents.patch
@@ -196,10 +196,10 @@ index 36e528ae73df7a893d4f50dd2bc8660b803953d8..ca13e1610450ff0228de2e5d3c5ac70d
      return lst;
    }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 3ed696fb39f022dc588750f118ec8fca6b862637..85e90752d57f3401a87cfc6c5356012f49462a67 100644
+index a0313fda58b6f6cf7bbef6386bad4c44054e5c74..0c4edb13dcf79ed769851fcc7508a336326f252a 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-@@ -528,8 +528,7 @@ public class InvocationExprent extends Exprent {
+@@ -530,8 +530,7 @@ public class InvocationExprent extends Exprent {
    }
  
    @Override


### PR DESCRIPTION
fixes #122 
patch for decompile with classpath is empty