### PR TITLE
Fix calls to method handle not casting the return value when needed

### DIFF
--- a/FernFlower-Patches/0048-Fix-signature-polymorphic-methods.patch
+++ b/FernFlower-Patches/0048-Fix-signature-polymorphic-methods.patch
@@ -1,0 +1,108 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: coehlrich <coehlrich@users.noreply.github.com>
+Date: Mon, 14 Nov 2022 23:46:16 +1300
+Subject: [PATCH] Fix signature polymorphic methods
+
+
+diff --git a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
+index fd6c22a4b18b2875a5f0f1b7d3f18fa2ed0ba305..7078bd10c2bccd11c1aad74dfe05802eab460281 100644
+--- a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
++++ b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
+@@ -193,6 +193,8 @@ public class MethodProcessorRunnable implements Runnable {
+       stackProc.simplifyStackVars(root, mt, cl);
+       varProc.setVarVersions(root);
+ 
++      MethodHandleDescriptorHelper.changeMethodHandleDescriptorsStats(root);
++
+       LabelHelper.identifyLabels(root);
+ 
+       if (TryHelper.enhanceTryStats(root)) {
+diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/MethodHandleDescriptorHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/MethodHandleDescriptorHelper.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..99d632904eb139a1e21f7aa30098a05ddf9a4a88
+--- /dev/null
++++ b/src/org/jetbrains/java/decompiler/modules/decompiler/MethodHandleDescriptorHelper.java
+@@ -0,0 +1,83 @@
++package org.jetbrains.java.decompiler.modules.decompiler;
++
++import java.util.ArrayList;
++import java.util.Collections;
++import java.util.List;
++
++import org.jetbrains.java.decompiler.main.DecompilerContext;
++import org.jetbrains.java.decompiler.modules.decompiler.exps.AnnotationExprent;
++import org.jetbrains.java.decompiler.modules.decompiler.exps.ConstExprent;
++import org.jetbrains.java.decompiler.modules.decompiler.exps.Exprent;
++import org.jetbrains.java.decompiler.modules.decompiler.exps.FunctionExprent;
++import org.jetbrains.java.decompiler.modules.decompiler.exps.InvocationExprent;
++import org.jetbrains.java.decompiler.modules.decompiler.exps.NewExprent;
++import org.jetbrains.java.decompiler.modules.decompiler.stats.Statement;
++import org.jetbrains.java.decompiler.struct.StructClass;
++import org.jetbrains.java.decompiler.struct.StructMethod;
++import org.jetbrains.java.decompiler.struct.attr.StructAnnotationAttribute;
++import org.jetbrains.java.decompiler.struct.attr.StructGeneralAttribute;
++import org.jetbrains.java.decompiler.struct.gen.MethodDescriptor;
++import org.jetbrains.java.decompiler.struct.gen.VarType;
++
++public class MethodHandleDescriptorHelper
++{
++    public static void changeMethodHandleDescriptorsStats(Statement stat) {
++        for (Statement inner : stat.getStats()) {
++            changeMethodHandleDescriptorsStats(inner);
++        }
++
++        if (stat.getExprents() != null) {
++            for (int i = 0; i < stat.getExprents().size(); i++) {
++                Exprent exprent = stat.getExprents().get(i);
++                Exprent updated = updateExprent(exprent);
++                if (updated != null) {
++                    stat.getExprents().set(i, updated);
++                }
++            }
++        }
++    }
++
++    private static Exprent updateExprent(Exprent exprent) {
++        for (Exprent inner : exprent.getAllExprents()) {
++            Exprent updated = updateExprent(inner);
++            if (updated != null) {
++                exprent.replaceExprent(inner, updated);
++            }
++        }
++
++        if (exprent.type == Exprent.EXPRENT_INVOCATION) {
++            InvocationExprent invocation = (InvocationExprent) exprent;
++            StructClass cl = DecompilerContext.getStructContext().getClass(invocation.getClassName());
++            if (cl != null) {
++                StructMethod mtd = cl.getMethod(invocation.getName(), "([Ljava/lang/Object;)Ljava/lang/Object;");
++                if (mtd != null) {
++                    StructAnnotationAttribute annotations = mtd.getAttribute(StructGeneralAttribute.ATTRIBUTE_RUNTIME_VISIBLE_ANNOTATIONS);
++                    if (annotations != null) {
++                        for (AnnotationExprent annotation : annotations.getAnnotations()) {
++                            if (annotation.getClassName().equals("java/lang/invoke/MethodHandle$PolymorphicSignature")) {
++                                MethodDescriptor oldDesc = invocation.getDescriptor();
++                                invocation.setStringDescriptor(mtd.getDescriptor());
++                                invocation.setDescriptor(MethodDescriptor.parseDescriptor(mtd.getDescriptor()));
++
++                                List<Exprent> params = invocation.getParameters();
++                                NewExprent newParam = new NewExprent(VarType.VARTYPE_OBJECT.resizeArrayDim(1), Collections.emptyList(), null);
++                                newParam.setLstArrayElements(params);
++                                List<Exprent> newParams = new ArrayList<>();
++                                newParams.add(newParam);
++                                invocation.setParameters(newParams);
++
++                                List<Exprent> castExprents = new ArrayList<>();
++                                castExprents.add(invocation);
++                                castExprents.add(new ConstExprent(oldDesc.ret, null, null));
++                                FunctionExprent cast = new FunctionExprent(FunctionExprent.FUNCTION_CAST, castExprents, null);
++                                return cast;
++                            }
++                        }
++                    }
++                }
++            }
++        }
++        return null;
++    }
++
++}

--- a/FernFlower-Patches/0048-Fix-signature-polymorphic-methods.patch
+++ b/FernFlower-Patches/0048-Fix-signature-polymorphic-methods.patch
@@ -19,10 +19,10 @@ index fd6c22a4b18b2875a5f0f1b7d3f18fa2ed0ba305..7078bd10c2bccd11c1aad74dfe05802e
        if (TryHelper.enhanceTryStats(root)) {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/MethodHandleDescriptorHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/MethodHandleDescriptorHelper.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..99d632904eb139a1e21f7aa30098a05ddf9a4a88
+index 0000000000000000000000000000000000000000..6a641cf966ad040114e5d50fca9382f931d49700
 --- /dev/null
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/MethodHandleDescriptorHelper.java
-@@ -0,0 +1,83 @@
+@@ -0,0 +1,86 @@
 +package org.jetbrains.java.decompiler.modules.decompiler;
 +
 +import java.util.ArrayList;
@@ -91,11 +91,14 @@ index 0000000000000000000000000000000000000000..99d632904eb139a1e21f7aa30098a05d
 +                                newParams.add(newParam);
 +                                invocation.setParameters(newParams);
 +
-+                                List<Exprent> castExprents = new ArrayList<>();
-+                                castExprents.add(invocation);
-+                                castExprents.add(new ConstExprent(oldDesc.ret, null, null));
-+                                FunctionExprent cast = new FunctionExprent(FunctionExprent.FUNCTION_CAST, castExprents, null);
-+                                return cast;
++                                if (!VarType.VARTYPE_VOID.equals(oldDesc.ret)) {
++                                  List<Exprent> castExprents = new ArrayList<>();
++                                  castExprents.add(invocation);
++                                  castExprents.add(new ConstExprent(oldDesc.ret, null, null));
++                                  FunctionExprent cast = new FunctionExprent(FunctionExprent.FUNCTION_CAST, castExprents, null);
++                                  return cast;
++                                }
++                                return null;
 +                            }
 +                        }
 +                    }

