### PR TITLE
Fix loop generation causing improper loop promotion

### DIFF
--- a/FernFlower-Patches/0009-LVT-Fixes-and-Support-for-Enhanced-For-loop-detectio.patch
+++ b/FernFlower-Patches/0009-LVT-Fixes-and-Support-for-Enhanced-For-loop-detectio.patch
@@ -1610,6 +1610,150 @@ index c3263800aba7cb93e7b879d0bd46888fb696e861..d7c81a5f8538cdb6c99c752a9dd0fba5
  
    public StatEdge(@NotNull EdgeType type, Statement source, Statement destination, Statement closure) {
      this(type, source, destination);
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/FastExtendedPostdominanceHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/FastExtendedPostdominanceHelper.java
+index a86f0d2887c6c19cb1d911ec43830eb69f8aaada..bce06b032577f4e6e5a891b06435fdd62ee5ea3f 100644
+--- a/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/FastExtendedPostdominanceHelper.java
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/FastExtendedPostdominanceHelper.java
+@@ -3,6 +3,7 @@ package org.jetbrains.java.decompiler.modules.decompiler.decompose;
+ 
+ import org.jetbrains.java.decompiler.modules.decompiler.StatEdge;
+ import org.jetbrains.java.decompiler.modules.decompiler.StatEdge.EdgeType;
++import org.jetbrains.java.decompiler.modules.decompiler.StrongConnectivityHelper;
+ import org.jetbrains.java.decompiler.modules.decompiler.stats.Statement;
+ import org.jetbrains.java.decompiler.util.FastFixedSetFactory;
+ import org.jetbrains.java.decompiler.util.FastFixedSetFactory.FastFixedSet;
+@@ -51,6 +52,8 @@ public class FastExtendedPostdominanceHelper {
+ 
+     filterOnDominance(filter);
+ 
++    addSupportedComponents(filter);
++
+     Set<Entry<Integer, FastFixedSet<Integer>>> entries = mapExtPostdominators.entrySet();
+     HashMap<Integer, Set<Integer>> res = new HashMap<>(entries.size());
+     for (Entry<Integer, FastFixedSet<Integer>> entry : entries) {
+@@ -119,6 +122,23 @@ public class FastExtendedPostdominanceHelper {
+     }
+   }
+ 
++  private void addSupportedComponents(DominatorTreeExceptionFilter filter) {
++    StrongConnectivityHelper schelp = new StrongConnectivityHelper(this.statement);
++
++    for (List<Statement> comp : schelp.getComponents()) {
++      SupportComponent supcomp = SupportComponent.identify(comp, this.mapSupportPoints, filter.getDomEngine());
++
++      if (supcomp != null) {
++        // If the identified support component is not null, then add additional postdom info
++        for (Statement st : supcomp.stats) {
++          if (st != supcomp.supportedPoint) {
++            this.mapExtPostdominators.computeIfAbsent(st.id, i -> this.factory.spawnEmptySet()).add(supcomp.supportedPoint.id);
++          }
++        }
++      }
++    }
++  }
++
+   private void filterOnExceptionRanges(DominatorTreeExceptionFilter filter) {
+     for (Integer head : new HashSet<>(mapExtPostdominators.keySet())) {
+       FastFixedSet<Integer> set = mapExtPostdominators.get(head);
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/SupportComponent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/SupportComponent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..9123d92be14259e0117a0bb7b06a3d09958f7459
+--- /dev/null
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/decompose/SupportComponent.java
+@@ -0,0 +1,92 @@
++package org.jetbrains.java.decompiler.modules.decompiler.decompose;
++
++import org.jetbrains.java.decompiler.modules.decompiler.StatEdge;
++import org.jetbrains.java.decompiler.modules.decompiler.stats.Statement;
++import org.jetbrains.java.decompiler.util.FastFixedSetFactory;
++
++import java.util.*;
++
++// Model of a strongly connected component, the entrypoint (header), and the backedges to the entrypoint.
++// This allows us to find endpoint cycles to better calculate postdominance
++public final class SupportComponent {
++  // Statements in this component
++  public final List<Statement> stats;
++  // Backedges to loop header
++  public final Map<Integer, FastFixedSetFactory.FastFixedSet<Integer>> selfSupportPoints;
++  // Loop header
++  public final Statement supportedPoint;
++
++  public SupportComponent(List<Statement> stats, Map<Integer, FastFixedSetFactory.FastFixedSet<Integer>> selfSupportPoints, Statement supportedPoint) {
++    this.stats = stats;
++    this.selfSupportPoints = selfSupportPoints;
++    this.supportedPoint = supportedPoint;
++  }
++
++
++  public static SupportComponent identify(List<Statement> component, Map<Integer, FastFixedSetFactory.FastFixedSet<Integer>> mapSupportPoints, DominatorEngine dom) {
++    Map<Integer, FastFixedSetFactory.FastFixedSet<Integer>> selfSupportPoints = new HashMap<>();
++    Set<Statement> supportedAll = new HashSet<>();
++    for (Statement st : component) {
++      FastFixedSetFactory.FastFixedSet<Integer> supReach = mapSupportPoints.get(st.id);
++
++      if (supReach != null) {
++        for (StatEdge edge : st.getSuccessorEdges(StatEdge.EdgeType.REGULAR)) {
++          Statement dest = edge.getDestination();
++
++          if (!component.contains(dest)) {
++            // Support point supports statement outside of component, invalid
++            return null;
++          } else {
++            // If the successor is a dominator of the current statement, then we know that it must be an earlier statement, so the successor is supported point
++            if (dom.isDominator(st.id, dest.id)) {
++              supportedAll.add(dest);
++            }
++          }
++        }
++
++        // no filter needed as this is coming from the component itself
++        selfSupportPoints.put(st.id, supReach);
++      }
++    }
++
++    // There should only be a single component that is supported: if there's more, then we know that there is a nested loop
++    // TODO: The algorithm isn't able to decompose nested loops, so we simply quit processing for now
++    if (supportedAll.size() != 1) {
++      return null;
++    }
++
++    // Somehow got no support points- should be impossible!
++    if (selfSupportPoints.isEmpty()) {
++      return null;
++    }
++
++    // Find all edges leaving this component. There should only be one, and that is the edge leading into the header!
++    List<Statement> outgoing = new ArrayList<>();
++    for (Statement st : component) {
++      for (StatEdge edge : st.getPredecessorEdges(StatEdge.EdgeType.REGULAR)) {
++        if (!component.contains(edge.getSource())) {
++          outgoing.add(st);
++        }
++      }
++    }
++
++    if (outgoing.size() != 1) {
++      return null;
++    }
++
++    // Ensure that the header is the dominator of every node in the component
++    Statement head = outgoing.get(0);
++    for (Statement st : component) {
++      if (!dom.isDominator(st.id, head.id)) {
++        return null;
++      }
++    }
++
++    return new SupportComponent(component, selfSupportPoints, head);
++  }
++
++  @Override
++  public String toString() {
++    return "SupportComponent[" + stats + ", selfSupportPoints=" + selfSupportPoints + ", header=" + supportedPoint + ']';
++  }
++}
+\ No newline at end of file
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 index bfae94c3dd24e9fbf624310591ae33ccb454ecff..afaf2bf239640309370fd34cf9750f4a9537ba74 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java


### PR DESCRIPTION
This PR fixes the longstanding bug that causes certain loops to get absolutely clobbered, causing multiple loops to get nested together. This can be seen in #70 and other places in Minecraft's code. When loops get misgenerated like this, the loop type can't be properly identifies and falls back to be while-true or do-while loops.

The actual mechanism behind this fix is a bit nebulous, but I'll try my best to explain: When Fernflower starts it's initial control flow graph analysis to build the statement graph, it builds the statements that it knows have control flow simple enough to be able to be represented as structured Java code. When it tries the simple method of trying to find every single type of statement ([here](https://github.com/MinecraftForge/FernFlower/blob/2545452a51edfbdbb35f46a6db75dc60530afb7a/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java#L646)) and finds that there's still more to analyze, it'll then try to cleave the control flow graph into a smaller subgraph in order to reduce the amount of control flow edges it has to sort through to find statements. The analysis method then tries to find the statements in the smaller subgraph, and then uses those results to finish decompiling the things it couldn't in the larger graph. The way Fernflower decides how and where to split the subgraph is [exceedingly convoluted](https://github.com/MinecraftForge/FernFlower/blob/2545452a51edfbdbb35f46a6db75dc60530afb7a/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java#L540-L548) but essentially it tries to find the smallest segment in the graph that has no outgoing edges in order to create an isolated graph, with information from `FastExtendedPostdominanceHelper`. That class analyzes the current subgraph to find for each statement the list of statements it needs to pass through to exit the method.

In a commit in March of 2015, the original Fernflower author [pushed a commit](https://github.com/MinecraftForge/FernFlower/commit/8a2d3c3c9c0571e8676616cc709c50dae7810dfe) that improved the performance of the postdominance calculator by modifying the algorithm and reducing the number of allocations. However, with this change they accidentally broke the algorithm in subtle ways- multiple code constructs silently decompiled differently, such as default branches in switch and, of course, nested loops. This change made it so that certain types of nested loops wouldn't have their postdominance calculated correctly, causing the graph parser to create subgraphs in bad places- places where splitting could create multiple loop statements for a single loop construct. This is what causes the bug, as a single loop is broken up into multiple smaller fragments due to subgraph splitting, making the resulting Java code significantly harder to read and understand.

The proposed fix uses a new class to model cycles (loop constructs) in `FastExtendedPostDominanceHelper`, and using that model to improve how postdominance of loops is generated. All the nodes found inside of a well formed loop get the loop header added as a postdominator, which allows the subgraph algorithm to better understand the reach of the loop, to prevent it from splitting a loop multiple times. I considered the alternative solution of simply reverting the fix, but that caused way more issues as a ton of code became slightly different and multiple parts of the Fernflower and ForgeFlower codebase were unprepared for that.

Fixes #70 
Diff: [1.19.2 diff](https://gist.github.com/SuperCoder7979/3d146553ad1a4fffaa0e21715ea6f99e) 