### PR TITLE
Fix incorrectly casting method parameters when referencing a subtype

### DIFF
--- a/FernFlower-Patches/0028-Improve-inferred-generic-types.patch
+++ b/FernFlower-Patches/0028-Improve-inferred-generic-types.patch
@@ -265,7 +265,7 @@ index 2ce8932cb33e4881de5ed09b728781804cdced57..90cfbde63ada4d96eb78c7192ed0e1fc
    public void getBytecodeRange(BitSet values) {
      measureBytecode(values, lstOperands);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 6fab98e2cbf3a2168daf3f80063123be60caad7b..4da029e83d7558ee75a8824a059779e6621782b5 100644
+index 6fab98e2cbf3a2168daf3f80063123be60caad7b..39c598c178c31c2b696946fb252360baa5fcddc9 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -32,6 +32,7 @@ import org.jetbrains.java.decompiler.util.TextUtil;
@@ -447,7 +447,9 @@ index 6fab98e2cbf3a2168daf3f80063123be60caad7b..4da029e83d7558ee75a8824a059779e6
              }
 +          }
 +        }
-+
+ 
+-            if (!map.isEmpty()) {
+-              ret = ret.remap(map);
 +        if (!isInvocationInstance) {
 +          upperBoundsMap.forEach((k, v) -> {
 +            if (fparams.contains(k.getValue()) && !GenericType.DUMMY_VAR.equals(v) && !genericsMap.containsKey(k)) {
@@ -455,9 +457,7 @@ index 6fab98e2cbf3a2168daf3f80063123be60caad7b..4da029e83d7558ee75a8824a059779e6
 +            }
 +          });
 +        }
- 
--            if (!map.isEmpty()) {
--              ret = ret.remap(map);
++
 +        Set<VarType> paramGenerics = new HashSet<>();
 +        if (!parameters.isEmpty() && desc.getSignature() != null) {
 +          List<VarVersionPair> mask = null;
@@ -723,7 +723,7 @@ index 6fab98e2cbf3a2168daf3f80063123be60caad7b..4da029e83d7558ee75a8824a059779e6
  
      // omit 'new Type[] {}' for the last parameter of a vararg method call
      if (parameters.size() == descriptor.params.length && isVarArgCall()) {
-@@ -523,20 +805,32 @@ public class InvocationExprent extends Exprent {
+@@ -523,20 +805,42 @@ public class InvocationExprent extends Exprent {
        }
      }
  
@@ -756,11 +756,21 @@ index 6fab98e2cbf3a2168daf3f80063123be60caad7b..4da029e83d7558ee75a8824a059779e6
 +      }
 +    }
 +    if (desc != null && desc.getSignature() != null) {
++      Map<VarType, VarType> hierarchyMap = new HashMap<>();
++      if (!className.equals(desc.getClassQualifiedName())) {
++        StructClass mthCls = DecompilerContext.getStructContext().getClass(className);
++        if (mthCls != null) {
++          Map<String, Map<VarType, VarType>> hierarchy = mthCls.getAllGenerics();
++          if (hierarchy.containsKey(desc.getClassQualifiedName())) {
++            hierarchyMap = hierarchy.get(desc.getClassQualifiedName());
++          }
++        }
++      }
 +      Set<VarType> namedGens = getNamedGenerics().keySet();
 +      int y = 0;
 +      for (int x = start; x < types.length; x++) {
 +        if (mask == null || mask.get(x) == null) {
-+          VarType type = desc.getSignature().parameterTypes.get(y++).remap(genericsMap);
++          VarType type = desc.getSignature().parameterTypes.get(y++).remap(hierarchyMap).remap(genericsMap);
 +          if (type != null && !(type.isGeneric() && ((GenericType)type).hasUnknownGenericType(namedGens))) {
 +            types[x] = type;
 +          }
@@ -769,7 +779,7 @@ index 6fab98e2cbf3a2168daf3f80063123be60caad7b..4da029e83d7558ee75a8824a059779e6
      }
  
  
-@@ -574,6 +868,10 @@ public class InvocationExprent extends Exprent {
+@@ -574,6 +878,10 @@ public class InvocationExprent extends Exprent {
          }
          */
  
@@ -780,7 +790,7 @@ index 6fab98e2cbf3a2168daf3f80063123be60caad7b..4da029e83d7558ee75a8824a059779e6
          // 'byte' and 'short' literals need an explicit narrowing type cast when used as a parameter
          ExprProcessor.getCastedExprent(this.parameters.get(i), types[i], buff, indent, true, ambiguous, true, true, tracer);
  
-@@ -589,8 +887,6 @@ public class InvocationExprent extends Exprent {
+@@ -589,8 +897,6 @@ public class InvocationExprent extends Exprent {
        }
      }
  
@@ -789,7 +799,7 @@ index 6fab98e2cbf3a2168daf3f80063123be60caad7b..4da029e83d7558ee75a8824a059779e6
      return buf;
    }
  
-@@ -888,6 +1184,162 @@ public class InvocationExprent extends Exprent {
+@@ -888,6 +1194,162 @@ public class InvocationExprent extends Exprent {
      return ambiguous;
    }
  
@@ -952,7 +962,7 @@ index 6fab98e2cbf3a2168daf3f80063123be60caad7b..4da029e83d7558ee75a8824a059779e6
    @Override
    public void replaceExprent(Exprent oldExpr, Exprent newExpr) {
      if (oldExpr == instance) {
-@@ -1000,6 +1452,19 @@ public class InvocationExprent extends Exprent {
+@@ -1000,6 +1462,19 @@ public class InvocationExprent extends Exprent {
      return isSyntheticNullCheck;
    }
  

--- a/FernFlower-Patches/0029-Improve-stack-var-processor-output.patch
+++ b/FernFlower-Patches/0029-Improve-stack-var-processor-output.patch
@@ -318,7 +318,7 @@ index d8fd9bdf784704836e69cfdd1596ae29b2732232..139ccdb55347a5d66627c1489ee73910
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 4da029e83d7558ee75a8824a059779e6621782b5..bdbb91aefccdf2081a3c016fdf9b78316bb16e05 100644
+index 39c598c178c31c2b696946fb252360baa5fcddc9..bb9986f561c0e13db9971ffbedf5f3fd14e26a10 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -169,6 +169,11 @@ public class InvocationExprent extends Exprent {

--- a/FernFlower-Patches/0032-Add-explicit-cast-to-invocations-of-java-nio-Buffer-.patch
+++ b/FernFlower-Patches/0032-Add-explicit-cast-to-invocations-of-java-nio-Buffer-.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Add explicit cast to invocations of java/nio/Buffer
 Java 9+ added overrides to these functions to return the specific subclass, however, when there is a compiler "bug" that when targeting release * or below, it will still reference these new methods, causing exceptions at runtime on Java 8.
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index bdbb91aefccdf2081a3c016fdf9b78316bb16e05..2ce9992b3ee519323e7ee48a8f4de7ed731ea72d 100644
+index bb9986f561c0e13db9971ffbedf5f3fd14e26a10..e98c97e61097b448de85182294006fa5603db421 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -47,6 +47,8 @@ public class InvocationExprent extends Exprent {

--- a/FernFlower-Patches/0045-Reduce-allocations-in-getAllExprents.patch
+++ b/FernFlower-Patches/0045-Reduce-allocations-in-getAllExprents.patch
@@ -229,7 +229,7 @@ index 18d2c40d9af0e822004f4baaa3c6b567914a7545..de3723ed7b731fc76afe15482d4caff8
      return lst;
    }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 2ce9992b3ee519323e7ee48a8f4de7ed731ea72d..58aa9b3703b9aedcc935922a73c39426111c74ea 100644
+index e98c97e61097b448de85182294006fa5603db421..6961e5b7ece731f18825dee674a5e1260548dc60 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -530,8 +530,7 @@ public class InvocationExprent extends Exprent {


### PR DESCRIPTION
Fixes some method parameters getting casted to incorrect types when the method reference is via a subtype that is an interface.

1.19.3-pre3 diff: https://gist.github.com/coehlrich/d8451d90b0fc298cabbf06e36e533149