--- a/FernFlower-Patches/0048-Fix-signature-polymorphic-methods.patch
+++ b/FernFlower-Patches/0048-Fix-signature-polymorphic-methods.patch
@@ -19,10 +19,10 @@ index fd6c22a4b18b2875a5f0f1b7d3f18fa2ed0ba305..7078bd10c2bccd11c1aad74dfe05802e
        if (TryHelper.enhanceTryStats(root)) {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/MethodHandleDescriptorHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/MethodHandleDescriptorHelper.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..6a641cf966ad040114e5d50fca9382f931d49700
+index 0000000000000000000000000000000000000000..641d616a4a99bb0a779f42737b883076a9e98deb
 --- /dev/null
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/MethodHandleDescriptorHelper.java
-@@ -0,0 +1,86 @@
+@@ -0,0 +1,92 @@
 +package org.jetbrains.java.decompiler.modules.decompiler;
 +
 +import java.util.ArrayList;
@@ -46,6 +46,9 @@ index 0000000000000000000000000000000000000000..6a641cf966ad040114e5d50fca9382f9
 +
 +public class MethodHandleDescriptorHelper
 +{
++
++    private static final String OBJECT_ARRAY_PARAM = "([Ljava/lang/Object;)";
++
 +    public static void changeMethodHandleDescriptorsStats(Statement stat) {
 +        for (Statement inner : stat.getStats()) {
 +            changeMethodHandleDescriptorsStats(inner);
@@ -74,7 +77,10 @@ index 0000000000000000000000000000000000000000..6a641cf966ad040114e5d50fca9382f9
 +            InvocationExprent invocation = (InvocationExprent) exprent;
 +            StructClass cl = DecompilerContext.getStructContext().getClass(invocation.getClassName());
 +            if (cl != null) {
-+                StructMethod mtd = cl.getMethod(invocation.getName(), "([Ljava/lang/Object;)Ljava/lang/Object;");
++                StructMethod mtd = cl.getMethod(invocation.getName(), OBJECT_ARRAY_PARAM + "Ljava/lang/Object;");
++                if (mtd == null) {
++                    mtd = cl.getMethod(invocation.getName(), OBJECT_ARRAY_PARAM + invocation.getDescriptor().ret);
++                }
 +                if (mtd != null) {
 +                    StructAnnotationAttribute annotations = mtd.getAttribute(StructGeneralAttribute.ATTRIBUTE_RUNTIME_VISIBLE_ANNOTATIONS);
 +                    if (annotations != null) {


### PR DESCRIPTION
Fixes not casting return values from polymorphic signature method calls (The methods only exist in `MethodHandle` and `VarHandle` currently) to the correct type.

Even though at source level it looks like the methods have a descriptor of `([Ljava/lang/Object;)Ljava/lang/Object` or some other return type if the return type is to be kept and the parameter is a varargs parameter, when compiled they get the descriptor of whatever argument types the method call is given and if the method returns an `Object` a return type of whatever the cast is otherwise the return type is kept.

The specification for this is https://docs.oracle.com/javase/specs/jls/se17/html/jls-15.html#jls-15.12.3.

The diff for 22w45a is https://gist.github.com/coehlrich/4002a2cc38d373aecc467989c96c1231 (There is a call with parameters in `DebugMemoryUntracker`