### PR TITLE
Fix try with resources being created when it shouldn't be

### DIFF
--- a/FernFlower-Patches/0024-Add-try-with-resource-support.patch
+++ b/FernFlower-Patches/0024-Add-try-with-resource-support.patch
@@ -21,10 +21,10 @@ index 81fed9eaea4d73a99e87545d15171033f98db3b1..cc6f6ad706aa1fcb0b129ea9da80b47f
        }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/TryHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/TryHelper.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..74f8661d10c840fff38ebde68bd284fd9ed16a72
+index 0000000000000000000000000000000000000000..88b868c9ddbe9f3aec362fe34724c0cc480d2b84
 --- /dev/null
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/TryHelper.java
-@@ -0,0 +1,595 @@
+@@ -0,0 +1,602 @@
 +package org.jetbrains.java.decompiler.modules.decompiler;
 +
 +import org.jetbrains.java.decompiler.code.CodeConstants;
@@ -199,6 +199,10 @@ index 0000000000000000000000000000000000000000..74f8661d10c840fff38ebde68bd284fd
 +      return false;
 +    }
 +
++    if (!tryStatement.getVars().get(0).getVarType().getValue().equals("java/lang/Throwable")) {
++      return false;
++    }
++
 +    Statement inner = tryStatement.getStats().get(1); // Get catch block
 +
 +    VarExprent closeable = null;
@@ -282,6 +286,9 @@ index 0000000000000000000000000000000000000000..74f8661d10c840fff38ebde68bd284fd
 +    }
 +
 +    Set<Statement> destinations = findExitpoints(tryStatement);
++    if (destinations.isEmpty()) {
++      return false;
++    }
 +
 +    Statement check = tryStatement;
 +    List<StatEdge> preds = new ArrayList<>();


### PR DESCRIPTION
Fixes a bug in the try with resources processor that caused it to be too lenient when matching the bytecode pattern, by making sure that the catch type is `Throwable` and that if no `close()` is found then it would fail, rather than attempting to validate an empty set.

1.19.2 diff:
```patch
diff -r -u3 -N a/net/minecraft/util/DirectoryLock.java b/net/minecraft/util/DirectoryLock.java
--- a/net/minecraft/util/DirectoryLock.java	1970-01-11 17:58:04.000000000 -0500
+++ b/net/minecraft/util/DirectoryLock.java	1970-01-11 17:58:04.000000000 -0500
@@ -23,7 +23,9 @@
          Files.createDirectories(p_13641_);
       }
 
-      try (FileChannel filechannel = FileChannel.open(path, StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
+      FileChannel filechannel = FileChannel.open(path, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+
+      try {
          filechannel.write(f_13634_.duplicate());
          filechannel.force(true);
          FileLock filelock = filechannel.tryLock();
@@ -32,6 +34,14 @@
          } else {
             return new DirectoryLock(filechannel, filelock);
          }
+      } catch (IOException ioexception1) {
+         try {
+            filechannel.close();
+         } catch (IOException ioexception) {
+            ioexception1.addSuppressed(ioexception);
+         }
+
+         throw ioexception1;
       }
    }
 ```