### PR TITLE
Rebase on upstream 0e3593f

### DIFF
--- a/FernFlower-Patches/0001-Git-filter-and-setup-cleanup-for-java-17.patch
+++ b/FernFlower-Patches/0001-Git-filter-and-setup-cleanup-for-java-17.patch
@@ -308,7 +308,7 @@ index 3f5a417a01d918a21b7dcb057b2eb259ec2df475..9b15cd643468b3852b0092f7bffd3995
  \* means 0 or more times\
 diff --git a/build.gradle b/build.gradle
 deleted file mode 100644
-index efa9dfcfa2204db2314dc867ba995a6cfca37581..0000000000000000000000000000000000000000
+index 02824bca257e3bb1d20d79a898a06aa9237f1b2f..0000000000000000000000000000000000000000
 --- a/build.gradle
 +++ /dev/null
 @@ -1,26 +0,0 @@
@@ -316,8 +316,8 @@ index efa9dfcfa2204db2314dc867ba995a6cfca37581..00000000000000000000000000000000
 -apply plugin: 'java'
 -
 -compileJava {
--  sourceCompatibility '11'
--  targetCompatibility '11'
+-  sourceCompatibility '17'
+-  targetCompatibility '17'
 -}
 -
 -sourceSets {
@@ -329,7 +329,7 @@ index efa9dfcfa2204db2314dc867ba995a6cfca37581..00000000000000000000000000000000
 -dependencies {
 -  implementation 'org.jetbrains:annotations:20.1.0'
 -  testImplementation 'junit:junit:4.12'
--  testImplementation 'org.assertj:assertj-core:3.12.2'
+-  testImplementation 'org.assertj:assertj-core:3.23.1'
 -}
 -
 -jar {
@@ -683,17 +683,6 @@ z1oZy=k51*2LJZ(Ikk`8;K(9hbeF-B(c~>0hU;Gye{L8ZN*NH8Id@mP-u<kJdqbmLd
 zMeKb5hFAZC+k4_b_qu=C#=hYGO^yR`fRh0G>;Fmb8YuorjLrW&ndip8CN%_qp982r
 w1WEnz9^$&s1hkp_3#lPJQ~!HI7WYYjA7>z!`?f%npAh2%rB@vD|Lau$2O)#1n*aa+
 
-diff --git a/gradle/wrapper/gradle-wrapper.properties b/gradle/wrapper/gradle-wrapper.properties
-index 2e6e5897b5285c749d75662c65ac5d2904c37bc6..ae04661ee733431762e7ccf8ab9b7409ed44960c 100644
---- a/gradle/wrapper/gradle-wrapper.properties
-+++ b/gradle/wrapper/gradle-wrapper.properties
-@@ -1,5 +1,5 @@
- distributionBase=GRADLE_USER_HOME
- distributionPath=wrapper/dists
--distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
-+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
- zipStoreBase=GRADLE_USER_HOME
- zipStorePath=wrapper/dists
 diff --git a/gradlew b/gradlew
 index c53aefaa5fc898b78c7265ea99a3bdc09349a7d0..1b6c787337ffb79f0e3cf8b1e9f00f680a959de1 100755
 --- a/gradlew

--- a/FernFlower-Patches/0002-Test-Framework-upgrades.patch
+++ b/FernFlower-Patches/0002-Test-Framework-upgrades.patch
@@ -20,7 +20,7 @@ index bb303e84f33161a4b4fd40a73aa48d29981d9ef2..cc1f537e71af0748b7b97d7d8489198e
      throw new RuntimeException("not implemented");
    }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java
-index c870c683cad7935d7aba141c0310ec0f0a2fdeda..272601270ea32fb5ccc4a822cd9d1b959bae9c35 100644
+index 18a820c7d4723b35f09fa4c841e8399a547acdc7..224d3636f7c9d502cc65c122f542324c1ba7028a 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java
 @@ -430,6 +430,10 @@ public abstract class Statement implements IMatchable {
@@ -35,50 +35,47 @@ index c870c683cad7935d7aba141c0310ec0f0a2fdeda..272601270ea32fb5ccc4a822cd9d1b95
      throw new RuntimeException("not implemented");
    }
 diff --git a/test/org/jetbrains/java/decompiler/DecompilerTestFixture.java b/test/org/jetbrains/java/decompiler/DecompilerTestFixture.java
-index 4c5641fec76837a51094d4a54800d5b7475446ca..7d29c198014cbfee8092fd31461208ce58e7f775 100644
+index f8c2afde883ffe8c681d4e63821991ae82fccdaa..49cbf8407df5952f3da980e6a10f284ff2f27817 100644
 --- a/test/org/jetbrains/java/decompiler/DecompilerTestFixture.java
 +++ b/test/org/jetbrains/java/decompiler/DecompilerTestFixture.java
-@@ -23,6 +23,7 @@ public class DecompilerTestFixture {
-   private File tempDir;
-   private File targetDir;
+@@ -28,6 +28,7 @@ public class DecompilerTestFixture {
+   private Path tempDir;
+   private Path targetDir;
    private TestConsoleDecompiler decompiler;
 +  private boolean cleanup = true;
  
-   public void setUp(String... optionPairs) throws IOException {
-     assertThat(optionPairs.length % 2).isEqualTo(0);
+   public void setUp(Map<String, String> customOptions) throws IOException {
+     testDataDir = Path.of("testData");
 @@ -56,7 +57,7 @@ public class DecompilerTestFixture {
-   }
  
-   public void tearDown() {
--    if (tempDir != null) {
-+    if (tempDir != null && cleanup) {
-       delete(tempDir);
+   public void tearDown() throws IOException {
+     try {
+-      if (tempDir != null) {
++      if (tempDir != null && cleanup) {
+         deleteRecursively(tempDir);
+       }
      }
-     decompiler.close();
-@@ -77,6 +78,14 @@ public class DecompilerTestFixture {
-   public ConsoleDecompiler getDecompiler() {
+@@ -81,6 +82,14 @@ public class DecompilerTestFixture {
      return decompiler;
    }
-+  
+ 
 +  public void setCleanup(boolean value) {
 +    this.cleanup = value;
 +  }
-+  
++
 +  public boolean getCleanup() {
 +    return cleanup;
 +  }
- 
-   private static boolean isTestDataDir(File dir) {
-     return dir.isDirectory() && new File(dir, "classes").isDirectory() && new File(dir, "results").isDirectory();
++
+   private static boolean isTestDataDir(Path dir) {
+     return Files.isDirectory(dir) && Files.isDirectory(dir.resolve("classes")) && Files.isDirectory(dir.resolve("results"));
+   }
 diff --git a/test/org/jetbrains/java/decompiler/SingleClassesTest.java b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
-index e64cf91c0674163f5c81b874e21e84da83fd264e..8c4811fe2e4c46bf87bc0b4ac7752bae5243faf1 100644
+index fc6a4427e586f51fa0bbe43cbb206809e32dfa57..89adb4e6fca7186ae849e62b98a9253de2dd29ef 100644
 --- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
 +++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
-@@ -2,27 +2,13 @@
- package org.jetbrains.java.decompiler;
- 
+@@ -4,28 +4,13 @@ package org.jetbrains.java.decompiler;
  import org.jetbrains.java.decompiler.main.DecompilerContext;
--import org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler;
  import org.jetbrains.java.decompiler.main.extern.ClassFormatException;
  import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
 -import org.junit.After;
@@ -87,12 +84,16 @@ index e64cf91c0674163f5c81b874e21e84da83fd264e..8c4811fe2e4c46bf87bc0b4ac7752bae
  import org.junit.Test;
  import org.junit.rules.Timeout;
  
--import java.io.File;
 -import java.io.IOException;
+-import java.io.UncheckedIOException;
+-import java.nio.file.DirectoryStream;
+-import java.nio.file.Files;
+-import java.nio.file.Path;
 -import java.util.ArrayList;
--import java.util.Collections;
 -import java.util.List;
--
+ import java.util.Map;
+ 
+-import static org.assertj.core.api.Assertions.assertThat;
 -import static org.jetbrains.java.decompiler.DecompilerTestFixture.assertFilesEqual;
 -import static org.junit.Assert.assertTrue;
 -
@@ -103,75 +104,75 @@ index e64cf91c0674163f5c81b874e21e84da83fd264e..8c4811fe2e4c46bf87bc0b4ac7752bae
    /*
     * Set individual test duration time limit to 60 seconds.
     * This will help us to test bugs hanging decompiler.
-@@ -30,19 +16,14 @@ public class SingleClassesTest {
+@@ -33,19 +18,12 @@ public class SingleClassesTest {
    @Rule
    public Timeout globalTimeout = Timeout.seconds(60);
  
 -  @Before
 -  public void setUp() throws IOException {
 -    fixture = new DecompilerTestFixture();
--    fixture.setUp(IFernflowerPreferences.BYTECODE_SOURCE_MAPPING, "1",
--                  IFernflowerPreferences.DUMP_ORIGINAL_LINES, "1",
--                  IFernflowerPreferences.IGNORE_INVALID_BYTECODE, "1",
--                  IFernflowerPreferences.VERIFY_ANONYMOUS_CLASSES, "1");
+-    fixture.setUp(Map.of(IFernflowerPreferences.BYTECODE_SOURCE_MAPPING, "1",
++  @Override
++  protected Map<String, String> getDecompilerOptions() {
++    return Map.of(IFernflowerPreferences.BYTECODE_SOURCE_MAPPING, "1",
+                          IFernflowerPreferences.DUMP_ORIGINAL_LINES, "1",
+                          IFernflowerPreferences.IGNORE_INVALID_BYTECODE, "1",
+-                         IFernflowerPreferences.VERIFY_ANONYMOUS_CLASSES, "1"));
 -  }
 -
 -  @After
--  public void tearDown() {
+-  public void tearDown() throws IOException {
 -    fixture.tearDown();
 -    fixture = null;
-+  @Override
-+  protected String[] getDecompilerOptions() {
-+    return new String[] {
-+      IFernflowerPreferences.BYTECODE_SOURCE_MAPPING, "1",
-+      IFernflowerPreferences.DUMP_ORIGINAL_LINES, "1",
-+      IFernflowerPreferences.IGNORE_INVALID_BYTECODE, "1",
-+      IFernflowerPreferences.VERIFY_ANONYMOUS_CLASSES, "1",
-+    };
++                         IFernflowerPreferences.VERIFY_ANONYMOUS_CLASSES, "1");
    }
  
    @Test public void testPrimitiveNarrowing() { doTest("pkg/TestPrimitiveNarrowing"); }
-@@ -226,45 +207,4 @@ public class SingleClassesTest {
+@@ -229,49 +207,4 @@ public class SingleClassesTest {
  
    @Test(expected = ClassFormatException.class)
    public void testUnsupportedConstantPoolEntry() { doTest("java11/TestUnsupportedConstantPoolEntry"); }
 -
 -  private void doTest(String testFile, String... companionFiles) {
--    ConsoleDecompiler decompiler = fixture.getDecompiler();
+-    var decompiler = fixture.getDecompiler();
 -
--    File classFile = new File(fixture.getTestDataDir(), "/classes/" + testFile + ".class");
--    assertTrue(classFile.isFile());
--    for (File file : collectClasses(classFile)) {
--      decompiler.addSource(file);
+-    var classFile = fixture.getTestDataDir().resolve("classes/" + testFile + ".class");
+-    assertThat(classFile).isRegularFile();
+-    for (var file : collectClasses(classFile)) {
+-      decompiler.addSource(file.toFile());
 -    }
 -
 -    for (String companionFile : companionFiles) {
--      File companionClassFile = new File(fixture.getTestDataDir(), "/classes/" + companionFile + ".class");
--      assertTrue(companionClassFile.isFile());
--      for (File file : collectClasses(companionClassFile)) {
--        decompiler.addSource(file);
+-      var companionClassFile = fixture.getTestDataDir().resolve("classes/" + companionFile + ".class");
+-      assertThat(companionClassFile).isRegularFile();
+-      for (var file : collectClasses(companionClassFile)) {
+-        decompiler.addSource(file.toFile());
 -      }
 -    }
 -
 -    decompiler.decompileContext();
 -
--    String testName = classFile.getName().substring(0, classFile.getName().length() - 6);
--    File decompiledFile = new File(fixture.getTargetDir(), testName + ".java");
--    assertTrue(decompiledFile.isFile());
--    File referenceFile = new File(fixture.getTestDataDir(), "results/" + testName + ".dec");
--    assertTrue(referenceFile.isFile());
+-    var decompiledFile = fixture.getTargetDir().resolve(classFile.getFileName().toString().replace(".class", ".java"));
+-    assertThat(decompiledFile).isRegularFile();
+-    assertTrue(Files.isRegularFile(decompiledFile));
+-    var referenceFile = fixture.getTestDataDir().resolve("results/" + classFile.getFileName().toString().replace(".class", ".dec"));
+-    assertThat(referenceFile).isRegularFile();
 -    assertFilesEqual(referenceFile, decompiledFile);
 -  }
 -
--  private static List<File> collectClasses(File classFile) {
--    List<File> files = new ArrayList<>();
+-  private static List<Path> collectClasses(Path classFile) {
+-    var files = new ArrayList<Path>();
 -    files.add(classFile);
 -
--    File parent = classFile.getParentFile();
+-    var parent = classFile.getParent();
 -    if (parent != null) {
--      final String pattern = classFile.getName().replace(".class", "") + "\\$.+\\.class";
--      File[] inner = parent.listFiles((dir, name) -> name.matches(pattern));
--      if (inner != null) Collections.addAll(files, inner);
+-      var glob = classFile.getFileName().toString().replace(".class", "$*.class");
+-      try (DirectoryStream<Path> inner = Files.newDirectoryStream(parent, glob)) {
+-        inner.forEach(files::add);
+-      }
+-      catch (IOException e) {
+-        throw new UncheckedIOException(e);
+-      }
 -    }
 -
 -    return files;
@@ -179,10 +180,10 @@ index e64cf91c0674163f5c81b874e21e84da83fd264e..8c4811fe2e4c46bf87bc0b4ac7752bae
  }
 diff --git a/test/org/jetbrains/java/decompiler/SingleClassesTestBase.java b/test/org/jetbrains/java/decompiler/SingleClassesTestBase.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..081bb55728a0e759bb510c983a56c27b4f39c4d6
+index 0000000000000000000000000000000000000000..05df2e2f7842eb444a1015c69894efc69416f55a
 --- /dev/null
 +++ b/test/org/jetbrains/java/decompiler/SingleClassesTestBase.java
-@@ -0,0 +1,90 @@
+@@ -0,0 +1,96 @@
 +/*
 + * Copyright 2000-2017 JetBrains s.r.o.
 + *
@@ -200,23 +201,26 @@ index 0000000000000000000000000000000000000000..081bb55728a0e759bb510c983a56c27b
 + */
 +package org.jetbrains.java.decompiler;
 +
-+import org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler;
 +import org.junit.After;
 +import org.junit.Before;
-+import java.io.File;
 +import java.io.IOException;
++import java.io.UncheckedIOException;
++import java.nio.file.DirectoryStream;
++import java.nio.file.Files;
++import java.nio.file.Path;
 +import java.util.ArrayList;
-+import java.util.Collections;
 +import java.util.List;
++import java.util.Map;
 +
++import static org.assertj.core.api.Assertions.assertThat;
 +import static org.jetbrains.java.decompiler.DecompilerTestFixture.assertFilesEqual;
 +import static org.junit.Assert.assertTrue;
 +
 +public class SingleClassesTestBase {
 +  protected DecompilerTestFixture fixture;
 +  
-+  protected String[] getDecompilerOptions() {
-+    return new String[] {};
++  protected Map<String, String> getDecompilerOptions() {
++    return Map.of();
 +  }
 +
 +  @Before
@@ -226,48 +230,51 @@ index 0000000000000000000000000000000000000000..081bb55728a0e759bb510c983a56c27b
 +  }
 +
 +  @After
-+  public void tearDown() {
++  public void tearDown() throws IOException {
 +    fixture.tearDown();
 +    fixture = null;
 +  }
 +
-+
 +  protected void doTest(String testFile, String... companionFiles) {
-+    ConsoleDecompiler decompiler = fixture.getDecompiler();
++    var decompiler = fixture.getDecompiler();
 +
-+    File classFile = new File(fixture.getTestDataDir(), "/classes/" + testFile + ".class");
-+    assertTrue(classFile.isFile());
-+    for (File file : collectClasses(classFile)) {
-+      decompiler.addSource(file);
++    var classFile = fixture.getTestDataDir().resolve("classes/" + testFile + ".class");
++    assertThat(classFile).isRegularFile();
++    for (var file : collectClasses(classFile)) {
++      decompiler.addSource(file.toFile());
 +    }
 +
 +    for (String companionFile : companionFiles) {
-+      File companionClassFile = new File(fixture.getTestDataDir(), "/classes/" + companionFile + ".class");
-+      assertTrue(companionClassFile.isFile());
-+      for (File file : collectClasses(companionClassFile)) {
-+        decompiler.addSource(file);
++      var companionClassFile = fixture.getTestDataDir().resolve("classes/" + companionFile + ".class");
++      assertThat(companionClassFile).isRegularFile();
++      for (var file : collectClasses(companionClassFile)) {
++        decompiler.addSource(file.toFile());
 +      }
 +    }
 +
 +    decompiler.decompileContext();
 +
-+    String testName = classFile.getName().substring(0, classFile.getName().length() - 6);
-+    File decompiledFile = new File(fixture.getTargetDir(), testName + ".java");
-+    assertTrue(decompiledFile.isFile());
-+    File referenceFile = new File(fixture.getTestDataDir(), "results/" + testName + ".dec");
-+    assertTrue(referenceFile.isFile());
++    var decompiledFile = fixture.getTargetDir().resolve(classFile.getFileName().toString().replace(".class", ".java"));
++    assertThat(decompiledFile).isRegularFile();
++    assertTrue(Files.isRegularFile(decompiledFile));
++    var referenceFile = fixture.getTestDataDir().resolve("results/" + classFile.getFileName().toString().replace(".class", ".dec"));
++    assertThat(referenceFile).isRegularFile();
 +    assertFilesEqual(referenceFile, decompiledFile);
 +  }
 +
-+  private static List<File> collectClasses(File classFile) {
-+    List<File> files = new ArrayList<>();
++  private static List<Path> collectClasses(Path classFile) {
++    var files = new ArrayList<Path>();
 +    files.add(classFile);
 +
-+    File parent = classFile.getParentFile();
++    var parent = classFile.getParent();
 +    if (parent != null) {
-+      final String pattern = classFile.getName().replace(".class", "") + "\\$.+\\.class";
-+      File[] inner = parent.listFiles((dir, name) -> name.matches(pattern));
-+      if (inner != null) Collections.addAll(files, inner);
++      var glob = classFile.getFileName().toString().replace(".class", "$*.class");
++      try (DirectoryStream<Path> inner = Files.newDirectoryStream(parent, glob)) {
++        inner.forEach(files::add);
++      }
++      catch (IOException e) {
++        throw new UncheckedIOException(e);
++      }
 +    }
 +
 +    return files;

--- a/FernFlower-Patches/0003-Fix-initializers-for-anon-and-synthetic-classes.patch
+++ b/FernFlower-Patches/0003-Fix-initializers-for-anon-and-synthetic-classes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix initializers for anon and synthetic classes
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 959ff51c479db3f0144df9f0de5b3ef863dcdff6..0dc28bc9d8e3b622f691939b1c8fcce9a09c11fe 100644
+index c012edd94f3f13c3bde885c992a74ce6d58eb0ee..1989a01b158570651f332cf80dca0e0baeb4153c 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -46,6 +46,7 @@ public class ClassWriter {
@@ -17,7 +17,7 @@ index 959ff51c479db3f0144df9f0de5b3ef863dcdff6..0dc28bc9d8e3b622f691939b1c8fcce9
      if (node.type == ClassNode.CLASS_ROOT &&
          !cl.isVersion5() &&
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
-index 804443bf66c6cc2a9cadf5ef11c44827257aaf53..a45067feeedaece4546ae2dbc5148fbf9b2c0309 100644
+index 168d7dfdeb65138ef7c26e30971738cd5161ffff..4a539357120d333d47f20f5e05b57ef4ad7b1fa8 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 @@ -88,6 +88,31 @@ public class ClassesProcessor implements CodeConstants {
@@ -53,7 +53,7 @@ index 804443bf66c6cc2a9cadf5ef11c44827257aaf53..a45067feeedaece4546ae2dbc5148fbf
                String enclClassName = entry.outerNameIdx != 0 ? entry.enclosingName : cl.qualifiedName;
                if (enclClassName == null || innerName.equals(enclClassName)) {
 diff --git a/src/org/jetbrains/java/decompiler/main/InitializerProcessor.java b/src/org/jetbrains/java/decompiler/main/InitializerProcessor.java
-index bc8992ff40bf8655077d2c01a7038bfbbfe999c0..34be3854cad1675d54a32929d5e1fe1641f1a929 100644
+index 7abfd011cee7c1c14a1418f826a39403f75a62db..b44a78019f0717213822ef5572c5d7ecde6d4ee3 100644
 --- a/src/org/jetbrains/java/decompiler/main/InitializerProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/InitializerProcessor.java
 @@ -13,6 +13,9 @@ import org.jetbrains.java.decompiler.modules.decompiler.stats.Statements;

--- a/FernFlower-Patches/0004-Fix-output-discrepancies-to-produce-stable-output.patch
+++ b/FernFlower-Patches/0004-Fix-output-discrepancies-to-produce-stable-output.patch
@@ -7,7 +7,7 @@ Running JVM and timestamp result in output varying between
 environments and runs.
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
-index a45067feeedaece4546ae2dbc5148fbf9b2c0309..7db5b328969a6dac49054e57b5c00c672ca4ea85 100644
+index 4a539357120d333d47f20f5e05b57ef4ad7b1fa8..9104ad3f1edae3deb11913bb08d101269370ca7d 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 @@ -249,6 +249,7 @@ public class ClassesProcessor implements CodeConstants {
@@ -18,7 +18,7 @@ index a45067feeedaece4546ae2dbc5148fbf9b2c0309..7db5b328969a6dac49054e57b5c00c67
            }
          }
        }
-@@ -454,7 +455,7 @@ public class ClassesProcessor implements CodeConstants {
+@@ -451,7 +452,7 @@ public class ClassesProcessor implements CodeConstants {
    }
  
  
@@ -27,7 +27,7 @@ index a45067feeedaece4546ae2dbc5148fbf9b2c0309..7db5b328969a6dac49054e57b5c00c67
      public static final int CLASS_ROOT = 0;
      public static final int CLASS_MEMBER = 1;
      public static final int CLASS_ANONYMOUS = 2;
-@@ -545,6 +546,12 @@ public class ClassesProcessor implements CodeConstants {
+@@ -542,6 +543,12 @@ public class ClassesProcessor implements CodeConstants {
        isNonSealed = nonSealed;
      }
  
@@ -134,7 +134,7 @@ index 05e6e2d720aa5812ef12c4741eab06b8ea477e0f..f9c8c6a0334512699c545c8812071947
        }
      }
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-index 7a8655702381a23063c06594aa07bdd9b5c0a8fe..bc116db0c8ad1b1312f220b9b9e22c5d7cdddad8 100644
+index 7fca17c41c49b5378614130cf3b94b4aef6d1176..09eb2ca3b49093d291aaa4fc8bb769316d5a62ac 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 @@ -218,6 +218,7 @@ public class NestedClassProcessor {
@@ -146,7 +146,7 @@ index 7a8655702381a23063c06594aa07bdd9b5c0a8fe..bc116db0c8ad1b1312f220b9b9e22c5d
          return true;
        }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java
-index fe2d3b14c6e48dc08831123ef80902bc3126ceca..86cac9e08f0f0d3ebd43353b64eba9560279de55 100644
+index 868955437f5c05d8b011671089de24aa7d5ab8cc..277e792a2856334970bafe0661582a8c8d09ad5a 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java
 @@ -194,7 +194,7 @@ public final class DomHelper {
@@ -167,7 +167,7 @@ index fe2d3b14c6e48dc08831123ef80902bc3126ceca..86cac9e08f0f0d3ebd43353b64eba956
  
      SequenceHelper.condenseSequences(root);
      root.buildMonitorFlags();
-@@ -467,11 +467,11 @@ public final class DomHelper {
+@@ -452,11 +452,11 @@ public final class DomHelper {
  
          boolean same = (post == head);
  
@@ -181,7 +181,7 @@ index fe2d3b14c6e48dc08831123ef80902bc3126ceca..86cac9e08f0f0d3ebd43353b64eba956
          setHandlers.add(head);
          while (true) {
  
-@@ -616,7 +616,7 @@ public final class DomHelper {
+@@ -601,7 +601,7 @@ public final class DomHelper {
                set.removeAll(setOldNodes);
  
                if (setOldNodes.contains(key)) {
@@ -191,10 +191,10 @@ index fe2d3b14c6e48dc08831123ef80902bc3126ceca..86cac9e08f0f0d3ebd43353b64eba956
                }
                else {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
-index 939863351be0544adc7c4079dc2dbb18be877fb9..6216a80e20d1a1bbb80c5b343b743832e0421dbc 100644
+index cf3ce3d5c4d304c8f1ee121a9781d3238f794b91..6783382a1c199ba33df1af3477d3cf5e13230b09 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
-@@ -932,6 +932,7 @@ public class ExprProcessor implements CodeConstants {
+@@ -928,6 +928,7 @@ public class ExprProcessor implements CodeConstants {
      }
  
      TextBuffer buf = new TextBuffer();
@@ -203,11 +203,11 @@ index 939863351be0544adc7c4079dc2dbb18be877fb9..6216a80e20d1a1bbb80c5b343b743832
      for (Exprent expr : lst) {
        if (buf.length() > 0 && expr.type == Exprent.EXPRENT_VAR && ((VarExprent)expr).isClassDef()) {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java
-index 13d747a5ec6b961763f70b9174efeaf976336dbc..ad41b185d8c830f26b4f598a6568b3272a11d86f 100644
+index 2770c678a4572cd95bbb0d7f98fadb4bb62fcbd8..878c12b061975d4060b8a44abffa3d60d35d17a3 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java
-@@ -480,10 +480,17 @@ public class FinallyProcessor {
-     // so remove dummy exit
+@@ -453,9 +453,16 @@ public class FinallyProcessor {
+     // `throw` in the `try` body will point directly to the dummy exit, so remove it
      startBlocks.remove(graph.getLast());
      startBlocks.removeAll(tryBlocks);
 +    List<BasicBlock> starts = new ArrayList<>(startBlocks);
@@ -218,34 +218,28 @@ index 13d747a5ec6b961763f70b9174efeaf976336dbc..ad41b185d8c830f26b4f598a6568b327
 +      }
 +    });
  
-     List<Area> lstAreas = new ArrayList<>();
- 
+     List<Area> areas = new ArrayList<>();
 -    for (BasicBlock start : startBlocks) {
 +    for (BasicBlock start : starts) {
- 
-       Area arr = compareSubgraphsEx(graph, start, catchBlocks, first, finallytype, mapLast, skippedFirst);
+       Area arr = compareSubGraphsEx(graph, start, catchBlocks, first, finallyType, mapLast, skippedFirst);
        if (arr == null) {
-@@ -506,8 +513,17 @@ public class FinallyProcessor {
-     //			DotExporter.toDotFile(graph, new File("c:\\Temp\\fern5.dot"), true);
-     //		} catch(Exception ex){ex.printStackTrace();}
+         return false;
+@@ -468,8 +475,12 @@ public class FinallyProcessor {
+       deleteArea(graph, area);
+     }
  
 +    List<Entry<BasicBlock, Boolean>> lasts = new ArrayList<>(mapLast.entrySet());
 +    // We must sort here to prevent decompile differences deriving from hash maps.
-+    Collections.sort(lasts, new Comparator<Entry<BasicBlock, Boolean>>() {
-+      @Override
-+      public int compare(Entry<BasicBlock, Boolean> o1, Entry<BasicBlock, Boolean> o2) {
-+        return o1.getKey().id - o2.getKey().id;
-+      }
-+    });
++    lasts.sort(Comparator.comparingInt(o -> o.getKey().id));
 +
-     // INFO: empty basic blocks may remain in the graph!
+     // INFO: Empty basic blocks may remain in the graph!
 -    for (Entry<BasicBlock, Boolean> entry : mapLast.entrySet()) {
 +    for (Entry<BasicBlock, Boolean> entry : lasts) {
        BasicBlock last = entry.getKey();
  
        if (entry.getValue()) {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/LabelHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/LabelHelper.java
-index fba6145dd11f851b2487c11ad2b529c94ef72c35..d7397455f8a67bb220e3236da77d0c4b14aeb1e5 100644
+index df41b33643bd48f0f5549efe0931eb489dac21c9..1416640aedb91596be42c94697c3f74a25c1229d 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/LabelHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/LabelHelper.java
 @@ -23,7 +23,7 @@ public final class LabelHelper {
@@ -338,43 +332,42 @@ index 82ae0a25a20d2727f611d359e699d6666d1e0ae4..a86f0d2887c6c19cb1d911ec43830eb6
  
      return res;
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
-index a7033f507fd9667d773977803718c08810f0d750..3edae784f56848a5697879cfef9e05130ee38d34 100644
+index caa160fdc4ff5954b0976b11d81177278ae79ab6..e6363319573d157f5878dfdd93f8e60b44facb64 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
-@@ -219,7 +219,7 @@ public class ConstExprent extends Exprent {
+@@ -216,7 +216,7 @@ public class ConstExprent extends Exprent {
          else if (floatVal == Float.NEGATIVE_INFINITY) {
-           return new TextBuffer("-1.0F / 0.0F");
+           yield new TextBuffer("-1.0F / 0.0F");
          }
--        return new TextBuffer(value.toString()).append('F');
-+        return new TextBuffer(trimZeros(value.toString())).append('F');
- 
-       case CodeConstants.TYPE_DOUBLE:
+-        yield new TextBuffer(value.toString()).append('F');
++        yield new TextBuffer(trimZeros(value.toString())).append('F');
+       }
+       case CodeConstants.TYPE_DOUBLE -> {
          double doubleVal = (Double)value;
-@@ -250,15 +250,15 @@ public class ConstExprent extends Exprent {
+@@ -247,15 +247,15 @@ public class ConstExprent extends Exprent {
            }
          }
          else if (Double.isNaN(doubleVal)) {
--          return new TextBuffer("0.0 / 0.0");
-+          return new TextBuffer("0.0D / 0.0D");
+-          yield new TextBuffer("0.0 / 0.0");
++          yield new TextBuffer("0.0D / 0.0D");
          }
          else if (doubleVal == Double.POSITIVE_INFINITY) {
--          return new TextBuffer("1.0 / 0.0");
-+          return new TextBuffer("1.0D / 0.0D");
+-          yield new TextBuffer("1.0 / 0.0");
++          yield new TextBuffer("1.0D / 0.0D");
          }
          else if (doubleVal == Double.NEGATIVE_INFINITY) {
--          return new TextBuffer("-1.0 / 0.0");
-+          return new TextBuffer("-1.0D / 0.0D");
+-          yield new TextBuffer("-1.0 / 0.0");
++          yield new TextBuffer("-1.0D / 0.0D");
          }
--        return new TextBuffer(value.toString());
-+        return new TextBuffer(trimZeros(value.toString())).append('D');
- 
-       case CodeConstants.TYPE_NULL:
-         return new TextBuffer("null");
-@@ -276,6 +276,18 @@ public class ConstExprent extends Exprent {
- 
-     throw new RuntimeException("invalid constant type: " + constType);
+-        yield new TextBuffer(value.toString());
++        yield new TextBuffer(trimZeros(value.toString())).append('D');
+       }
+       case CodeConstants.TYPE_NULL -> new TextBuffer("null");
+       case CodeConstants.TYPE_OBJECT -> {
+@@ -273,6 +273,18 @@ public class ConstExprent extends Exprent {
+     };
    }
-+  
+ 
 +  // Different JVM implementations/version display Floats and Doubles with different number of trailing zeros.
 +  // This trims them all down to only the necessary amount.
 +  private static String trimZeros(String value) {
@@ -386,9 +379,10 @@ index a7033f507fd9667d773977803718c08810f0d750..3edae784f56848a5697879cfef9e0513
 +        i++;
 +      return value.substring(0, i + 1);
 +  }
- 
++
    private boolean inConstantVariable(String classSignature, String variableName) {
      ClassesProcessor.ClassNode node = (ClassesProcessor.ClassNode)DecompilerContext.getProperty(DecompilerContext.CURRENT_CLASS_NODE);
+     return node.classStruct.qualifiedName.equals(classSignature) &&
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
 index cc1f537e71af0748b7b97d7d8489198e2a677cc9..9b1b3de632a63bbba1f5f7a99d5f75bf537bd171 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/Exprent.java
@@ -445,7 +439,7 @@ index cc1f537e71af0748b7b97d7d8489198e2a677cc9..9b1b3de632a63bbba1f5f7a99d5f75bf
    // IMatchable implementation
    // *****************************************************************************
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java
-index 53afa148cf8ae11ceeacf454673a1963d4892212..a1f931b79adb35660ee0f29b1d522214384a044f 100644
+index 3991c5131e1b49cd7ee25626aa64ad3999766ce5..70b053d4138127c772f72eca7a54a1b8b3098cbf 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java
 @@ -22,6 +22,7 @@ import org.jetbrains.java.decompiler.util.SFormsFastMapDirect;
@@ -466,7 +460,7 @@ index 53afa148cf8ae11ceeacf454673a1963d4892212..a1f931b79adb35660ee0f29b1d522214
        setInit.add(i);
      }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java
-index c6287d302d83548e19f51260e1e984dc991e7f86..80d6d34d3329f831e8add4a0617b8e8bf8a86006 100644
+index 4d76ee298513f0989eadc2866d7a9d1f229612ef..8cd9f1de252412494f36a847167a9b74a7dd7625 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java
 @@ -68,7 +68,7 @@ public class SSAUConstructorSparseEx {
@@ -524,10 +518,10 @@ index 133d87f45ab3b057e78589a53529821e5a6a6dea..119949c8bd35082b95cbfde2b185aa2d
      }
    }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java
-index 0bdf9048e55b5d8873959ce3146b913805406fab..f9ffa3a3279fd8c3639489260a0dc4a01950c1a2 100644
+index 244898d5845029fb28126bd0c0365eec1c06f657..472faf9ad843f4d4bafdc2cf7753b67d8c34bddc 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java
-@@ -277,7 +277,10 @@ public class VarVersionsProcessor {
+@@ -245,7 +245,10 @@ public class VarVersionsProcessor {
      Map<Integer, Integer> mapOriginalVarIndices = new HashMap<>();
  
      // map var-version pairs on new var indexes

--- a/FernFlower-Patches/0005-Convert-Exprent.bytecode-to-a-BitMap.patch
+++ b/FernFlower-Patches/0005-Convert-Exprent.bytecode-to-a-BitMap.patch
@@ -141,7 +141,7 @@ index c6a23b3277c3a93be621d6686b1554d51be01c9b..32ca965883f26cd8944bfb5e838d5cf5
      }
    }
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-index bc116db0c8ad1b1312f220b9b9e22c5d7cdddad8..b274560fadc6911d272c5c9358d1cdf7eb808357 100644
+index 09eb2ca3b49093d291aaa4fc8bb769316d5a62ac..8126a50cf043593c0a041ea8942971f12cf4f090 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 @@ -533,7 +533,7 @@ public class NestedClassProcessor {
@@ -163,7 +163,7 @@ index bc116db0c8ad1b1312f220b9b9e22c5d7cdddad8..b274560fadc6911d272c5c9358d1cdf7
              }
  
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/ConcatenationHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/ConcatenationHelper.java
-index 228a7b835307d950e030fe16bcb2e8a41c0fafb3..f1f3e7c7e903dd0571c2a18f1ed976999cff99da 100644
+index c78b5ea78197f3c18ffb99caf5bd0e6bb49469f2..d85dead7cab48a9f551cb1226ef952807a067ec8 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/ConcatenationHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ConcatenationHelper.java
 @@ -11,8 +11,8 @@ import org.jetbrains.java.decompiler.struct.gen.VarType;
@@ -176,7 +176,7 @@ index 228a7b835307d950e030fe16bcb2e8a41c0fafb3..f1f3e7c7e903dd0571c2a18f1ed97699
  
  public final class ConcatenationHelper {
  
-@@ -124,7 +124,7 @@ public final class ConcatenationHelper {
+@@ -125,7 +125,7 @@ public final class ConcatenationHelper {
      return createConcatExprent(lstOperands, expr.bytecode);
    }
  
@@ -186,7 +186,7 @@ index 228a7b835307d950e030fe16bcb2e8a41c0fafb3..f1f3e7c7e903dd0571c2a18f1ed97699
      Exprent func = lstOperands.get(0);
  
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
-index 6216a80e20d1a1bbb80c5b343b743832e0421dbc..0a437f1a324bcae5d86e60e990f35bc84ed277ce 100644
+index 6783382a1c199ba33df1af3477d3cf5e13230b09..3b10e5b29ff9e344815592e533b6b04891fe294c 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 @@ -266,7 +266,15 @@ public class ExprProcessor implements CodeConstants {
@@ -237,55 +237,61 @@ index 6216a80e20d1a1bbb80c5b343b743832e0421dbc..0a437f1a324bcae5d86e60e990f35bc8
            List<Exprent> operands = Arrays.asList(varExpr.copy(), new ConstExprent(VarType.VARTYPE_INT, Math.abs(instr.operand(1)), null));
            exprList.add(new AssignmentExprent(varExpr, new FunctionExprent(type, operands, offsets), offsets));
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java
-index ad41b185d8c830f26b4f598a6568b3272a11d86f..362e11b75c647920c328b16cb9f2778537fca275 100644
+index 878c12b061975d4060b8a44abffa3d60d35d17a3..b240e83853cff82f917a7fc9f80dab661dd7ceb9 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java
-@@ -315,6 +315,7 @@ public class FinallyProcessor {
+@@ -304,6 +304,7 @@ public class FinallyProcessor {
        }
      }
  
-+    final int store_length = var <= 3 ? 1 : var <= 128 ? 2 : 4;
++    final int storeLength = var <= 3 ? 1 : var <= 128 ? 2 : 4;
      // disable semaphore at statement exit points
      for (BasicBlock block : setTry) {
-       List<BasicBlock> lstSucc = block.getSuccessors();
-@@ -324,8 +325,8 @@ public class FinallyProcessor {
+       for (BasicBlock dest : block.getSuccessors()) {
+@@ -311,8 +312,8 @@ public class FinallyProcessor {
          if (dest != graph.getLast() && !setCopy.contains(dest)) {
            // disable semaphore
            SimpleInstructionSequence seq = new SimpleInstructionSequence();
--          seq.addInstruction(Instruction.create(CodeConstants.opc_bipush, false, CodeConstants.GROUP_GENERAL, bytecode_version, new int[]{0}), -1);
--          seq.addInstruction(Instruction.create(CodeConstants.opc_istore, false, CodeConstants.GROUP_GENERAL, bytecode_version, new int[]{var}), -1);
-+          seq.addInstruction(Instruction.create(CodeConstants.opc_bipush, false, CodeConstants.GROUP_GENERAL, bytecode_version, new int[]{0}, 1), -1);
-+          seq.addInstruction(Instruction.create(CodeConstants.opc_istore, false, CodeConstants.GROUP_GENERAL, bytecode_version, new int[]{var}, store_length), -1);
+-          seq.addInstruction(Instruction.create(CodeConstants.opc_bipush, false, CodeConstants.GROUP_GENERAL, bytecodeVersion, new int[]{0}), -1);
+-          seq.addInstruction(Instruction.create(CodeConstants.opc_istore, false, CodeConstants.GROUP_GENERAL, bytecodeVersion, new int[]{var}), -1);
++          seq.addInstruction(Instruction.create(CodeConstants.opc_bipush, false, CodeConstants.GROUP_GENERAL, bytecodeVersion, new int[]{0}, 1), -1);
++          seq.addInstruction(Instruction.create(CodeConstants.opc_istore, false, CodeConstants.GROUP_GENERAL, bytecodeVersion, new int[]{var}, storeLength), -1);
  
            // build a separate block
            BasicBlock newBlock = new BasicBlock(++graph.last_id, seq);
-@@ -353,8 +354,8 @@ public class FinallyProcessor {
+@@ -331,11 +332,11 @@ public class FinallyProcessor {
+     }
  
      // enable semaphore at the statement entrance
-     SimpleInstructionSequence seq = new SimpleInstructionSequence();
--    seq.addInstruction(Instruction.create(CodeConstants.opc_bipush, false, CodeConstants.GROUP_GENERAL, bytecode_version, new int[]{1}), -1);
--    seq.addInstruction(Instruction.create(CodeConstants.opc_istore, false, CodeConstants.GROUP_GENERAL, bytecode_version, new int[]{var}), -1);
-+    seq.addInstruction(Instruction.create(CodeConstants.opc_bipush, false, CodeConstants.GROUP_GENERAL, bytecode_version, new int[]{1}, 1), -1);
-+    seq.addInstruction(Instruction.create(CodeConstants.opc_istore, false, CodeConstants.GROUP_GENERAL, bytecode_version, new int[]{var}, store_length), -1);
- 
-     BasicBlock newHead = new BasicBlock(++graph.last_id, seq);
- 
-@@ -362,8 +363,8 @@ public class FinallyProcessor {
+-    BasicBlock newHead = createHeadBlock(graph, 1, var, bytecodeVersion);
++    BasicBlock newHead = createHeadBlock(graph, 1, var, bytecodeVersion, storeLength);
+     insertBlockBefore(graph, head, newHead);
  
      // initialize semaphore with false
-     seq = new SimpleInstructionSequence();
--    seq.addInstruction(Instruction.create(CodeConstants.opc_bipush, false, CodeConstants.GROUP_GENERAL, bytecode_version, new int[]{0}), -1);
--    seq.addInstruction(Instruction.create(CodeConstants.opc_istore, false, CodeConstants.GROUP_GENERAL, bytecode_version, new int[]{var}), -1);
-+    seq.addInstruction(Instruction.create(CodeConstants.opc_bipush, false, CodeConstants.GROUP_GENERAL, bytecode_version, new int[]{0}, 1), -1);
-+    seq.addInstruction(Instruction.create(CodeConstants.opc_istore, false, CodeConstants.GROUP_GENERAL, bytecode_version, new int[]{var}, store_length), -1);
+-    BasicBlock newHeadInit = createHeadBlock(graph, 0, var, bytecodeVersion);
++    BasicBlock newHeadInit = createHeadBlock(graph, 0, var, bytecodeVersion, storeLength);
+     insertBlockBefore(graph, newHead, newHeadInit);
  
-     BasicBlock newHeadInit = new BasicBlock(++graph.last_id, seq);
+     setCopy.add(newHead);
+@@ -352,10 +353,10 @@ public class FinallyProcessor {
+   }
+ 
+   @NotNull
+-  private static BasicBlock createHeadBlock(ControlFlowGraph graph, int value, int var, int bytecodeVersion) {
++  private static BasicBlock createHeadBlock(ControlFlowGraph graph, int value, int var, int bytecodeVersion, int storeLength) {
+     SimpleInstructionSequence seq = new SimpleInstructionSequence();
+-    seq.addInstruction(Instruction.create(CodeConstants.opc_bipush, false, CodeConstants.GROUP_GENERAL, bytecodeVersion, new int[]{value}), -1);
+-    seq.addInstruction(Instruction.create(CodeConstants.opc_istore, false, CodeConstants.GROUP_GENERAL, bytecodeVersion, new int[]{var}), -1);
++    seq.addInstruction(Instruction.create(CodeConstants.opc_bipush, false, CodeConstants.GROUP_GENERAL, bytecodeVersion, new int[]{value}, 1), -1);
++    seq.addInstruction(Instruction.create(CodeConstants.opc_istore, false, CodeConstants.GROUP_GENERAL, bytecodeVersion, new int[]{var}, storeLength), -1);
+     return new BasicBlock(++graph.last_id, seq);
+   }
  
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/MergeHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/MergeHelper.java
-index 545a7766f6ed6dca92f29f6317503ae8852bb9e0..ba131586bc96dc3522a1db41814102d8bdf62c8c 100644
+index a5e7ccf98c61f2fb585054c48fd967eeb4e70a49..bbd7bd0cb42057638e765c5bb675b8d30b9b6796 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/MergeHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/MergeHelper.java
-@@ -94,6 +94,12 @@ public final class MergeHelper {
+@@ -92,6 +92,12 @@ public final class MergeHelper {
            if (ifedge.getType() == EdgeType.BREAK) {
              ifexpr.negateIf();
            }
@@ -298,7 +304,7 @@ index 545a7766f6ed6dca92f29f6317503ae8852bb9e0..ba131586bc96dc3522a1db41814102d8
            stat.setConditionExprent(ifexpr.getCondition());
            lastif.getFirst().removeSuccessor(ifedge);
            lastif.removeSuccessor(elseedge);
-@@ -148,6 +154,12 @@ public final class MergeHelper {
+@@ -146,6 +152,12 @@ public final class MergeHelper {
                // negate condition (while header)
                IfExprent ifexpr = (IfExprent)firstif.getHeadexprent().copy();
                ifexpr.negateIf();
@@ -311,7 +317,7 @@ index 545a7766f6ed6dca92f29f6317503ae8852bb9e0..ba131586bc96dc3522a1db41814102d8
                stat.setConditionExprent(ifexpr.getCondition());
  
                // remove edges
-@@ -186,7 +198,12 @@ public final class MergeHelper {
+@@ -184,7 +196,12 @@ public final class MergeHelper {
                stat.setLoopType(LoopType.WHILE);
  
                // no need to negate the while condition
@@ -325,7 +331,7 @@ index 545a7766f6ed6dca92f29f6317503ae8852bb9e0..ba131586bc96dc3522a1db41814102d8
  
                // remove edges
                StatEdge ifedge = firstif.getIfEdge();
-@@ -338,9 +355,17 @@ public final class MergeHelper {
+@@ -336,9 +353,17 @@ public final class MergeHelper {
  
        stat.setLoopType(LoopType.FOR);
        if (hasinit) {
@@ -346,10 +352,10 @@ index 545a7766f6ed6dca92f29f6317503ae8852bb9e0..ba131586bc96dc3522a1db41814102d8
  
      if (lastData.getExprents().isEmpty()) {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
-index 82d12b891da94538ca844e4964e71908ed146a9b..1af6fc576e1528f6c06b0e493bd912b9b37edff6 100644
+index 7a2376d0c0a2d4c18ca3ce8a4f35c0ae75bed962..eb96762fa2174047a3f9dcecfb8c57bf4721c11f 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
-@@ -640,7 +640,7 @@ public class SimplifyExprentsHelper {
+@@ -641,7 +641,7 @@ public class SimplifyExprentsHelper {
      if (stat.type == StatementType.IF && stat.getExprents() == null) {
        IfStatement statement = (IfStatement)stat;
        Exprent ifHeadExpr = statement.getHeadexprent();
@@ -474,10 +480,10 @@ index 13faa7fd16307e584d00bdf9f990e7cc7245babd..6cc60fd5314369cef21bd56c12e2af8e
    // getter and setter methods
    // *****************************************************************************
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
-index 3edae784f56848a5697879cfef9e05130ee38d34..08903784da127ef326d115d8af8287cc8f65c2ca 100644
+index e6363319573d157f5878dfdd93f8e60b44facb64..29cb0533a353084f83e19b565db6c0e66ab418c1 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
-@@ -51,20 +51,20 @@ public class ConstExprent extends Exprent {
+@@ -52,20 +52,20 @@ public class ConstExprent extends Exprent {
    private final Object value;
    private final boolean boolPermitted;
  
@@ -502,7 +508,7 @@ index 3edae784f56848a5697879cfef9e05130ee38d34..08903784da127ef326d115d8af8287cc
      super(EXPRENT_CONST);
      this.constType = constType;
      this.value = value;
-@@ -453,6 +453,11 @@ public class ConstExprent extends Exprent {
+@@ -423,6 +423,11 @@ public class ConstExprent extends Exprent {
      return boolPermitted;
    }
  
@@ -664,7 +670,7 @@ index ec3a8668a94c7da89091a09a3002fd14346cc684..11669fe44ea78ab7322b82c844c8b220
    // IMatchable implementation
    // *****************************************************************************
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
-index 8bdade633e911e8cabe2ef7deacc56da3508fc78..f2efd6b594b700b20814c620328753a66aea22a4 100644
+index a4ee85ba5deafed6f9618f9a8b93c5f554878a1d..ac2b3a50e65c46ff998173335d505cdfc8a27b21 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
 @@ -183,7 +183,7 @@ public class FunctionExprent extends Exprent {
@@ -694,7 +700,7 @@ index 8bdade633e911e8cabe2ef7deacc56da3508fc78..f2efd6b594b700b20814c620328753a6
      this(funcType, new ArrayList<>(1), bytecodeOffsets);
      lstOperands.add(operand);
    }
-@@ -598,6 +598,12 @@ public class FunctionExprent extends Exprent {
+@@ -566,6 +566,12 @@ public class FunctionExprent extends Exprent {
      this.implicitType = implicitType;
    }
  
@@ -754,7 +760,7 @@ index d5a743fd1a4e068616a82e8f23d119a8ba2b1d59..18d2c40d9af0e822004f4baaa3c6b567
 +  }
 +}
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 4e6eb0cb06362df98589932c67a22c3b6741fc27..0c55cfba952a92ffcefe28f12109bd40f56eaf42 100644
+index d4ce3d808e9802b9f25a0a07a821f18fe3fed3f4..d94561755621c6517976a763f8b9a0a4e49528e2 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -65,7 +65,7 @@ public class InvocationExprent extends Exprent {
@@ -766,7 +772,7 @@ index 4e6eb0cb06362df98589932c67a22c3b6741fc27..0c55cfba952a92ffcefe28f12109bd40
      this();
  
      name = cn.elementname;
-@@ -622,6 +622,13 @@ public class InvocationExprent extends Exprent {
+@@ -603,6 +603,13 @@ public class InvocationExprent extends Exprent {
      return bootstrapArguments;
    }
  
@@ -1031,7 +1037,7 @@ index b0cca026cbe68b2741a6ca01a50c6a46be128bc8..b1c9165f9a4a2135128d22a3971303cc
    }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/IfStatement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/IfStatement.java
-index 0d0cb081dcbf15a11c42ac5d586459b8ac35d384..6420052a9215a0ab826a4d955e8d3d662f5ba563 100644
+index 300314e0197e3914f8365c4acab064fec4e78445..611f501b4c94d15d557edf991eb84cd9eb7d4173 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/IfStatement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/IfStatement.java
 @@ -12,6 +12,7 @@ import org.jetbrains.java.decompiler.struct.match.IMatchable;
@@ -1081,7 +1087,7 @@ index 0946904c8610c2d21de597361e0adf377e88a675..163efe83fdfd94ccb945509fe4593f84
 +  }
 +}
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java
-index 272601270ea32fb5ccc4a822cd9d1b959bae9c35..9d5fcfd4c907e69c52965517dfe69e3a2f82c5df 100644
+index 224d3636f7c9d502cc65c122f542324c1ba7028a..9498f3c548d18ead3bcbc076222bd5ace82b8275 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java
 @@ -19,6 +19,7 @@ import org.jetbrains.java.decompiler.struct.match.IMatchable;
@@ -1164,10 +1170,10 @@ index 119949c8bd35082b95cbfde2b185aa2d23034224..18e40f99948e63d8e1d6136b4d1d5ead
      Map<StatEdge, Integer> edgeIndicesMapping = new HashMap<>();
      List<StatEdge> firstSuccessors = first.getSuccessorEdges(EdgeType.DIRECT_ALL);
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructMethod.java b/src/org/jetbrains/java/decompiler/struct/StructMethod.java
-index b0b41808499ab657c8ae799dd253d9410f1b001b..f58ee71d23ded6d1fe495b5872bd7965b4c6e61e 100644
+index b908ed26c27a60dd01f056b736490ebdf25dc125..470965603db2b5ffda4c2776549fcfbba5e7ee72 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructMethod.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructMethod.java
-@@ -299,11 +299,11 @@ public class StructMethod extends StructMember {
+@@ -253,11 +253,11 @@ public class StructMethod extends StructMember {
          }
        }
  

--- a/FernFlower-Patches/0006-Make-methods-hold-a-reference-to-their-declaring-cla.patch
+++ b/FernFlower-Patches/0006-Make-methods-hold-a-reference-to-their-declaring-cla.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Make methods hold a reference to their declaring class
 This is used in several later commits.
 
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructMethod.java b/src/org/jetbrains/java/decompiler/struct/StructMethod.java
-index f58ee71d23ded6d1fe495b5872bd7965b4c6e61e..4e5c7b4da350020f4f69da956eda4384b86df2aa 100644
+index 470965603db2b5ffda4c2776549fcfbba5e7ee72..0a7e5ba44d82f1923dadd9f79627d91f82b1014c 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructMethod.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructMethod.java
 @@ -41,7 +41,7 @@ public class StructMethod extends StructMember {
@@ -43,7 +43,7 @@ index f58ee71d23ded6d1fe495b5872bd7965b4c6e61e..4e5c7b4da350020f4f69da956eda4384
    }
  
    public void expandData(StructClass classStruct) throws IOException {
-@@ -378,4 +381,8 @@ public class StructMethod extends StructMember {
+@@ -332,4 +335,8 @@ public class StructMethod extends StructMember {
    public String toString() {
      return name;
    }

--- a/FernFlower-Patches/0007-Reintroduce-DotExporter-for-debugging-purposes.patch
+++ b/FernFlower-Patches/0007-Reintroduce-DotExporter-for-debugging-purposes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Reintroduce DotExporter for debugging purposes
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-index b274560fadc6911d272c5c9358d1cdf7eb808357..575759dabaea87058a5a615c05cb91932cb5873b 100644
+index 8126a50cf043593c0a041ea8942971f12cf4f090..216db28b337c729ea839415bdccc3b48a1219709 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 @@ -24,6 +24,7 @@ import org.jetbrains.java.decompiler.struct.attr.StructEnclosingMethodAttribute;
@@ -25,7 +25,7 @@ index b274560fadc6911d272c5c9358d1cdf7eb808357..575759dabaea87058a5a615c05cb9193
              List<Exprent> lst = exprent.getAllExprents(true);
              lst.add(exprent);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java
-index a1f931b79adb35660ee0f29b1d522214384a044f..3917ae87c6d147e808768ffc717cc24b08b3f433 100644
+index 70b053d4138127c772f72eca7a54a1b8b3098cbf..82e8870671180ade3be93bbb54920b0321a9912b 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java
 @@ -15,6 +15,7 @@ import org.jetbrains.java.decompiler.modules.decompiler.stats.Statement.Statemen
@@ -73,7 +73,7 @@ index a1f931b79adb35660ee0f29b1d522214384a044f..3917ae87c6d147e808768ffc717cc24b
      for (DirectNode node : dgraph.nodes) {
  
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java
-index 80d6d34d3329f831e8add4a0617b8e8bf8a86006..d233d671b4d1bdeb14327bb155310d3b792b932d 100644
+index 8cd9f1de252412494f36a847167a9b74a7dd7625..5e1e323a6e2043d776c513e800056be200ab2971 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java
 @@ -12,6 +12,7 @@ import org.jetbrains.java.decompiler.modules.decompiler.vars.VarVersionPair;
@@ -126,7 +126,7 @@ index 80d6d34d3329f831e8add4a0617b8e8bf8a86006..d233d671b4d1bdeb14327bb155310d3b
      for (DirectNode node : dgraph.nodes) {
  
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java
-index f9ffa3a3279fd8c3639489260a0dc4a01950c1a2..7a88cb7bc4744aac96bdaffc0ab95652d1937d25 100644
+index 472faf9ad843f4d4bafdc2cf7753b67d8c34bddc..d6a9c2a29c73d778eb383d718094b7548d14d2f3 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java
 @@ -14,6 +14,7 @@ import org.jetbrains.java.decompiler.modules.decompiler.stats.RootStatement;

--- a/FernFlower-Patches/0008-LVT-Fixes-and-Support-for-Enhanced-For-loop-detectio.patch
+++ b/FernFlower-Patches/0008-LVT-Fixes-and-Support-for-Enhanced-For-loop-detectio.patch
@@ -44,7 +44,7 @@ index ec59ac3c399dd1609663bc9444a098285b5dc48a..33906d3a433e4421bbf41c6aed5ff566
      }
    }
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
-index c122a3f7f937d01dbd99aefb674ad9f1d6f95d10..81fed9eaea4d73a99e87545d15171033f98db3b1 100644
+index 80f024eb8e069cc4d208a9b79dbc7edf67161ec7..fa4b5ed56fa58f2d864ea3acd758a36fa8e23e7a 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
 @@ -11,7 +11,13 @@ import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
@@ -158,7 +158,7 @@ index c122a3f7f937d01dbd99aefb674ad9f1d6f95d10..81fed9eaea4d73a99e87545d15171033
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-index 575759dabaea87058a5a615c05cb91932cb5873b..09a5887befc045f8faef7a1c53a71387ea8ff890 100644
+index 216db28b337c729ea839415bdccc3b48a1219709..5d0ec234807e0fa186ae88e7f74059710a47bd46 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 @@ -22,6 +22,7 @@ import org.jetbrains.java.decompiler.struct.StructField;
@@ -374,7 +374,7 @@ index 575759dabaea87058a5a615c05cb91932cb5873b..09a5887befc045f8faef7a1c53a71387
                }
              }
  
-@@ -922,4 +970,41 @@ public class NestedClassProcessor {
+@@ -913,4 +961,41 @@ public class NestedClassProcessor {
        return fieldKey.hashCode() + varPair.hashCode();
      }
    }
@@ -419,7 +419,7 @@ index 575759dabaea87058a5a615c05cb91932cb5873b..09a5887befc045f8faef7a1c53a71387
 +  }
 +}
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java
-index 86cac9e08f0f0d3ebd43353b64eba9560279de55..038dac26540f41092afd00936954670510e16df6 100644
+index 277e792a2856334970bafe0661582a8c8d09ad5a..ceffabcd6434f5504e7aaf89878abe7012cfcaa5 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/DomHelper.java
 @@ -12,6 +12,8 @@ import org.jetbrains.java.decompiler.modules.decompiler.decompose.FastExtendedPo
@@ -670,7 +670,7 @@ index c5ccfd1a659461646494c3796528767d0ba089c8..ef96a3f610c7fe1af746aa1d8663ba7a
  
        if (data != null && data.size() == 1) {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
-index 0a437f1a324bcae5d86e60e990f35bc84ed277ce..e160dc7f1bb3c8d1bdec0a1720035803f077e1e7 100644
+index 3b10e5b29ff9e344815592e533b6b04891fe294c..a242aa9e74698b14e20e27d655a3c8ae141ee2f5 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 @@ -315,7 +315,9 @@ public class ExprProcessor implements CodeConstants {
@@ -1016,7 +1016,7 @@ index 0000000000000000000000000000000000000000..04f0a2768d2a943475df28a17389407b
 +}
 \ No newline at end of file
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/MergeHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/MergeHelper.java
-index ba131586bc96dc3522a1db41814102d8bdf62c8c..1cd4898cc5499c44632b7d0f3e937041e3243269 100644
+index bbd7bd0cb42057638e765c5bb675b8d30b9b6796..9909e894e22fc8c19e05fae82b69db065b3be72d 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/MergeHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/MergeHelper.java
 @@ -5,8 +5,13 @@ import org.jetbrains.java.decompiler.code.cfg.BasicBlock;
@@ -1033,7 +1033,7 @@ index ba131586bc96dc3522a1db41814102d8bdf62c8c..1cd4898cc5499c44632b7d0f3e937041
  import org.jetbrains.java.decompiler.modules.decompiler.stats.*;
  import org.jetbrains.java.decompiler.modules.decompiler.stats.DoStatement.LoopType;
  import org.jetbrains.java.decompiler.modules.decompiler.stats.Statement.StatementType;
-@@ -47,17 +52,20 @@ public final class MergeHelper {
+@@ -47,15 +52,20 @@ public final class MergeHelper {
  
          // identify a while loop
          if (matchWhile(stat)) {
@@ -1047,18 +1047,18 @@ index ba131586bc96dc3522a1db41814102d8bdf62c8c..1cd4898cc5499c44632b7d0f3e937041
            // identify a do{}while loop
 -          matchDoWhile(stat);
 +          //matchDoWhile(stat);
-         }
- 
-         break;
-       case WHILE:
--        matchFor(stat);
++        }
++      }
++      case WHILE -> {
 +        if (!matchForEach(stat)) {
 +          matchFor(stat);
-+        }
+         }
+       }
+-      case WHILE -> matchFor(stat);
      }
  
      return (stat.getLoopType() != oldLoop);
-@@ -147,13 +155,14 @@ public final class MergeHelper {
+@@ -145,13 +155,14 @@ public final class MergeHelper {
          if (firstif.iftype == IfStatement.IFTYPE_IF) {
            if (firstif.getIfstat() == null) {
              StatEdge ifedge = firstif.getIfEdge();
@@ -1075,7 +1075,7 @@ index ba131586bc96dc3522a1db41814102d8bdf62c8c..1cd4898cc5499c44632b7d0f3e937041
  
                if (stat.getConditionExprent() != null) {
                  ifexpr.getCondition().addBytecodeOffsets(stat.getConditionExprent().bytecode);
-@@ -191,7 +200,7 @@ public final class MergeHelper {
+@@ -189,7 +200,7 @@ public final class MergeHelper {
                return true;
              }
            }
@@ -1084,7 +1084,7 @@ index ba131586bc96dc3522a1db41814102d8bdf62c8c..1cd4898cc5499c44632b7d0f3e937041
              StatEdge elseedge = firstif.getAllSuccessorEdges().get(0);
              if (isDirectPath(stat, elseedge.getDestination())) {
                // exit condition identified
-@@ -245,7 +254,7 @@ public final class MergeHelper {
+@@ -243,7 +254,7 @@ public final class MergeHelper {
  
                return true;
              }
@@ -1093,7 +1093,7 @@ index ba131586bc96dc3522a1db41814102d8bdf62c8c..1cd4898cc5499c44632b7d0f3e937041
          }
        }
      }
-@@ -330,6 +339,8 @@ public final class MergeHelper {
+@@ -328,6 +339,8 @@ public final class MergeHelper {
          }
          else {
            preData = current.getNeighbours(EdgeType.REGULAR, EdgeDirection.BACKWARD).get(0);
@@ -1102,7 +1102,7 @@ index ba131586bc96dc3522a1db41814102d8bdf62c8c..1cd4898cc5499c44632b7d0f3e937041
            preData = getLastDirectData(preData);
            if (preData != null && !preData.getExprents().isEmpty()) {
              initDoExprent = preData.getExprents().get(preData.getExprents().size() - 1);
-@@ -368,12 +379,16 @@ public final class MergeHelper {
+@@ -366,12 +379,16 @@ public final class MergeHelper {
        stat.setIncExprent(exp);
      }
  
@@ -1123,7 +1123,7 @@ index ba131586bc96dc3522a1db41814102d8bdf62c8c..1cd4898cc5499c44632b7d0f3e937041
      }
    }
  
-@@ -406,14 +421,346 @@ public final class MergeHelper {
+@@ -404,14 +421,346 @@ public final class MergeHelper {
        return stat;
      }
  
@@ -1174,8 +1174,8 @@ index ba131586bc96dc3522a1db41814102d8bdf62c8c..1cd4898cc5499c44632b7d0f3e937041
 +            }
 +          }
 +          break;
-+        }
-+      }
+         }
+       }
 +      else {
 +        break;
 +      }
@@ -1334,7 +1334,7 @@ index ba131586bc96dc3522a1db41814102d8bdf62c8c..1cd4898cc5499c44632b7d0f3e937041
 +        FunctionExprent fun = (FunctionExprent)exp;
 +        if (fun.getFuncType() == FunctionExprent.FUNCTION_BOOL_NOT) {
 +          exp = fun.getLstOperands().get(0);
-         }
++        }
 +        else if (fun.getFuncType() == FunctionExprent.FUNCTION_EQ ||
 +                 fun.getFuncType() == FunctionExprent.FUNCTION_NE) {
 +          return fun.getLstOperands().get(0);
@@ -1368,8 +1368,8 @@ index ba131586bc96dc3522a1db41814102d8bdf62c8c..1cd4898cc5499c44632b7d0f3e937041
 +      FunctionExprent func = (FunctionExprent)exp;
 +      if (func.getFuncType() == FunctionExprent.FUNCTION_CAST) {
 +        return getUncast(func.getLstOperands().get(0));
-       }
-     }
++      }
++    }
 +    return exp;
 +  }
 +
@@ -1377,7 +1377,7 @@ index ba131586bc96dc3522a1db41814102d8bdf62c8c..1cd4898cc5499c44632b7d0f3e937041
 +    exp = getUncast(exp);
 +    if (exp.type == Exprent.EXPRENT_INVOCATION) {
 +      return (InvocationExprent) exp;
-+    }
+     }
      return null;
    }
 -}
@@ -1748,10 +1748,10 @@ index 0000000000000000000000000000000000000000..9123d92be14259e0117a0bb7b06a3d09
 +}
 \ No newline at end of file
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 0c55cfba952a92ffcefe28f12109bd40f56eaf42..8356b5b643139d6c8346070d826877c724e4f8a2 100644
+index d94561755621c6517976a763f8b9a0a4e49528e2..8d2ce0f8f4d4368f87ed596e4e76442ff97fed19 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-@@ -462,7 +462,7 @@ public class InvocationExprent extends Exprent {
+@@ -443,7 +443,7 @@ public class InvocationExprent extends Exprent {
      "charValue", "java/lang/Character"
    );
  
@@ -1760,7 +1760,7 @@ index 0c55cfba952a92ffcefe28f12109bd40f56eaf42..8356b5b643139d6c8346070d826877c7
      return !isStatic && parameters.size() == 0 && className.equals(UNBOXING_METHODS.get(name));
    }
  
-@@ -663,4 +663,4 @@ public class InvocationExprent extends Exprent {
+@@ -644,4 +644,4 @@ public class InvocationExprent extends Exprent {
  
      return true;
    }
@@ -2004,18 +2004,19 @@ index a20acdff7d3ef1415fe6c90d05b92a90cfaf0073..6f21cd6df597613099861d874bb320ef
      // 0 - success, do nothing
      // 1 - cancel iteration
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/FlattenStatementsHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/FlattenStatementsHelper.java
-index c05f6eb84fb8d09d8842851c0c2725dff527449b..a3ef4b8b5fdb820c520a21fcd727e08e9dfe2510 100644
+index 592860d16b742ea70f85d2fe0270e2cbf5830f42..ccb7b3d9d0b38a5be9a6c9c727b4800bf815e715 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/FlattenStatementsHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/FlattenStatementsHelper.java
-@@ -205,6 +205,7 @@ public class FlattenStatementsHelper {
+@@ -201,7 +201,7 @@ public class FlattenStatementsHelper {
+                 }
                  sourcenode = node;
-                 break;
-               case FOR:
-+              case FOREACH:
+               }
+-              case FOR -> {
++              case FOR, FOREACH -> {
                  DirectNode nodeinit = new DirectNode(DirectNodeType.INIT, stat, stat.id + "_init");
                  if (dostat.getInitExprent() != null) {
                    nodeinit.exprents = dostat.getInitExprentList();
-@@ -212,7 +213,9 @@ public class FlattenStatementsHelper {
+@@ -209,7 +209,9 @@ public class FlattenStatementsHelper {
                  graph.nodes.putWithKey(nodeinit, nodeinit.id);
  
                  DirectNode nodecond = new DirectNode(DirectNodeType.CONDITION, stat, stat.id + "_cond");
@@ -2027,25 +2028,25 @@ index c05f6eb84fb8d09d8842851c0c2725dff527449b..a3ef4b8b5fdb820c520a21fcd727e08e
  
                  DirectNode nodeinc = new DirectNode(DirectNodeType.INCREMENT, stat, stat.id + "_inc");
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DoStatement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DoStatement.java
-index 2dc447272c2786a80f9638a91c95716484911fe2..0c64170a05d6675803b69284d8ee532e44212ee2 100644
+index 56f429ac8433cd5db3e5ea22ab4c3b0e8c7927f5..018d3fbdf53036db90b6c64e872098542133b630 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DoStatement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DoStatement.java
-@@ -103,6 +103,14 @@ public final class DoStatement extends Statement {
-         buf.append(ExprProcessor.jmpWrapper(first, indent + 1, false, tracer));
+@@ -105,6 +105,14 @@ public final class DoStatement extends Statement {
          buf.appendIndent(indent).append("}").appendLineSeparator();
          tracer.incrementCurrentSourceLine();
-+        break;
-+      case FOREACH:
+       }
++      case FOREACH -> {
 +        buf.appendIndent(indent).append("for(").append(initExprent.get(0).toJava(indent, tracer));
 +        buf.append(" : ").append(incExprent.get(0).toJava(indent, tracer)).append(") {").appendLineSeparator();
 +        tracer.incrementCurrentSourceLine();
 +        buf.append(ExprProcessor.jmpWrapper(first, indent + 1, true, tracer));
 +        buf.appendIndent(indent).append("}").appendLineSeparator();
 +        tracer.incrementCurrentSourceLine();
++      }
      }
      return buf;
    }
-@@ -117,6 +125,10 @@ public final class DoStatement extends Statement {
+@@ -119,6 +127,10 @@ public final class DoStatement extends Statement {
          }
        case WHILE:
          lst.add(getConditionExprent());
@@ -2056,7 +2057,7 @@ index 2dc447272c2786a80f9638a91c95716484911fe2..0c64170a05d6675803b69284d8ee532e
      }
      lst.add(first);
      switch (loopType) {
-@@ -195,6 +207,7 @@ public final class DoStatement extends Statement {
+@@ -194,6 +206,7 @@ public final class DoStatement extends Statement {
      DO,
      DO_WHILE,
      WHILE,
@@ -2066,7 +2067,7 @@ index 2dc447272c2786a80f9638a91c95716484911fe2..0c64170a05d6675803b69284d8ee532e
    }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java
-index 9d5fcfd4c907e69c52965517dfe69e3a2f82c5df..57475f98e56d87c8dbd7edc3cda7cf243f0b6b16 100644
+index 9498f3c548d18ead3bcbc076222bd5ace82b8275..e65af740228e237d3159cf4dd3398a9fe1d21199 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/Statement.java
 @@ -768,6 +768,14 @@ public abstract class Statement implements IMatchable {
@@ -2094,7 +2095,7 @@ index 9d5fcfd4c907e69c52965517dfe69e3a2f82c5df..57475f98e56d87c8dbd7edc3cda7cf24
  
    //TODO: Cleanup/cache?
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
-index 46e405dcb94da78180efa7a8e2374392590027db..b65a7ceb11c31ab892d8bd1f6e1a30fc78aa11ab 100644
+index 49729c1d27c1a1a42904949c25c0635f6a03a736..6f8a2619c728d168431673b14f53b94ba783cf2f 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
 @@ -4,18 +4,28 @@ package org.jetbrains.java.decompiler.modules.decompiler.vars;
@@ -2273,7 +2274,7 @@ index 46e405dcb94da78180efa7a8e2374392590027db..b65a7ceb11c31ab892d8bd1f6e1a30fc
    private Statement findFirstBlock(Statement stat, Integer varindex) {
  
      LinkedList<Statement> stack = new LinkedList<>();
-@@ -256,6 +331,7 @@ public class VarDefinitionHelper {
+@@ -250,6 +325,7 @@ public class VarDefinitionHelper {
            if (st.type == StatementType.DO) {
              DoStatement dost = (DoStatement)st;
              if (dost.getLoopType() != LoopType.FOR &&
@@ -2281,7 +2282,7 @@ index 46e405dcb94da78180efa7a8e2374392590027db..b65a7ceb11c31ab892d8bd1f6e1a30fc
                  dost.getLoopType() != LoopType.DO) {
                currVars.add(dost.getConditionExprent());
              }
-@@ -326,7 +402,7 @@ public class VarDefinitionHelper {
+@@ -320,7 +396,7 @@ public class VarDefinitionHelper {
      return res;
    }
  
@@ -2290,7 +2291,7 @@ index 46e405dcb94da78180efa7a8e2374392590027db..b65a7ceb11c31ab892d8bd1f6e1a30fc
      if (expr.type == Exprent.EXPRENT_ASSIGNMENT) {
        Exprent left = ((AssignmentExprent)expr).getLeft();
        if (left.type == Exprent.EXPRENT_VAR) {
-@@ -339,4 +415,660 @@ public class VarDefinitionHelper {
+@@ -333,4 +409,660 @@ public class VarDefinitionHelper {
      }
      return false;
    }
@@ -3118,7 +3119,7 @@ index 33c4c3efcf7d9b26737717a2445bffad0db5c4c0..559c96b54667b5b9a051039fdbb3643f
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarTypeProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarTypeProcessor.java
-index 8a73c2655aa12ecfd26df4e2f4eae17145f8f3e6..f57626ccb91231c5a79ed6f955bb0b4dd650776b 100644
+index ac06d30f079427a287b62f6851f008eac39b402c..293fdc6cba46ed47259c786c940488bb1d74fba9 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarTypeProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarTypeProcessor.java
 @@ -193,7 +193,12 @@ public class VarTypeProcessor {
@@ -3136,7 +3137,7 @@ index 8a73c2655aa12ecfd26df4e2f4eae17145f8f3e6..f57626ccb91231c5a79ed6f955bb0b4d
          else if (exprent.type == Exprent.EXPRENT_CONST) {
            ConstExprent constExprent = (ConstExprent)exprent;
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java
-index 7a88cb7bc4744aac96bdaffc0ab95652d1937d25..02152730af21f255d9fa12bda1e9422159e93694 100644
+index d6a9c2a29c73d778eb383d718094b7548d14d2f3..b11ff686109fd466c3b07e853fd433e5677fbf9e 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarVersionsProcessor.java
 @@ -22,7 +22,7 @@ import java.util.Map.Entry;
@@ -3157,7 +3158,7 @@ index 7a88cb7bc4744aac96bdaffc0ab95652d1937d25..02152730af21f255d9fa12bda1e94221
  
      // FIXME: advanced merging
  
-@@ -277,7 +277,8 @@ public class VarVersionsProcessor {
+@@ -245,7 +245,8 @@ public class VarVersionsProcessor {
      CounterContainer counters = DecompilerContext.getCounterContainer();
  
      final Map<VarVersionPair, Integer> mapVarPaar = new HashMap<>();
@@ -3167,7 +3168,7 @@ index 7a88cb7bc4744aac96bdaffc0ab95652d1937d25..02152730af21f255d9fa12bda1e94221
  
      // map var-version pairs on new var indexes
      List<VarVersionPair> vvps = new ArrayList<>(mapExprentMinTypes.keySet());
-@@ -298,7 +299,7 @@ public class VarVersionsProcessor {
+@@ -266,7 +267,7 @@ public class VarVersionsProcessor {
          }
  
          mapVarPaar.put(pair, newIndex);
@@ -3176,7 +3177,7 @@ index 7a88cb7bc4744aac96bdaffc0ab95652d1937d25..02152730af21f255d9fa12bda1e94221
        }
      }
  
-@@ -328,11 +329,11 @@ public class VarVersionsProcessor {
+@@ -296,11 +297,11 @@ public class VarVersionsProcessor {
      });
  
      if (previousVersionsProcessor != null) {
@@ -3192,7 +3193,7 @@ index 7a88cb7bc4744aac96bdaffc0ab95652d1937d25..02152730af21f255d9fa12bda1e94221
          value = oldValue != null ? oldValue : value;
          this.mapOriginalVarIndices.put(entry.getKey(), value);
        }
-@@ -359,7 +360,11 @@ public class VarVersionsProcessor {
+@@ -327,7 +328,11 @@ public class VarVersionsProcessor {
      typeProcessor.getFinalVariables().put(pair, finalType);
    }
  
@@ -3207,10 +3208,10 @@ index 7a88cb7bc4744aac96bdaffc0ab95652d1937d25..02152730af21f255d9fa12bda1e94221
  }
 \ No newline at end of file
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructContext.java b/src/org/jetbrains/java/decompiler/struct/StructContext.java
-index 80f1e91d6227fc4363b0039e13439d5838d790eb..94cedbee257faebd95ea933ab80a7d242c1ba023 100644
+index a929aca1f633a76660111010256dae0ef014f6fd..2f55882afdd1dd1b9960aa0c2a007069204797e9 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructContext.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructContext.java
-@@ -159,4 +159,30 @@ public class StructContext {
+@@ -164,4 +164,30 @@ public class StructContext {
    public Map<String, StructClass> getClasses() {
      return classes;
    }
@@ -3556,10 +3557,10 @@ index 0000000000000000000000000000000000000000..311db9ff7f0c543b3d131f588baed0d9
 +}
 diff --git a/test/org/jetbrains/java/decompiler/LVTTest.java b/test/org/jetbrains/java/decompiler/LVTTest.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..71d689df60a4377103777be6a408ed4f8651377c
+index 0000000000000000000000000000000000000000..388e1facddbac3286eaed3dbccc3b23197daf5d6
 --- /dev/null
 +++ b/test/org/jetbrains/java/decompiler/LVTTest.java
-@@ -0,0 +1,48 @@
+@@ -0,0 +1,49 @@
 +/*
 + * Copyright 2000-2014 JetBrains s.r.o.
 + *
@@ -3581,11 +3582,12 @@ index 0000000000000000000000000000000000000000..71d689df60a4377103777be6a408ed4f
 +import org.junit.Test;
 +
 +import java.io.IOException;
++import java.util.Map;
 +
 +public class LVTTest extends SingleClassesTestBase {
 +  @Override
-+  protected String[] getDecompilerOptions() {
-+    return new String[] {
++  protected Map<String, String> getDecompilerOptions() {
++    return Map.of(
 +      IFernflowerPreferences.DECOMPILE_INNER,"1",
 +      IFernflowerPreferences.DECOMPILE_GENERIC_SIGNATURES,"1",
 +      IFernflowerPreferences.ASCII_STRING_CHARACTERS,"1",
@@ -3593,7 +3595,7 @@ index 0000000000000000000000000000000000000000..71d689df60a4377103777be6a408ed4f
 +      IFernflowerPreferences.REMOVE_SYNTHETIC, "1",
 +      IFernflowerPreferences.REMOVE_BRIDGE, "1",
 +      IFernflowerPreferences.USE_DEBUG_VAR_NAMES, "1"
-+    };
++    );
 +  }
 +
 +  @Override
@@ -3609,11 +3611,11 @@ index 0000000000000000000000000000000000000000..71d689df60a4377103777be6a408ed4f
 +  @Test public void testLoopMerging() { doTest("pkg/TestLoopMerging"); }
 +}
 diff --git a/test/org/jetbrains/java/decompiler/SingleClassesTest.java b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
-index 8c4811fe2e4c46bf87bc0b4ac7752bae5243faf1..2018e2e548a35e13f925bf42858064e24f3f8696 100644
+index 89adb4e6fca7186ae849e62b98a9253de2dd29ef..dd0e178cc1df1c6edc9e77e3149c2b0e9bffe884 100644
 --- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
 +++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
 @@ -26,6 +26,7 @@ public class SingleClassesTest extends SingleClassesTestBase {
-     };
+                          IFernflowerPreferences.VERIFY_ANONYMOUS_CLASSES, "1");
    }
  
 +  @Test public void testEnhancedForLoops() { doTest("pkg/TestEnhancedForLoops"); }

--- a/FernFlower-Patches/0009-Rework-of-Generics-system-for-better-output.patch
+++ b/FernFlower-Patches/0009-Rework-of-Generics-system-for-better-output.patch
@@ -34,7 +34,7 @@ index 4c4916e4cc5ccdd06dd4138dae54c31fb7f3bd34..decfe747ba2ab3643209987294ef7bcb
 \ No newline at end of file
 +}
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 0dc28bc9d8e3b622f691939b1c8fcce9a09c11fe..b7467530cba1d8e317500a5c213dd6013d00a369 100644
+index 1989a01b158570651f332cf80dca0e0baeb4153c..31236841f1b4bf4f452f30d6b95f21fcc99ec5b9 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -371,9 +371,14 @@ public class ClassWriter {
@@ -116,16 +116,16 @@ index 0dc28bc9d8e3b622f691939b1c8fcce9a09c11fe..b7467530cba1d8e317500a5c213dd601
        }
      }
      else if (fd.hasModifier(CodeConstants.ACC_FINAL) && fd.hasModifier(CodeConstants.ACC_STATIC)) {
-@@ -639,7 +620,7 @@ public class ClassWriter {
+@@ -638,7 +619,7 @@ public class ClassWriter {
        boolean isDeprecated = mt.hasAttribute(StructGeneralAttribute.ATTRIBUTE_DEPRECATED);
-       boolean clInit = false, init = false, dInit = false;
+       boolean clInit = false, dInit = false;
  
 -      MethodDescriptor md = MethodDescriptor.parseDescriptor(mt.getDescriptor());
 +      MethodDescriptor md = MethodDescriptor.parseDescriptor(mt, node);
  
        int flags = mt.getAccessFlags();
        if ((flags & CodeConstants.ACC_NATIVE) != 0) {
-@@ -667,28 +648,7 @@ public class ClassWriter {
+@@ -666,25 +647,7 @@ public class ClassWriter {
          appendComment(buffer, "bridge method", indent);
        }
  
@@ -140,9 +140,6 @@ index 0dc28bc9d8e3b622f691939b1c8fcce9a09c11fe..b7467530cba1d8e317500a5c213dd601
 -            if (mask != null) {
 -              actualParams = mask.stream().filter(Objects::isNull).count();
 -            }
--            else if (isEnum && init) {
--              actualParams -= 2;
--            }
 -            if (actualParams != descriptor.parameterTypes.size()) {
 -              String message = "Inconsistent generic signature in method " + mt.getName() + " " + mt.getDescriptor() + " in " + cl.qualifiedName;
 -              DecompilerContext.getLogger().writeMessage(message, IFernflowerLogger.Severity.WARN);
@@ -155,7 +152,7 @@ index 0dc28bc9d8e3b622f691939b1c8fcce9a09c11fe..b7467530cba1d8e317500a5c213dd601
        appendAnnotations(buffer, indent, mt);
  
        buffer.appendIndent(indent);
-@@ -729,12 +689,7 @@ public class ClassWriter {
+@@ -726,12 +689,7 @@ public class ClassWriter {
          if (init) {
            emptyTypeAnnotations.forEach(typeAnnotation -> typeAnnotation.writeTo(buffer));
          } else {
@@ -169,7 +166,7 @@ index 0dc28bc9d8e3b622f691939b1c8fcce9a09c11fe..b7467530cba1d8e317500a5c213dd601
            buffer.append(' ');
          }
  
-@@ -751,7 +706,12 @@ public class ClassWriter {
+@@ -748,7 +706,12 @@ public class ClassWriter {
          }
  
          int index = methodWrapper.varproc.getFirstParameterVarIndex();
@@ -182,7 +179,7 @@ index 0dc28bc9d8e3b622f691939b1c8fcce9a09c11fe..b7467530cba1d8e317500a5c213dd601
            if (mask == null || mask.get(i) == null) {
              if (paramCount > 0) {
                buffer.append(", ");
-@@ -768,24 +728,12 @@ public class ClassWriter {
+@@ -765,24 +728,12 @@ public class ClassWriter {
              }
  
              String typeName;
@@ -211,7 +208,7 @@ index 0dc28bc9d8e3b622f691939b1c8fcce9a09c11fe..b7467530cba1d8e317500a5c213dd601
  
              if (ExprProcessor.UNDEFINED_TYPE_STRING.equals(typeName) &&
                  DecompilerContext.getOption(IFernflowerPreferences.UNDEFINED_PARAM_TYPE_OBJECT)) {
-@@ -804,7 +752,7 @@ public class ClassWriter {
+@@ -801,7 +752,7 @@ public class ClassWriter {
              paramCount++;
            }
  
@@ -220,7 +217,7 @@ index 0dc28bc9d8e3b622f691939b1c8fcce9a09c11fe..b7467530cba1d8e317500a5c213dd601
          }
  
          buffer.append(')');
-@@ -814,19 +762,14 @@ public class ClassWriter {
+@@ -811,19 +762,14 @@ public class ClassWriter {
            throwsExceptions = true;
            buffer.append(" throws ");
  
@@ -243,7 +240,7 @@ index 0dc28bc9d8e3b622f691939b1c8fcce9a09c11fe..b7467530cba1d8e317500a5c213dd601
            }
          }
        }
-@@ -1054,7 +997,7 @@ public class ClassWriter {
+@@ -1051,7 +997,7 @@ public class ClassWriter {
  
      final List<TypeAnnotation> typeAnnotations = TypeAnnotation.listFrom(cd);
      if (descriptor != null) {
@@ -252,7 +249,7 @@ index 0dc28bc9d8e3b622f691939b1c8fcce9a09c11fe..b7467530cba1d8e317500a5c213dd601
          varArgComponent ? descriptor.type.decreaseArrayDim() : descriptor.type,
          TypeAnnotationWriteHelper.create(typeAnnotations)
        ));
-@@ -1108,14 +1051,7 @@ public class ClassWriter {
+@@ -1105,14 +1051,7 @@ public class ClassWriter {
    private static Map.Entry<VarType, GenericFieldDescriptor> getFieldTypeData(StructField fd) {
      VarType fieldType = new VarType(fd.getDescriptor(), false);
  
@@ -268,7 +265,7 @@ index 0dc28bc9d8e3b622f691939b1c8fcce9a09c11fe..b7467530cba1d8e317500a5c213dd601
      return new AbstractMap.SimpleImmutableEntry<>(fieldType, descriptor);
    }
  
-@@ -1255,22 +1191,11 @@ public class ClassWriter {
+@@ -1249,22 +1188,11 @@ public class ClassWriter {
      }
    }
  
@@ -295,7 +292,7 @@ index 0dc28bc9d8e3b622f691939b1c8fcce9a09c11fe..b7467530cba1d8e317500a5c213dd601
      buffer.append('<');
      for (int i = 0; i < parameters.size(); i++) {
        if (i > 0) {
-@@ -1278,15 +1203,15 @@ public class ClassWriter {
+@@ -1272,15 +1200,15 @@ public class ClassWriter {
        }
        TargetInfo.TypeParameterTarget.extract(typeAnnotations, i).forEach(typeAnnotation -> typeAnnotation.writeTo(buffer));
        buffer.append(parameters.get(i));
@@ -314,7 +311,7 @@ index 0dc28bc9d8e3b622f691939b1c8fcce9a09c11fe..b7467530cba1d8e317500a5c213dd601
          }
        }
      }
-@@ -1303,4 +1228,4 @@ public class ClassWriter {
+@@ -1297,4 +1225,4 @@ public class ClassWriter {
        }
      }
    }
@@ -412,7 +409,7 @@ index 33906d3a433e4421bbf41c6aed5ff566a69a904a..c1126a2b7559e2f8a69a54ee0b7db2ce
 \ No newline at end of file
 +}
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
-index e160dc7f1bb3c8d1bdec0a1720035803f077e1e7..3534ca10c55713f5856163b7325e0c6e71c2c502 100644
+index a242aa9e74698b14e20e27d655a3c8ae141ee2f5..e005b2941b4e76b736b8d00905726ac8500c3dc2 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 @@ -29,6 +29,7 @@ import org.jetbrains.java.decompiler.struct.consts.PrimitiveConstant;
@@ -432,7 +429,7 @@ index e160dc7f1bb3c8d1bdec0a1720035803f077e1e7..3534ca10c55713f5856163b7325e0c6e
            break;
          case opc_monitorenter:
          case opc_monitorexit:
-@@ -689,7 +690,15 @@ public class ExprProcessor implements CodeConstants {
+@@ -685,7 +686,15 @@ public class ExprProcessor implements CodeConstants {
        sb.append("void");
        return sb.toString();
      }
@@ -448,7 +445,7 @@ index e160dc7f1bb3c8d1bdec0a1720035803f077e1e7..3534ca10c55713f5856163b7325e0c6e
        String ret;
        if (getShort) {
          ret = DecompilerContext.getImportCollector().getNestedName(type.getValue());
-@@ -740,7 +749,9 @@ public class ExprProcessor implements CodeConstants {
+@@ -736,7 +745,9 @@ public class ExprProcessor implements CodeConstants {
        boolean shouldWrite = true;
        if (!enclosingClasses.isEmpty() && i != nestedTypes.size() - 1) {
          String enclosingType = enclosingClasses.remove(0).simpleName;
@@ -459,7 +456,7 @@ index e160dc7f1bb3c8d1bdec0a1720035803f077e1e7..3534ca10c55713f5856163b7325e0c6e
        }
        if (i == 0) { // first annotation can be written already
          if (!sb.toString().isEmpty()) shouldWrite = true; // write if annotation exists
-@@ -956,6 +967,8 @@ public class ExprProcessor implements CodeConstants {
+@@ -952,6 +963,8 @@ public class ExprProcessor implements CodeConstants {
          tracer.incrementCurrentSourceLine();
        }
  
@@ -468,7 +465,7 @@ index e160dc7f1bb3c8d1bdec0a1720035803f077e1e7..3534ca10c55713f5856163b7325e0c6e
        TextBuffer content = expr.toJava(indent, tracer);
  
        if (content.length() > 0) {
-@@ -1028,7 +1041,7 @@ public class ExprProcessor implements CodeConstants {
+@@ -1024,7 +1037,7 @@ public class ExprProcessor implements CodeConstants {
        }
      }
  
@@ -478,10 +475,10 @@ index e160dc7f1bb3c8d1bdec0a1720035803f077e1e7..3534ca10c55713f5856163b7325e0c6e
      boolean cast =
        castAlways ||
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
-index 1af6fc576e1528f6c06b0e493bd912b9b37edff6..e1bed2f0f5f501d05f93dfa6bfcd2f2b3e76b822 100644
+index eb96762fa2174047a3f9dcecfb8c57bf4721c11f..dc3d20eed5ddcac36204fc9ed75d73c53a8c9805 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
-@@ -721,7 +721,7 @@ public class SimplifyExprentsHelper {
+@@ -722,7 +722,7 @@ public class SimplifyExprentsHelper {
                                                                                 Arrays.asList(
                                                                                   statement.getHeadexprent().getCondition(),
                                                                                   ifExit.getValue(),
@@ -490,7 +487,7 @@ index 1af6fc576e1528f6c06b0e493bd912b9b37edff6..e1bed2f0f5f501d05f93dfa6bfcd2f2b
                statement.setExprents(data);
  
                StatEdge retEdge = ifStatement.getAllSuccessorEdges().get(0);
-@@ -767,4 +767,4 @@ public class SimplifyExprentsHelper {
+@@ -768,4 +768,4 @@ public class SimplifyExprentsHelper {
  
      return ret;
    }
@@ -836,7 +833,7 @@ index 11669fe44ea78ab7322b82c844c8b220ca1a9975..b76d5dd1f39f3ef9a2847414bcf1cc37
 \ No newline at end of file
 +}
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
-index f2efd6b594b700b20814c620328753a66aea22a4..f227df9c03dd6ae3972b80ce11dc36d468addea3 100644
+index ac2b3a50e65c46ff998173335d505cdfc8a27b21..0a6281872ae535dbc0569cb08b301d58b6c5c9a3 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
 @@ -2,6 +2,8 @@
@@ -864,7 +861,7 @@ index f2efd6b594b700b20814c620328753a66aea22a4..f227df9c03dd6ae3972b80ce11dc36d4
  
    public FunctionExprent(int funcType, ListStack<Exprent> stack, BitSet bytecodeOffsets) {
      this(funcType, new ArrayList<>(), bytecodeOffsets);
-@@ -289,6 +291,46 @@ public class FunctionExprent extends Exprent {
+@@ -269,6 +271,46 @@ public class FunctionExprent extends Exprent {
      return exprType;
    }
  
@@ -911,17 +908,22 @@ index f2efd6b594b700b20814c620328753a66aea22a4..f227df9c03dd6ae3972b80ce11dc36d4
    @Override
    public int getExprentUse() {
      if (funcType >= FUNCTION_IMM && funcType <= FUNCTION_PPI) {
-@@ -463,6 +505,9 @@ public class FunctionExprent extends Exprent {
-       case FUNCTION_NEG:
-         return wrapOperandString(lstOperands.get(0), true, indent, tracer).prepend("-");
-       case FUNCTION_CAST:
+@@ -439,8 +481,12 @@ public class FunctionExprent extends Exprent {
+       case FUNCTION_BIT_NOT -> wrapOperandString(lstOperands.get(0), true, indent, tracer).prepend("~");
+       case FUNCTION_BOOL_NOT -> wrapOperandString(lstOperands.get(0), true, indent, tracer).prepend("!");
+       case FUNCTION_NEG -> wrapOperandString(lstOperands.get(0), true, indent, tracer).prepend("-");
+-      case FUNCTION_CAST -> lstOperands.get(1).toJava(indent, tracer).enclose("(", ")")
+-        .append(wrapOperandString(lstOperands.get(0), true, indent, tracer));
++      case FUNCTION_CAST -> {
 +        if (!needsCast) {
-+          return lstOperands.get(0).toJava(indent, tracer);
++          yield lstOperands.get(0).toJava(indent, tracer);
 +        }
-         return lstOperands.get(1).toJava(indent, tracer).enclose("(", ")").append(wrapOperandString(lstOperands.get(0), true, indent, tracer));
-       case FUNCTION_ARRAY_LENGTH:
++        yield lstOperands.get(1).toJava(indent, tracer).enclose("(", ")").append(wrapOperandString(lstOperands.get(0), true, indent, tracer));
++      }
+       case FUNCTION_ARRAY_LENGTH -> {
          Exprent arr = lstOperands.get(0);
-@@ -603,7 +648,7 @@ public class FunctionExprent extends Exprent {
+         TextBuffer res = wrapOperandString(arr, false, indent, tracer);
+@@ -571,7 +617,7 @@ public class FunctionExprent extends Exprent {
      measureBytecode(values, lstOperands);
      measureBytecode(values);
    }
@@ -931,7 +933,7 @@ index f2efd6b594b700b20814c620328753a66aea22a4..f227df9c03dd6ae3972b80ce11dc36d4
    // IMatchable implementation
    // *****************************************************************************
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 8356b5b643139d6c8346070d826877c724e4f8a2..104f2f112c621e3433bdbc1ce5afb05dee272833 100644
+index 8d2ce0f8f4d4368f87ed596e4e76442ff97fed19..6eab93e5ed261b0903ae3fe4677118bfa2d1d60e 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -19,6 +19,8 @@ import org.jetbrains.java.decompiler.struct.consts.LinkConstant;
@@ -951,7 +953,7 @@ index 8356b5b643139d6c8346070d826877c724e4f8a2..104f2f112c621e3433bdbc1ce5afb05d
  
    public InvocationExprent() {
      super(EXPRENT_INVOCATION);
-@@ -165,6 +168,55 @@ public class InvocationExprent extends Exprent {
+@@ -158,6 +161,55 @@ public class InvocationExprent extends Exprent {
      return descriptor.ret;
    }
  
@@ -1007,7 +1009,7 @@ index 8356b5b643139d6c8346070d826877c724e4f8a2..104f2f112c621e3433bdbc1ce5afb05d
    @Override
    public CheckTypesResult checkExprTypeBounds() {
      CheckTypesResult result = new CheckTypesResult();
-@@ -297,6 +349,7 @@ public class InvocationExprent extends Exprent {
+@@ -290,6 +342,7 @@ public class InvocationExprent extends Exprent {
  
          if (buf.length() > 0) {
            buf.append(".");
@@ -1015,7 +1017,7 @@ index 8356b5b643139d6c8346070d826877c724e4f8a2..104f2f112c621e3433bdbc1ce5afb05d
          }
  
          buf.append(name);
-@@ -333,8 +386,30 @@ public class InvocationExprent extends Exprent {
+@@ -324,8 +377,30 @@ public class InvocationExprent extends Exprent {
          isEnum = newNode.classStruct.hasModifier(CodeConstants.ACC_ENUM) && DecompilerContext.getOption(IFernflowerPreferences.DECOMPILE_ENUM);
        }
      }
@@ -1047,7 +1049,7 @@ index 8356b5b643139d6c8346070d826877c724e4f8a2..104f2f112c621e3433bdbc1ce5afb05d
  
      // omit 'new Type[] {}' for the last parameter of a vararg method call
      if (parameters.size() == descriptor.params.length && isVarArgCall()) {
-@@ -350,6 +425,34 @@ public class InvocationExprent extends Exprent {
+@@ -341,6 +416,34 @@ public class InvocationExprent extends Exprent {
        if (mask == null || mask.get(i) == null) {
          TextBuffer buff = new TextBuffer();
          boolean ambiguous = setAmbiguousParameters.get(i);
@@ -1082,7 +1084,7 @@ index 8356b5b643139d6c8346070d826877c724e4f8a2..104f2f112c621e3433bdbc1ce5afb05d
  
          // 'byte' and 'short' literals need an explicit narrowing type cast when used as a parameter
          ExprProcessor.getCastedExprent(parameters.get(i), descriptor.params[i], buff, indent, true, ambiguous, true, true, tracer);
-@@ -466,12 +569,11 @@ public class InvocationExprent extends Exprent {
+@@ -447,12 +550,11 @@ public class InvocationExprent extends Exprent {
      return !isStatic && parameters.size() == 0 && className.equals(UNBOXING_METHODS.get(name));
    }
  
@@ -1098,7 +1100,7 @@ index 8356b5b643139d6c8346070d826877c724e4f8a2..104f2f112c621e3433bdbc1ce5afb05d
      nextMethod:
      for (StructMethod mt : cl.getMethods()) {
        if (name.equals(mt.getName())) {
-@@ -482,11 +584,19 @@ public class InvocationExprent extends Exprent {
+@@ -463,11 +565,19 @@ public class InvocationExprent extends Exprent {
                continue nextMethod;
              }
            }
@@ -1120,7 +1122,7 @@ index 8356b5b643139d6c8346070d826877c724e4f8a2..104f2f112c621e3433bdbc1ce5afb05d
  
      // check if a call is unambiguous
      StructMethod mt = cl.getMethod(InterpreterUtil.makeUniqueKey(name, stringDescriptor));
-@@ -508,7 +618,14 @@ public class InvocationExprent extends Exprent {
+@@ -489,7 +599,14 @@ public class InvocationExprent extends Exprent {
      BitSet ambiguous = new BitSet(descriptor.params.length);
      for (int i = 0; i < descriptor.params.length; i++) {
        VarType paramType = descriptor.params[i];
@@ -1272,19 +1274,19 @@ index 2fda2ba5fc05992faf891d2af14910023228c6b6..9ba49d3d3ee30e6e8db7cacd836f7f62
                  }
                }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DoStatement.java b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DoStatement.java
-index 0c64170a05d6675803b69284d8ee532e44212ee2..7a54601fd2fd88d0c652384587e16c2d3f704f7e 100644
+index 018d3fbdf53036db90b6c64e872098542133b630..d58218e0baa786456f15a14ef23a8d82d466ba18 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DoStatement.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/stats/DoStatement.java
-@@ -106,6 +106,7 @@ public final class DoStatement extends Statement {
-         break;
-       case FOREACH:
+@@ -107,6 +107,7 @@ public final class DoStatement extends Statement {
+       }
+       case FOREACH -> {
          buf.appendIndent(indent).append("for(").append(initExprent.get(0).toJava(indent, tracer));
 +        incExprent.get(0).getInferredExprType(null); //TODO: Find a better then null? For now just calls it to clear casts if needed
          buf.append(" : ").append(incExprent.get(0).toJava(indent, tracer)).append(") {").appendLineSeparator();
          tracer.incrementCurrentSourceLine();
          buf.append(ExprProcessor.jmpWrapper(first, indent + 1, true, tracer));
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
-index b65a7ceb11c31ab892d8bd1f6e1a30fc78aa11ab..2c314dffc92ee5ca40ae8056c93c845f4f2dd6c3 100644
+index 6f8a2619c728d168431673b14f53b94ba783cf2f..abe421340550d258edce046fc901479fa027a23e 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
 @@ -24,7 +24,6 @@ import org.jetbrains.java.decompiler.struct.StructMethod;
@@ -1295,7 +1297,7 @@ index b65a7ceb11c31ab892d8bd1f6e1a30fc78aa11ab..2c314dffc92ee5ca40ae8056c93c845f
  import org.jetbrains.java.decompiler.struct.gen.generics.GenericType;
  
  import java.util.*;
-@@ -993,7 +992,7 @@ public class VarDefinitionHelper {
+@@ -987,7 +986,7 @@ public class VarDefinitionHelper {
  
      private VarInfo(LocalVariable lvt, VarType type) {
        if (lvt != null && lvt.getSignature() != null)
@@ -1493,10 +1495,10 @@ index 0b4275f57e3092623c4e462b032b418cf2bdd84b..bead2d172e27075e63f6977562988041
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructContext.java b/src/org/jetbrains/java/decompiler/struct/StructContext.java
-index 94cedbee257faebd95ea933ab80a7d242c1ba023..301737310f3d346cc2229395551d504a34cb6dbc 100644
+index 2f55882afdd1dd1b9960aa0c2a007069204797e9..85fc95d87bd7e672613f6c1beb75b2d56d1d759f 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructContext.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructContext.java
-@@ -156,6 +156,19 @@ public class StructContext {
+@@ -161,6 +161,19 @@ public class StructContext {
      }
    }
  
@@ -1578,7 +1580,7 @@ index 0d6df7e05b9b385e743c85261b77215314167989..da073261717d3583fc91b6c9c30351ce
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructMethod.java b/src/org/jetbrains/java/decompiler/struct/StructMethod.java
-index 4e5c7b4da350020f4f69da956eda4384b86df2aa..e3d5edf6e78c37206e5a37abaf24efbb6eb6dfa3 100644
+index 0a7e5ba44d82f1923dadd9f79627d91f82b1014c..d48e950e7511d2a00ac9885d5dc7d4ff524bbb37 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructMethod.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructMethod.java
 @@ -2,12 +2,17 @@
@@ -1642,7 +1644,7 @@ index 4e5c7b4da350020f4f69da956eda4384b86df2aa..e3d5edf6e78c37206e5a37abaf24efbb
    }
  
    public void expandData(StructClass classStruct) throws IOException {
-@@ -385,4 +401,8 @@ public class StructMethod extends StructMember {
+@@ -339,4 +355,8 @@ public class StructMethod extends StructMember {
    public String getClassQualifiedName() {
      return classQualifiedName;
    }
@@ -1693,7 +1695,7 @@ index e50983daf2a1bf6c93ec92c99221587d7c4f7c6a..11fa1a3e621221a09c0e611a7f912932
    }
  }
 diff --git a/src/org/jetbrains/java/decompiler/struct/gen/MethodDescriptor.java b/src/org/jetbrains/java/decompiler/struct/gen/MethodDescriptor.java
-index 14aaf8e28413ccb2dda4d2d181fc79976f2b0710..8044f348e8aad96f451a47ef24f54972e171b9c7 100644
+index 7007b680a005a28a5d919e5e9e4298ed6c0ec566..49494925b2d67b95920bb2b8c8371e886341492f 100644
 --- a/src/org/jetbrains/java/decompiler/struct/gen/MethodDescriptor.java
 +++ b/src/org/jetbrains/java/decompiler/struct/gen/MethodDescriptor.java
 @@ -2,14 +2,24 @@
@@ -1721,7 +1723,7 @@ index 14aaf8e28413ccb2dda4d2d181fc79976f2b0710..8044f348e8aad96f451a47ef24f54972
  
    private MethodDescriptor(VarType[] params, VarType ret) {
      this.params = params;
-@@ -63,6 +73,41 @@ public final class MethodDescriptor {
+@@ -64,6 +74,35 @@ public final class MethodDescriptor {
      return new MethodDescriptor(params, ret);
    }
  
@@ -1737,12 +1739,6 @@ index 14aaf8e28413ccb2dda4d2d181fc79976f2b0710..8044f348e8aad96f451a47ef24f54972
 +        List<VarVersionPair> sigFields = methodWrapper == null ? null : methodWrapper.synthParameters;
 +        if (sigFields != null) {
 +          actualParams = sigFields.stream().filter(Objects::isNull).count();
-+        }
-+        else if (init) {
-+          // && isEnum
-+          if (DecompilerContext.getOption(IFernflowerPreferences.DECOMPILE_ENUM) && DecompilerContext.getStructContext().getClass(struct.getClassQualifiedName()).hasModifier(CodeConstants.ACC_ENUM)) {
-+            actualParams -= 2;
-+          }
 +        }
 +        if (actualParams != sig.parameterTypes.size()) {
 +          String message = "Inconsistent generic signature in method " + struct.getName() + " " + struct.getDescriptor() + " in " + struct.getClassQualifiedName();
@@ -1763,7 +1759,7 @@ index 14aaf8e28413ccb2dda4d2d181fc79976f2b0710..8044f348e8aad96f451a47ef24f54972
    public String buildNewDescriptor(NewClassNameBuilder builder) {
      boolean updated = false;
  
-@@ -125,4 +170,4 @@ public final class MethodDescriptor {
+@@ -126,4 +165,4 @@ public final class MethodDescriptor {
      result = 31 * result + params.length;
      return result;
    }
@@ -1771,7 +1767,7 @@ index 14aaf8e28413ccb2dda4d2d181fc79976f2b0710..8044f348e8aad96f451a47ef24f54972
 \ No newline at end of file
 +}
 diff --git a/src/org/jetbrains/java/decompiler/struct/gen/VarType.java b/src/org/jetbrains/java/decompiler/struct/gen/VarType.java
-index e5100010a55590d289820d91301ddb732398e3f2..d8388e50f6c88e91a0007854400e756153cdb4a6 100644
+index 30b31f5604f0c1566c536737aa7d9c61363e08c5..44d120256a8020b833567fe0f24c7b2c67caafde 100644
 --- a/src/org/jetbrains/java/decompiler/struct/gen/VarType.java
 +++ b/src/org/jetbrains/java/decompiler/struct/gen/VarType.java
 @@ -3,6 +3,7 @@ package org.jetbrains.java.decompiler.struct.gen;
@@ -1791,8 +1787,8 @@ index e5100010a55590d289820d91301ddb732398e3f2..d8388e50f6c88e91a0007854400e7561
      this.type = type;
      this.arrayDim = arrayDim;
      this.value = value;
-@@ -165,7 +166,7 @@ public class VarType implements Type {  // TODO: optimize switch
-     }
+@@ -147,7 +148,7 @@ public class VarType implements Type {  // TODO: optimize switch
+     };
    }
  
 -  private static int getStackSize(int type, int arrayDim) {
@@ -1800,8 +1796,8 @@ index e5100010a55590d289820d91301ddb732398e3f2..d8388e50f6c88e91a0007854400e7561
      if (arrayDim > 0) {
        return 1;
      }
-@@ -182,7 +183,7 @@ public class VarType implements Type {  // TODO: optimize switch
-     }
+@@ -159,7 +160,7 @@ public class VarType implements Type {  // TODO: optimize switch
+     };
    }
  
 -  private static int getFamily(int type, int arrayDim) {
@@ -1809,7 +1805,7 @@ index e5100010a55590d289820d91301ddb732398e3f2..d8388e50f6c88e91a0007854400e7561
      if (arrayDim > 0) {
        return CodeConstants.TYPE_FAMILY_OBJECT;
      }
-@@ -283,6 +284,15 @@ public class VarType implements Type {  // TODO: optimize switch
+@@ -248,6 +249,15 @@ public class VarType implements Type {  // TODO: optimize switch
      return res;
    }
  
@@ -1825,9 +1821,9 @@ index e5100010a55590d289820d91301ddb732398e3f2..d8388e50f6c88e91a0007854400e7561
    @Override
    public boolean equals(Object o) {
      if (o == this) {
-@@ -429,4 +439,15 @@ public class VarType implements Type {  // TODO: optimize switch
-         throw new IllegalArgumentException("Invalid type: " + c);
-     }
+@@ -374,4 +384,15 @@ public class VarType implements Type {  // TODO: optimize switch
+       default -> throw new IllegalArgumentException("Invalid type: " + c);
+     };
    }
 +
 +  public boolean isGeneric() {
@@ -1887,7 +1883,7 @@ index a65181762765bfdc9d2ee5695f3ffa68b7768b74..2b0fdf1dad01ec62f3e21f372297c124
  }
 \ No newline at end of file
 diff --git a/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericMain.java b/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericMain.java
-index 4bf0c0ada3e92dda77bb698fcf78d232f4c2bb2d..4c35ce1fc3fface6ce485d8947a5b453ee88fb66 100644
+index 315786d5a56e2871a1d0829760b672398a17d972..16aa2ee5a55fa9ba832909cdd9f5043f5d3e7ba7 100644
 --- a/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericMain.java
 +++ b/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericMain.java
 @@ -7,9 +7,9 @@ import org.jetbrains.java.decompiler.main.extern.IFernflowerLogger;
@@ -1990,7 +1986,7 @@ index 4bf0c0ada3e92dda77bb698fcf78d232f4c2bb2d..4c35ce1fc3fface6ce485d8947a5b453
      if (signature.charAt(0) != '<') {
        return signature;
      }
-@@ -132,7 +140,7 @@ public final class GenericMain {
+@@ -131,7 +139,7 @@ public final class GenericMain {
        String param = value.substring(0, to);
        value = value.substring(to + 1);
  
@@ -1999,7 +1995,7 @@ index 4bf0c0ada3e92dda77bb698fcf78d232f4c2bb2d..4c35ce1fc3fface6ce485d8947a5b453
  
        while (true) {
          if (value.charAt(0) == ':') {
-@@ -141,7 +149,7 @@ public final class GenericMain {
+@@ -140,7 +148,7 @@ public final class GenericMain {
          }
  
          String bound = GenericType.getNextType(value);
@@ -2008,7 +2004,7 @@ index 4bf0c0ada3e92dda77bb698fcf78d232f4c2bb2d..4c35ce1fc3fface6ce485d8947a5b453
          value = value.substring(bound.length());
  
  
-@@ -184,83 +192,14 @@ public final class GenericMain {
+@@ -183,77 +191,14 @@ public final class GenericMain {
      }
      else if (tp == CodeConstants.TYPE_OBJECT) {
        StringBuilder sb = new StringBuilder();
@@ -2068,15 +2064,9 @@ index 4bf0c0ada3e92dda77bb698fcf78d232f4c2bb2d..4c35ce1fc3fface6ce485d8947a5b453
 -        typeAnnWriteHelpers.removeAll(locTypeAnnWriteHelpers);
 -        locTypeAnnWriteHelpers = writeTypeAnnotationBeforeWildCard(sb, genPar, wildcard, locTypeAnnWriteHelpers);
 -        switch (wildcard) {
--          case GenericType.WILDCARD_UNBOUND:
--            sb.append('?');
--            break;
--          case GenericType.WILDCARD_EXTENDS:
--            sb.append("? extends ");
--            break;
--          case GenericType.WILDCARD_SUPER:
--            sb.append("? super ");
--            break;
+-          case GenericType.WILDCARD_UNBOUND -> sb.append('?');
+-          case GenericType.WILDCARD_EXTENDS -> sb.append("? extends ");
+-          case GenericType.WILDCARD_SUPER -> sb.append("? super ");
 -        }
 -        locTypeAnnWriteHelpers = writeTypeAnnotationAfterWildCard(sb, genPar, locTypeAnnWriteHelpers);
 -        if (genPar != null) {
@@ -2094,7 +2084,7 @@ index 4bf0c0ada3e92dda77bb698fcf78d232f4c2bb2d..4c35ce1fc3fface6ce485d8947a5b453
      int argIndex,
      List<TypeAnnotationWriteHelper> typeAnnWriteHelpers
    ) {
-@@ -273,9 +212,9 @@ public final class GenericMain {
+@@ -266,9 +211,9 @@ public final class GenericMain {
      }).collect(Collectors.toList());
    }
  
@@ -2106,7 +2096,7 @@ index 4bf0c0ada3e92dda77bb698fcf78d232f4c2bb2d..4c35ce1fc3fface6ce485d8947a5b453
      int wildcard,
      List<TypeAnnotationWriteHelper> typeAnnWriteHelpers
    ) {
-@@ -285,7 +224,7 @@ public final class GenericMain {
+@@ -278,7 +223,7 @@ public final class GenericMain {
          typeAnnWriteHelper.writeTo(sb);
          return false;
        }
@@ -2115,7 +2105,7 @@ index 4bf0c0ada3e92dda77bb698fcf78d232f4c2bb2d..4c35ce1fc3fface6ce485d8947a5b453
          typeAnnWriteHelper.writeTo(sb);
          return false;
        }
-@@ -293,9 +232,9 @@ public final class GenericMain {
+@@ -286,9 +231,9 @@ public final class GenericMain {
      }).collect(Collectors.toList());
    }
  
@@ -2161,7 +2151,7 @@ index eb8049193e952f7476a99188838b6c8907f49f8d..a93d250e2400a9680d7561d73cc1a69f
      this.typeParameterBounds = substitute(typeParameterBounds);
      this.parameterTypes = substitute(parameterTypes);
 diff --git a/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericType.java b/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericType.java
-index ff1fe46b43531409fdce2151485cfc48366d3b62..077ebbd169338e0cf4db79bb75100a944026dfd3 100644
+index a042dd3a747f224a63a0987ff465f6259d783de4..e430a99b30757bb0ba5b8dda66e0790383ab8d75 100644
 --- a/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericType.java
 +++ b/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericType.java
 @@ -2,44 +2,49 @@
@@ -2345,7 +2335,7 @@ index ff1fe46b43531409fdce2151485cfc48366d3b62..077ebbd169338e0cf4db79bb75100a94
    }
  
    private static String getNextClassSignature(String value) {
-@@ -138,11 +161,13 @@ public class GenericType implements Type {
+@@ -135,11 +158,13 @@ public class GenericType implements Type {
      return value.substring(0, index);
    }
  
@@ -2361,9 +2351,9 @@ index ff1fe46b43531409fdce2151485cfc48366d3b62..077ebbd169338e0cf4db79bb75100a94
      while (value.length() > 0) {
        String typeStr = getNextType(value);
        int len = typeStr.length();
-@@ -160,16 +185,16 @@ public class GenericType implements Type {
-           break;
-       }
+@@ -150,16 +175,16 @@ public class GenericType implements Type {
+         default -> WILDCARD_NO;
+       };
  
 -      type.getWildcards().add(wildcard);
 -
@@ -2381,7 +2371,7 @@ index ff1fe46b43531409fdce2151485cfc48366d3b62..077ebbd169338e0cf4db79bb75100a94
    }
  
    public static String getNextType(String value) {
-@@ -218,20 +243,134 @@ public class GenericType implements Type {
+@@ -208,20 +233,134 @@ public class GenericType implements Type {
      return value.substring(0, index + 1);
    }
  
@@ -2395,13 +2385,13 @@ index ff1fe46b43531409fdce2151485cfc48366d3b62..077ebbd169338e0cf4db79bb75100a94
 +  @Override
 +  public VarType resizeArrayDim(int newArrayDim) {
 +    return new GenericType(getType(), newArrayDim, getValue(), parent, arguments, wildcard);
++  }
++
++  public VarType getParent() {
++    return parent;
    }
  
 -  public List<GenericType> getArguments() {
-+  public VarType getParent() {
-+    return parent;
-+  }
-+
 +  public List<VarType> getArguments() {
      return arguments;
    }
@@ -2415,10 +2405,8 @@ index ff1fe46b43531409fdce2151485cfc48366d3b62..077ebbd169338e0cf4db79bb75100a94
 +
 +  public int getWildcard() {
 +    return wildcard;
-   }
- 
--  public List<Integer> getWildcards() {
--    return wildcards;
++  }
++
 +  public List<TypeAnnotationWriteHelper> appendCastName(final StringBuilder clsName, List<TypeAnnotationWriteHelper> typeAnnWriteHelpers) {
 +    if (parent != null && parent.isGeneric()) {
 +      typeAnnWriteHelpers = ((GenericType) parent).appendCastName(clsName, typeAnnWriteHelpers);
@@ -2488,8 +2476,10 @@ index ff1fe46b43531409fdce2151485cfc48366d3b62..077ebbd169338e0cf4db79bb75100a94
 +    buf.append(super.toString());
 +    appendTypeArguments(buf, Collections.emptyList());
 +    return buf.toString();
-+  }
-+
+   }
+ 
+-  public List<Integer> getWildcards() {
+-    return wildcards;
 +
 +  @Override
 +  public VarType remap(Map<VarType, VarType> map) {
@@ -2636,15 +2626,17 @@ index 0000000000000000000000000000000000000000..cc91edd842805b55a757c5794b4fb7dc
 +    }
 +}
 diff --git a/test/org/jetbrains/java/decompiler/SingleClassesTest.java b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
-index 2018e2e548a35e13f925bf42858064e24f3f8696..256f412db7806d11c41d9f48d8e3d28361e50c39 100644
+index dd0e178cc1df1c6edc9e77e3149c2b0e9bffe884..645d99f07322c311a20b5fd76a5235de6cdae74d 100644
 --- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
 +++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
-@@ -23,9 +23,11 @@ public class SingleClassesTest extends SingleClassesTestBase {
-       IFernflowerPreferences.DUMP_ORIGINAL_LINES, "1",
-       IFernflowerPreferences.IGNORE_INVALID_BYTECODE, "1",
-       IFernflowerPreferences.VERIFY_ANONYMOUS_CLASSES, "1",
-+      IFernflowerPreferences.INCLUDE_ENTIRE_CLASSPATH, "1"
-     };
+@@ -23,9 +23,12 @@ public class SingleClassesTest extends SingleClassesTestBase {
+     return Map.of(IFernflowerPreferences.BYTECODE_SOURCE_MAPPING, "1",
+                          IFernflowerPreferences.DUMP_ORIGINAL_LINES, "1",
+                          IFernflowerPreferences.IGNORE_INVALID_BYTECODE, "1",
+-                         IFernflowerPreferences.VERIFY_ANONYMOUS_CLASSES, "1");
++                         IFernflowerPreferences.VERIFY_ANONYMOUS_CLASSES, "1",
++                         IFernflowerPreferences.INCLUDE_ENTIRE_CLASSPATH, "1"
++);
    }
  
 +  @Test public void testGenerics() { doTest("pkg/TestGenerics"); }

--- a/FernFlower-Patches/0010-Improvements-to-var-and-var.patch
+++ b/FernFlower-Patches/0010-Improvements-to-var-and-var.patch
@@ -5,18 +5,18 @@ Subject: [PATCH] Improvements to var++ and var--
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-index 09a5887befc045f8faef7a1c53a71387ea8ff890..52575665f1021b39a09412a774587b10dad34812 100644
+index 5d0ec234807e0fa186ae88e7f74059710a47bd46..866cea112a60907c3ef02160a3b6c0bac1a075ae 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-@@ -926,7 +926,7 @@ public class NestedClassProcessor {
-           res = classname.equals(((InvocationExprent)expr).getClassName());
-           break;
-         case Exprent.EXPRENT_NEW:
+@@ -916,7 +916,7 @@ public class NestedClassProcessor {
+         case Exprent.EXPRENT_FIELD -> res = classname.equals(((FieldExprent)expr).getClassname());
+         case Exprent.EXPRENT_INVOCATION -> res = classname.equals(((InvocationExprent)expr).getClassName());
+         case Exprent.EXPRENT_NEW -> {
 -          VarType newType = expr.getExprType();
 +          VarType newType = ((NewExprent)expr).getNewType();
            res = newType.getType() == CodeConstants.TYPE_OBJECT && classname.equals(newType.getValue());
-           break;
-         case Exprent.EXPRENT_VAR:
+         }
+         case Exprent.EXPRENT_VAR -> {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/PPandMMHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/PPandMMHelper.java
 index 81b4c480810a2f74388a4626a4dc0c2bfc523365..f0f66146eb4ecad4ed1bbd41712cace8fe466ed5 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/PPandMMHelper.java
@@ -114,10 +114,10 @@ index 81b4c480810a2f74388a4626a4dc0c2bfc523365..f0f66146eb4ecad4ed1bbd41712cace8
            }
          }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
-index 08903784da127ef326d115d8af8287cc8f65c2ca..2b0a80c8e2f1229664e86159f6cefc74955e197e 100644
+index 29cb0533a353084f83e19b565db6c0e66ab418c1..06025ab6d1c96e8bedb91b4efcbd2e00641c477e 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
-@@ -457,7 +457,12 @@ public class ConstExprent extends Exprent {
+@@ -427,7 +427,12 @@ public class ConstExprent extends Exprent {
    public void getBytecodeRange(BitSet values) {
      measureBytecode(values);
    }
@@ -132,10 +132,10 @@ index 08903784da127ef326d115d8af8287cc8f65c2ca..2b0a80c8e2f1229664e86159f6cefc74
    // IMatchable implementation
    // *****************************************************************************
 diff --git a/test/org/jetbrains/java/decompiler/LVTTest.java b/test/org/jetbrains/java/decompiler/LVTTest.java
-index 71d689df60a4377103777be6a408ed4f8651377c..76e406446e524ad1df39881ab5178c09c1e5b421 100644
+index 388e1facddbac3286eaed3dbccc3b23197daf5d6..6ffaa0f8581c48b4fd2f96d0c21368d63e69cf5f 100644
 --- a/test/org/jetbrains/java/decompiler/LVTTest.java
 +++ b/test/org/jetbrains/java/decompiler/LVTTest.java
-@@ -45,4 +45,5 @@ public class LVTTest extends SingleClassesTestBase {
+@@ -46,4 +46,5 @@ public class LVTTest extends SingleClassesTestBase {
    @Test public void testLVTComplex() { doTest("pkg/TestLVTComplex"); }
    @Test public void testVarType() { doTest("pkg/TestVarType"); }
    @Test public void testLoopMerging() { doTest("pkg/TestLoopMerging"); }

--- a/FernFlower-Patches/0011-JAD-Style-variable-naming.patch
+++ b/FernFlower-Patches/0011-JAD-Style-variable-naming.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] JAD Style variable naming
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 31236841f1b4bf4f452f30d6b95f21fcc99ec5b9..0e98490e2b4e68eaad0fce79ce4b6e3b7d636ad5 100644
+index 31236841f1b4bf4f452f30d6b95f21fcc99ec5b9..54a54ca34e7dc8222688521bd30023a543c189a9 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -117,15 +117,20 @@ public class ClassWriter {
@@ -14,7 +14,7 @@ index 31236841f1b4bf4f452f30d6b95f21fcc99ec5b9..0e98490e2b4e68eaad0fce79ce4b6e3b
  
 +              List<TypeAnnotation> iParameterTypeAnnotations = TargetInfo.FormalParameterTarget.extract(parameterTypeAnnotations, i);
 +              VarType type = md_content.params[i];
-+              String typeName = ExprProcessor.getCastTypeName(type, TypeAnnotationWriteHelper.create(iParameterTypeAnnotations));
++              String typeName = ExprProcessor.getCastTypeName(type, explicitlyTyped, TypeAnnotationWriteHelper.create(iParameterTypeAnnotations));
                if (explicitlyTyped) {
 -                List<TypeAnnotation> iParameterTypeAnnotations = TargetInfo.FormalParameterTarget.extract(parameterTypeAnnotations, i);
 -                VarType type = md_content.params[i];
@@ -28,7 +28,7 @@ index 31236841f1b4bf4f452f30d6b95f21fcc99ec5b9..0e98490e2b4e68eaad0fce79ce4b6e3b
 +              if (parameterName == null) {
 +                parameterName = "param" + index; // null iff decompiled with errors
 +              }
-+              parameterName = methodWrapper.methodStruct.getVariableNamer().renameParameter(mt.getAccessFlags(), typeName, parameterName, index);
++              parameterName = mt.getVariableNamer().renameParameter(mt.getAccessFlags(), typeName, parameterName, index);
 +              buffer.append(parameterName);
  
                firstParameter = false;
@@ -358,6 +358,28 @@ index 0000000000000000000000000000000000000000..fc1d7d67864ab12e894fcdf0ed8e1297
 +public interface IVariableNamingFactory {
 +  public IVariableNameProvider createFactory(StructMethod structMethod);
 +}
+diff --git a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
+index 866cea112a60907c3ef02160a3b6c0bac1a075ae..4fb8a34372213f8edbc240f0d5b640cae87255f9 100644
+--- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
++++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
+@@ -125,7 +125,7 @@ public class NestedClassProcessor {
+         if (expr.type == Exprent.EXPRENT_NEW) {
+           NewExprent new_expr = (NewExprent)expr;
+ 
+-          VarNamesCollector enclosingCollector = new VarNamesCollector(enclosingMethod.varproc.getVarNames());
++          // VarNamesCollector enclosingCollector = new VarNamesCollector(enclosingMethod.varproc.getVarNames());
+ 
+           if (new_expr.isLambda() && lambda_class_type.equals(new_expr.getNewType())) {
+             InvocationExprent inv_dynamic = new_expr.getConstructor();
+@@ -144,7 +144,7 @@ public class NestedClassProcessor {
+                 }
+               }
+               else {
+-                mapNewNames.put(varVersion, enclosingCollector.getFreeName(method.varproc.getVarName(varVersion)));
++                // mapNewNames.put(varVersion, enclosingCollector.getFreeName(method.varproc.getVarName(varVersion)));
+               }
+ 
+               varIndex += md_content.params[i].getStackSize();
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
 index abe421340550d258edce046fc901479fa027a23e..cf7f00021cad6818e144342dcbf5b6198e8adeb3 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java

--- a/FernFlower-Patches/0011-JAD-Style-variable-naming.patch
+++ b/FernFlower-Patches/0011-JAD-Style-variable-naming.patch
@@ -358,6 +358,19 @@ index 0000000000000000000000000000000000000000..fc1d7d67864ab12e894fcdf0ed8e1297
 +public interface IVariableNamingFactory {
 +  public IVariableNameProvider createFactory(StructMethod structMethod);
 +}
+diff --git a/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java b/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
+index c1126a2b7559e2f8a69a54ee0b7db2ceda3d9776..614591114f548010b35893d5199afe4d022ee88f 100644
+--- a/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
++++ b/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
+@@ -158,7 +158,7 @@ public class ClassWrapper {
+   }
+ 
+   private static void applyDebugInfo(StructMethod mt, VarProcessor varProc, MethodWrapper methodWrapper) {
+-    if (DecompilerContext.getOption(IFernflowerPreferences.USE_DEBUG_VAR_NAMES)) {
++    if (DecompilerContext.getOption(IFernflowerPreferences.USE_DEBUG_VAR_NAMES) && !DecompilerContext.getOption(IFernflowerPreferences.USE_JAD_VARNAMING)) {
+       StructLocalVariableTableAttribute attr = mt.getLocalVariableAttr();
+       if (attr != null) {
+         // only param names here
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
 index abe421340550d258edce046fc901479fa027a23e..cf7f00021cad6818e144342dcbf5b6198e8adeb3 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java

--- a/FernFlower-Patches/0011-JAD-Style-variable-naming.patch
+++ b/FernFlower-Patches/0011-JAD-Style-variable-naming.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] JAD Style variable naming
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 31236841f1b4bf4f452f30d6b95f21fcc99ec5b9..54a54ca34e7dc8222688521bd30023a543c189a9 100644
+index 31236841f1b4bf4f452f30d6b95f21fcc99ec5b9..0e98490e2b4e68eaad0fce79ce4b6e3b7d636ad5 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -117,15 +117,20 @@ public class ClassWriter {
@@ -14,7 +14,7 @@ index 31236841f1b4bf4f452f30d6b95f21fcc99ec5b9..54a54ca34e7dc8222688521bd30023a5
  
 +              List<TypeAnnotation> iParameterTypeAnnotations = TargetInfo.FormalParameterTarget.extract(parameterTypeAnnotations, i);
 +              VarType type = md_content.params[i];
-+              String typeName = ExprProcessor.getCastTypeName(type, explicitlyTyped, TypeAnnotationWriteHelper.create(iParameterTypeAnnotations));
++              String typeName = ExprProcessor.getCastTypeName(type, TypeAnnotationWriteHelper.create(iParameterTypeAnnotations));
                if (explicitlyTyped) {
 -                List<TypeAnnotation> iParameterTypeAnnotations = TargetInfo.FormalParameterTarget.extract(parameterTypeAnnotations, i);
 -                VarType type = md_content.params[i];
@@ -28,7 +28,7 @@ index 31236841f1b4bf4f452f30d6b95f21fcc99ec5b9..54a54ca34e7dc8222688521bd30023a5
 +              if (parameterName == null) {
 +                parameterName = "param" + index; // null iff decompiled with errors
 +              }
-+              parameterName = mt.getVariableNamer().renameParameter(mt.getAccessFlags(), typeName, parameterName, index);
++              parameterName = methodWrapper.methodStruct.getVariableNamer().renameParameter(mt.getAccessFlags(), typeName, parameterName, index);
 +              buffer.append(parameterName);
  
                firstParameter = false;
@@ -358,28 +358,6 @@ index 0000000000000000000000000000000000000000..fc1d7d67864ab12e894fcdf0ed8e1297
 +public interface IVariableNamingFactory {
 +  public IVariableNameProvider createFactory(StructMethod structMethod);
 +}
-diff --git a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-index 866cea112a60907c3ef02160a3b6c0bac1a075ae..4fb8a34372213f8edbc240f0d5b640cae87255f9 100644
---- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-+++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-@@ -125,7 +125,7 @@ public class NestedClassProcessor {
-         if (expr.type == Exprent.EXPRENT_NEW) {
-           NewExprent new_expr = (NewExprent)expr;
- 
--          VarNamesCollector enclosingCollector = new VarNamesCollector(enclosingMethod.varproc.getVarNames());
-+          // VarNamesCollector enclosingCollector = new VarNamesCollector(enclosingMethod.varproc.getVarNames());
- 
-           if (new_expr.isLambda() && lambda_class_type.equals(new_expr.getNewType())) {
-             InvocationExprent inv_dynamic = new_expr.getConstructor();
-@@ -144,7 +144,7 @@ public class NestedClassProcessor {
-                 }
-               }
-               else {
--                mapNewNames.put(varVersion, enclosingCollector.getFreeName(method.varproc.getVarName(varVersion)));
-+                // mapNewNames.put(varVersion, enclosingCollector.getFreeName(method.varproc.getVarName(varVersion)));
-               }
- 
-               varIndex += md_content.params[i].getStackSize();
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
 index abe421340550d258edce046fc901479fa027a23e..cf7f00021cad6818e144342dcbf5b6198e8adeb3 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java

--- a/FernFlower-Patches/0011-JAD-Style-variable-naming.patch
+++ b/FernFlower-Patches/0011-JAD-Style-variable-naming.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] JAD Style variable naming
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index b7467530cba1d8e317500a5c213dd6013d00a369..a095a246733384782870a1b9cac17ede8fd558dc 100644
+index 31236841f1b4bf4f452f30d6b95f21fcc99ec5b9..0e98490e2b4e68eaad0fce79ce4b6e3b7d636ad5 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -117,15 +117,20 @@ public class ClassWriter {
@@ -60,7 +60,7 @@ index b7467530cba1d8e317500a5c213dd6013d00a369..a095a246733384782870a1b9cac17ede
              firstParameter = false;
            }
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
-index 7db5b328969a6dac49054e57b5c00c672ca4ea85..f0d59a81d1f40f95d21ff7699fd349e10d39278c 100644
+index 9104ad3f1edae3deb11913bb08d101269370ca7d..7149145b1f3ed3583f8bbe416947a0d68de523db 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 @@ -146,6 +146,7 @@ public class ClassesProcessor implements CodeConstants {
@@ -97,7 +97,7 @@ index 7db5b328969a6dac49054e57b5c00c672ca4ea85..f0d59a81d1f40f95d21ff7699fd349e1
    private static boolean isAnonymous(StructClass cl, StructClass enclosingCl) {
      // checking super class and interfaces
      int[] interfaces = cl.getInterfaces();
-@@ -444,6 +464,7 @@ public class ClassesProcessor implements CodeConstants {
+@@ -441,6 +461,7 @@ public class ClassesProcessor implements CodeConstants {
    private static void destroyWrappers(ClassNode node) {
      node.wrapper = null;
      node.classStruct.releaseResources();
@@ -105,7 +105,7 @@ index 7db5b328969a6dac49054e57b5c00c672ca4ea85..f0d59a81d1f40f95d21ff7699fd349e1
  
      for (ClassNode nd : node.nested) {
        destroyWrappers(nd);
-@@ -503,7 +524,7 @@ public class ClassesProcessor implements CodeConstants {
+@@ -500,7 +521,7 @@ public class ClassesProcessor implements CodeConstants {
  
        anonymousClassType = new VarType(lambda_class_name, true);
  
@@ -114,7 +114,7 @@ index 7db5b328969a6dac49054e57b5c00c672ca4ea85..f0d59a81d1f40f95d21ff7699fd349e1
        if (!is_method_reference) { // content method in the same class, check synthetic flag
          StructMethod mt = classStruct.getMethod(content_method_name, content_method_descriptor);
          is_method_reference = !mt.isSynthetic(); // if not synthetic -> method reference
-@@ -566,4 +587,4 @@ public class ClassesProcessor implements CodeConstants {
+@@ -563,4 +584,4 @@ public class ClassesProcessor implements CodeConstants {
        public boolean is_content_method_static;
      }
    }
@@ -359,7 +359,7 @@ index 0000000000000000000000000000000000000000..fc1d7d67864ab12e894fcdf0ed8e1297
 +  public IVariableNameProvider createFactory(StructMethod structMethod);
 +}
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
-index 2c314dffc92ee5ca40ae8056c93c845f4f2dd6c3..8340673d27079b96d7aee5d32d7f61af7ed80b67 100644
+index abe421340550d258edce046fc901479fa027a23e..cf7f00021cad6818e144342dcbf5b6198e8adeb3 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
 @@ -2,6 +2,7 @@
@@ -386,7 +386,7 @@ index 2c314dffc92ee5ca40ae8056c93c845f4f2dd6c3..8340673d27079b96d7aee5d32d7f61af
  
  import java.util.*;
  import java.util.Map.Entry;
-@@ -849,6 +852,53 @@ public class VarDefinitionHelper {
+@@ -843,6 +846,53 @@ public class VarDefinitionHelper {
      for (Entry<VarVersionPair, VarInfo> e : types.entrySet()) {
        typeNames.put(e.getKey(), e.getValue().getCast());
      }
@@ -440,7 +440,7 @@ index 2c314dffc92ee5ca40ae8056c93c845f4f2dd6c3..8340673d27079b96d7aee5d32d7f61af
      Map<VarVersionPair, LocalVariable> lvts = new HashMap<>();
  
      for (Entry<VarVersionPair, VarInfo> e : types.entrySet()) {
-@@ -858,7 +908,16 @@ public class VarDefinitionHelper {
+@@ -852,7 +902,16 @@ public class VarDefinitionHelper {
          continue;
        }
        LocalVariable lvt = e.getValue().getLVT();
@@ -457,7 +457,7 @@ index 2c314dffc92ee5ca40ae8056c93c845f4f2dd6c3..8340673d27079b96d7aee5d32d7f61af
          varproc.setVarLVT(idx, lvt);
          lvts.put(idx, lvt);
        }
-@@ -992,7 +1051,7 @@ public class VarDefinitionHelper {
+@@ -986,7 +1045,7 @@ public class VarDefinitionHelper {
  
      private VarInfo(LocalVariable lvt, VarType type) {
        if (lvt != null && lvt.getSignature() != null)
@@ -467,7 +467,7 @@ index 2c314dffc92ee5ca40ae8056c93c845f4f2dd6c3..8340673d27079b96d7aee5d32d7f61af
          this.cast = ExprProcessor.getCastTypeName(lvt.getVarType(), false, Collections.emptyList());
        else if (type != null)
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructMethod.java b/src/org/jetbrains/java/decompiler/struct/StructMethod.java
-index e3d5edf6e78c37206e5a37abaf24efbb6eb6dfa3..7237f2527530d8dea8d82f934c273c980ada0682 100644
+index d48e950e7511d2a00ac9885d5dc7d4ff524bbb37..08efdbaa173380dbbc0cd30c5ec5d43b0c2cf074 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructMethod.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructMethod.java
 @@ -4,6 +4,7 @@ package org.jetbrains.java.decompiler.struct;
@@ -495,7 +495,7 @@ index e3d5edf6e78c37206e5a37abaf24efbb6eb6dfa3..7237f2527530d8dea8d82f934c273c98
  
    private StructMethod(int accessFlags,
                         Map<String, StructGeneralAttribute> attributes,
-@@ -384,6 +388,17 @@ public class StructMethod extends StructMember {
+@@ -338,6 +342,17 @@ public class StructMethod extends StructMember {
      return seq;
    }
  
@@ -813,10 +813,10 @@ index 0000000000000000000000000000000000000000..a41c910e58c3c0e16e6b13a90fe9f34a
 +}
 diff --git a/test/org/jetbrains/java/decompiler/JADTest.java b/test/org/jetbrains/java/decompiler/JADTest.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..176b850d338fbfbbd65eab8405c46f35de662c7d
+index 0000000000000000000000000000000000000000..5348637179299ad07934495be8216583da36897b
 --- /dev/null
 +++ b/test/org/jetbrains/java/decompiler/JADTest.java
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,36 @@
 +/*
 + * Copyright 2000-2017 JetBrains s.r.o.
 + *
@@ -837,15 +837,17 @@ index 0000000000000000000000000000000000000000..176b850d338fbfbbd65eab8405c46f35
 +import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
 +import org.junit.Test;
 +
++import java.util.Map;
++
 +public class JADTest extends SingleClassesTestBase {
 +
 +    @Override
-+    protected String[] getDecompilerOptions() {
-+      return new String[] {
++    protected Map<String, String> getDecompilerOptions() {
++      return Map.of(
 +        IFernflowerPreferences.BYTECODE_SOURCE_MAPPING, "1",
 +        IFernflowerPreferences.DUMP_ORIGINAL_LINES, "1",
 +        IFernflowerPreferences.USE_JAD_VARNAMING, "1"
-+      };
++      );
 +    }
 +
 +    @Test public void testClassFields() { doTest("pkg/TestJADNaming"); }

--- a/FernFlower-Patches/0011-JAD-Style-variable-naming.patch
+++ b/FernFlower-Patches/0011-JAD-Style-variable-naming.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] JAD Style variable naming
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 31236841f1b4bf4f452f30d6b95f21fcc99ec5b9..0e98490e2b4e68eaad0fce79ce4b6e3b7d636ad5 100644
+index 31236841f1b4bf4f452f30d6b95f21fcc99ec5b9..aa990406ef8d91838aa2d928bdfb183fe9e19333 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -117,15 +117,20 @@ public class ClassWriter {
@@ -14,7 +14,7 @@ index 31236841f1b4bf4f452f30d6b95f21fcc99ec5b9..0e98490e2b4e68eaad0fce79ce4b6e3b
  
 +              List<TypeAnnotation> iParameterTypeAnnotations = TargetInfo.FormalParameterTarget.extract(parameterTypeAnnotations, i);
 +              VarType type = md_content.params[i];
-+              String typeName = ExprProcessor.getCastTypeName(type, TypeAnnotationWriteHelper.create(iParameterTypeAnnotations));
++              String typeName = ExprProcessor.getCastTypeName(type, explicitlyTyped, TypeAnnotationWriteHelper.create(iParameterTypeAnnotations));
                if (explicitlyTyped) {
 -                List<TypeAnnotation> iParameterTypeAnnotations = TargetInfo.FormalParameterTarget.extract(parameterTypeAnnotations, i);
 -                VarType type = md_content.params[i];

--- a/FernFlower-Patches/0011-JAD-Style-variable-naming.patch
+++ b/FernFlower-Patches/0011-JAD-Style-variable-naming.patch
@@ -359,15 +359,16 @@ index 0000000000000000000000000000000000000000..fc1d7d67864ab12e894fcdf0ed8e1297
 +  public IVariableNameProvider createFactory(StructMethod structMethod);
 +}
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java b/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
-index c1126a2b7559e2f8a69a54ee0b7db2ceda3d9776..614591114f548010b35893d5199afe4d022ee88f 100644
+index c1126a2b7559e2f8a69a54ee0b7db2ceda3d9776..964bff5a00b35969fa08e48ca355801fe2882ce8 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
-@@ -158,7 +158,7 @@ public class ClassWrapper {
+@@ -158,7 +158,8 @@ public class ClassWrapper {
    }
  
    private static void applyDebugInfo(StructMethod mt, VarProcessor varProc, MethodWrapper methodWrapper) {
 -    if (DecompilerContext.getOption(IFernflowerPreferences.USE_DEBUG_VAR_NAMES)) {
-+    if (DecompilerContext.getOption(IFernflowerPreferences.USE_DEBUG_VAR_NAMES) && !DecompilerContext.getOption(IFernflowerPreferences.USE_JAD_VARNAMING)) {
++    // Only rename parameters in the var processor if we aren't already renaming them with JAD naming
++    if (DecompilerContext.getOption(IFernflowerPreferences.USE_DEBUG_VAR_NAMES) && (!DecompilerContext.getOption(IFernflowerPreferences.USE_JAD_VARNAMING) || !DecompilerContext.getOption(IFernflowerPreferences.USE_JAD_PARAMETER_RENAMING))) {
        StructLocalVariableTableAttribute attr = mt.getLocalVariableAttr();
        if (attr != null) {
          // only param names here

--- a/FernFlower-Patches/0012-Fix-primitive-un-boxing-issues.patch
+++ b/FernFlower-Patches/0012-Fix-primitive-un-boxing-issues.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix primitive un/boxing issues.
 
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
-index 3534ca10c55713f5856163b7325e0c6e71c2c502..6ddd7caf2f8deeb0ebbe89d17ad96bf092e66cba 100644
+index e005b2941b4e76b736b8d00905726ac8500c3dc2..bc8c421206b44539c2f2da859658102f2b71af73 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
-@@ -1031,12 +1031,14 @@ public class ExprProcessor implements CodeConstants {
+@@ -1027,12 +1027,14 @@ public class ExprProcessor implements CodeConstants {
  
      if (unbox) {
        // "unbox" invocation parameters, e.g. 'byteSet.add((byte)123)' or 'new ShortContainer((short)813)'
@@ -30,31 +30,31 @@ index 3534ca10c55713f5856163b7325e0c6e71c2c502..6ddd7caf2f8deeb0ebbe89d17ad96bf0
        }
      }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
-index f227df9c03dd6ae3972b80ce11dc36d468addea3..f2dda05e818d680f72d73b22b56a76dd18656ece 100644
+index 0a6281872ae535dbc0569cb08b301d58b6c5c9a3..513ae5c2d5e1674694e86701e507c1e46c2f031b 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
-@@ -563,6 +563,19 @@ public class FunctionExprent extends Exprent {
-     }
- 
-     if (funcType <= FUNCTION_I2S) {
-+      // We can't directly cast some object types, so we need to make sure the unboxing happens.
-+      // The types seem to be inconsistant but there is no harm in forcing the unboxing when not strictly needed.
-+      // Type   | Works | Doesn't
-+      // Integer| LFD   | BCS
-+      // Long   | FD    | I
-+      // Float  | D     | IL
-+      // Double |       | ILF
-+      if (lstOperands.get(0).type == Exprent.EXPRENT_INVOCATION) {
-+        InvocationExprent inv = (InvocationExprent)lstOperands.get(0);
-+        if (inv.isUnboxingCall()) {
-+          inv.forceUnboxing(true);
+@@ -534,6 +534,19 @@ public class FunctionExprent extends Exprent {
+           .append(")");
+       default -> {
+         assert funcType <= FUNCTION_I2S;
++        // We can't directly cast some object types, so we need to make sure the unboxing happens.
++        // The types seem to be inconsistant but there is no harm in forcing the unboxing when not strictly needed.
++        // Type   | Works | Doesn't
++        // Integer| LFD   | BCS
++        // Long   | FD    | I
++        // Float  | D     | IL
++        // Double |       | ILF
++        if (lstOperands.get(0).type == Exprent.EXPRENT_INVOCATION) {
++          InvocationExprent inv = (InvocationExprent)lstOperands.get(0);
++          if (inv.isUnboxingCall()) {
++            inv.forceUnboxing(true);
++          }
 +        }
-+      }
-       return wrapOperandString(lstOperands.get(0), true, indent, tracer).prepend("(" + ExprProcessor.getTypeName(
-         TYPES[funcType - FUNCTION_I2L], Collections.emptyList()) + ")");
-     }
+         yield wrapOperandString(lstOperands.get(0), true, indent, tracer).prepend("(" + ExprProcessor.getTypeName(
+           TYPES[funcType - FUNCTION_I2L], Collections.emptyList()) + ")");
+       }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 104f2f112c621e3433bdbc1ce5afb05dee272833..cba6b5ab608f96de2ef6781d8c1cfec994e3a000 100644
+index 6eab93e5ed261b0903ae3fe4677118bfa2d1d60e..7ebc36c1de0265db791b47b9558c41e303a3d7b2 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -59,6 +59,8 @@ public class InvocationExprent extends Exprent {
@@ -66,7 +66,7 @@ index 104f2f112c621e3433bdbc1ce5afb05dee272833..cba6b5ab608f96de2ef6781d8c1cfec9
  
    public InvocationExprent() {
      super(EXPRENT_INVOCATION);
-@@ -263,10 +265,10 @@ public class InvocationExprent extends Exprent {
+@@ -256,10 +258,10 @@ public class InvocationExprent extends Exprent {
      }
  
      if (isStatic) {
@@ -79,7 +79,7 @@ index 104f2f112c621e3433bdbc1ce5afb05dee272833..cba6b5ab608f96de2ef6781d8c1cfec9
          return buf;
        }
  
-@@ -312,16 +314,36 @@ public class InvocationExprent extends Exprent {
+@@ -305,16 +307,36 @@ public class InvocationExprent extends Exprent {
            TextUtil.writeQualifiedSuper(buf, super_qualifier);
          }
          else if (instance != null) {
@@ -121,7 +121,7 @@ index 104f2f112c621e3433bdbc1ce5afb05dee272833..cba6b5ab608f96de2ef6781d8c1cfec9
  
            if (rightType.equals(VarType.VARTYPE_OBJECT) && !leftType.equals(rightType)) {
              buf.append("((").append(ExprProcessor.getCastTypeName(leftType, Collections.emptyList())).append(")");
-@@ -419,9 +441,88 @@ public class InvocationExprent extends Exprent {
+@@ -410,9 +432,88 @@ public class InvocationExprent extends Exprent {
        }
      }
  
@@ -211,7 +211,7 @@ index 104f2f112c621e3433bdbc1ce5afb05dee272833..cba6b5ab608f96de2ef6781d8c1cfec9
        if (mask == null || mask.get(i) == null) {
          TextBuffer buff = new TextBuffer();
          boolean ambiguous = setAmbiguousParameters.get(i);
-@@ -455,7 +556,7 @@ public class InvocationExprent extends Exprent {
+@@ -446,7 +547,7 @@ public class InvocationExprent extends Exprent {
          */
  
          // 'byte' and 'short' literals need an explicit narrowing type cast when used as a parameter
@@ -220,7 +220,7 @@ index 104f2f112c621e3433bdbc1ce5afb05dee272833..cba6b5ab608f96de2ef6781d8c1cfec9
  
          // the last "new Object[0]" in the vararg call is not printed
          if (buff.length() > 0) {
-@@ -508,7 +609,7 @@ public class InvocationExprent extends Exprent {
+@@ -499,7 +600,7 @@ public class InvocationExprent extends Exprent {
          }
  
          if (paramType == CodeConstants.TYPE_BYTECHAR || paramType == CodeConstants.TYPE_SHORTCHAR) {
@@ -229,7 +229,7 @@ index 104f2f112c621e3433bdbc1ce5afb05dee272833..cba6b5ab608f96de2ef6781d8c1cfec9
              return true;
            }
          }
-@@ -569,6 +670,18 @@ public class InvocationExprent extends Exprent {
+@@ -550,6 +651,18 @@ public class InvocationExprent extends Exprent {
      return !isStatic && parameters.size() == 0 && className.equals(UNBOXING_METHODS.get(name));
    }
  
@@ -248,7 +248,7 @@ index 104f2f112c621e3433bdbc1ce5afb05dee272833..cba6b5ab608f96de2ef6781d8c1cfec9
    private List<StructMethod> getMatchedDescriptors() {
      List<StructMethod> matches = new ArrayList<>();
      StructClass cl = DecompilerContext.getStructContext().getClass(className);
-@@ -598,6 +711,8 @@ public class InvocationExprent extends Exprent {
+@@ -579,6 +692,8 @@ public class InvocationExprent extends Exprent {
        return EMPTY_BIT_SET;
      }
  
@@ -257,7 +257,7 @@ index 104f2f112c621e3433bdbc1ce5afb05dee272833..cba6b5ab608f96de2ef6781d8c1cfec9
      // check if a call is unambiguous
      StructMethod mt = cl.getMethod(InterpreterUtil.makeUniqueKey(name, stringDescriptor));
      if (mt != null) {
-@@ -607,18 +722,50 @@ public class InvocationExprent extends Exprent {
+@@ -588,18 +703,50 @@ public class InvocationExprent extends Exprent {
          for (int i = 0; i < md.params.length; i++) {
            if (!md.params[i].equals(parameters.get(i).getExprType())) {
              exact = false;

--- a/FernFlower-Patches/0013-Add-Minecraft-test-framework.patch
+++ b/FernFlower-Patches/0013-Add-Minecraft-test-framework.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add Minecraft test framework
 
 diff --git a/test/org/jetbrains/java/decompiler/MinecraftTest.java b/test/org/jetbrains/java/decompiler/MinecraftTest.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c00385f0f59014289ddb152e4dc4e908a8427fb6
+index 0000000000000000000000000000000000000000..1f9a9dd03dab30cdb464bfc4901b9c592d558b8f
 --- /dev/null
 +++ b/test/org/jetbrains/java/decompiler/MinecraftTest.java
-@@ -0,0 +1,139 @@
+@@ -0,0 +1,136 @@
 +package org.jetbrains.java.decompiler;
 +
 +import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -30,14 +30,14 @@ index 0000000000000000000000000000000000000000..c00385f0f59014289ddb152e4dc4e908
 +import com.google.gson.Gson;
 +import com.google.gson.GsonBuilder;
 +
-+public class MinecraftTest  extends SingleClassesTestBase {
++public class MinecraftTest extends SingleClassesTestBase {
 +  private static final String MC_PATH = "Z:\\Projects\\MCP\\BlueMining\\mcp_update\\new";
 +  private static final Map<String, String> RESULTS = new HashMap<>();
 +  private static final Gson GSON = new GsonBuilder().create();
 +
 +  @Override
-+  protected String[] getDecompilerOptions() {
-+    return new String[] {
++  protected Map<String, String> getDecompilerOptions() {
++    return Map.of(
 +      IFernflowerPreferences.DECOMPILE_INNER,"1",
 +      IFernflowerPreferences.DECOMPILE_GENERIC_SIGNATURES,"1",
 +      IFernflowerPreferences.ASCII_STRING_CHARACTERS,"1",
@@ -46,7 +46,7 @@ index 0000000000000000000000000000000000000000..c00385f0f59014289ddb152e4dc4e908
 +      IFernflowerPreferences.REMOVE_BRIDGE, "1",
 +      IFernflowerPreferences.USE_DEBUG_VAR_NAMES, "1",
 +      IFernflowerPreferences.INCLUDE_ENTIRE_CLASSPATH, "1"
-+    };
++    );
 +  }
 +
 +  @Override
@@ -55,8 +55,7 @@ index 0000000000000000000000000000000000000000..c00385f0f59014289ddb152e4dc4e908
 +      private ConsoleDecompiler decompiler;
 +
 +      @Override
-+      public void setUp(String... optionPairs) throws IOException {
-+        assertThat(optionPairs.length % 2).isEqualTo(0);
++      public void setUp(Map<String, String> customOptions) throws IOException {
 +        File tempDir = File.createTempFile("decompiler_test_", "_dir");
 +        assertThat(tempDir.delete()).isTrue();
 +
@@ -70,9 +69,7 @@ index 0000000000000000000000000000000000000000..c00385f0f59014289ddb152e4dc4e908
 +        options.put(IFernflowerPreferences.REMOVE_BRIDGE, "1");
 +        options.put(IFernflowerPreferences.LITERALS_AS_IS, "1");
 +        options.put(IFernflowerPreferences.UNIT_TEST_MODE, "1");
-+        for (int i = 0; i < optionPairs.length; i += 2) {
-+          options.put(optionPairs[i], optionPairs[i + 1]);
-+        }
++        options.putAll(customOptions);
 +        decompiler = new ConsoleDecompiler(targetDir, options, new PrintStreamLogger(System.out)) {
 +          @Override
 +          public void saveClassFile(String path, String qualifiedName, String entryName, String content, int[] mapping) {

--- a/FernFlower-Patches/0014-Add-better-debug-logging.patch
+++ b/FernFlower-Patches/0014-Add-better-debug-logging.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add better debug logging
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 0e98490e2b4e68eaad0fce79ce4b6e3b7d636ad5..045b268134f11dbd70acdcd5b91906d7925b4073 100644
+index aa990406ef8d91838aa2d928bdfb183fe9e19333..410a83345e5e145962137536b95ca4f22185d678 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -824,7 +824,7 @@ public class ClassWriter {

--- a/FernFlower-Patches/0014-Add-better-debug-logging.patch
+++ b/FernFlower-Patches/0014-Add-better-debug-logging.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add better debug logging
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 54a54ca34e7dc8222688521bd30023a543c189a9..d9ea07f150642c1528e2729dfea9f0d49b9119b3 100644
+index 0e98490e2b4e68eaad0fce79ce4b6e3b7d636ad5..045b268134f11dbd70acdcd5b91906d7925b4073 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -824,7 +824,7 @@ public class ClassWriter {

--- a/FernFlower-Patches/0014-Add-better-debug-logging.patch
+++ b/FernFlower-Patches/0014-Add-better-debug-logging.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add better debug logging
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index a095a246733384782870a1b9cac17ede8fd558dc..e2545c0d094a25e13efaa554704198d7fa15e0f1 100644
+index 0e98490e2b4e68eaad0fce79ce4b6e3b7d636ad5..045b268134f11dbd70acdcd5b91906d7925b4073 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -824,7 +824,7 @@ public class ClassWriter {
@@ -31,7 +31,7 @@ index c1126a2b7559e2f8a69a54ee0b7db2ceda3d9776..9152bdbdb93f50fdd45c2ea3c353188d
          isError = true;
        }
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructContext.java b/src/org/jetbrains/java/decompiler/struct/StructContext.java
-index 301737310f3d346cc2229395551d504a34cb6dbc..b039480288011a5b9bdca635f7c66e85c92eb311 100644
+index 85fc95d87bd7e672613f6c1beb75b2d56d1d759f..2b6448c01968ddb6bde275304e0073837d7fa575 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructContext.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructContext.java
 @@ -3,6 +3,7 @@ package org.jetbrains.java.decompiler.struct;
@@ -50,7 +50,7 @@ index 301737310f3d346cc2229395551d504a34cb6dbc..b039480288011a5b9bdca635f7c66e85
      try (ZipFile archive = type == ContextUnit.TYPE_JAR ? new JarFile(file) : new ZipFile(file)) {
        Enumeration<? extends ZipEntry> entries = archive.entries();
        while (entries.hasMoreElements()) {
-@@ -140,6 +142,7 @@ public class StructContext {
+@@ -145,6 +147,7 @@ public class StructContext {
          if (!entry.isDirectory()) {
            if (name.endsWith(".class")) {
              byte[] bytes = InterpreterUtil.getBytes(archive, entry);
@@ -59,34 +59,27 @@ index 301737310f3d346cc2229395551d504a34cb6dbc..b039480288011a5b9bdca635f7c66e85
              classes.put(cl.qualifiedName, cl);
              unit.addClass(cl, name);
 diff --git a/src/org/jetbrains/java/decompiler/struct/consts/ConstantPool.java b/src/org/jetbrains/java/decompiler/struct/consts/ConstantPool.java
-index 037cb437ee5e93941364d73e3d88c1c9f14ac517..d4e98b9aea54e04c038641e472e215fc62e496a2 100644
+index 6da1e0d2c84e9c2c102bf0ffafabddeee2dcadd0..a824d326da2bc6a2c864d2da75af11545b8cf71e 100644
 --- a/src/org/jetbrains/java/decompiler/struct/consts/ConstantPool.java
 +++ b/src/org/jetbrains/java/decompiler/struct/consts/ConstantPool.java
-@@ -113,7 +113,8 @@ public class ConstantPool implements NewClassNameBuilder {
+@@ -94,7 +94,8 @@ public class ConstantPool implements NewClassNameBuilder {
      int size = in.readUnsignedShort();
  
      for (int i = 1; i < size; i++) {
 -      switch (in.readUnsignedByte()) {
 +      byte tag = (byte)in.readUnsignedByte();
 +      switch (tag) {
-         case CodeConstants.CONSTANT_Utf8:
-           in.readUTF();
-           break;
-@@ -138,11 +139,17 @@ public class ConstantPool implements NewClassNameBuilder {
-         case CodeConstants.CONSTANT_Class:
-         case CodeConstants.CONSTANT_String:
-         case CodeConstants.CONSTANT_MethodType:
-+        case CodeConstants.CONSTANT_Module:
-+        case CodeConstants.CONSTANT_Package:
-           in.discard(2);
-           break;
- 
-         case CodeConstants.CONSTANT_MethodHandle:
-           in.discard(3);
-+          break;
-+
-+        default:
-+            throw new RuntimeException("Invalid Constant Pool entry #" + i + " Type: " + tag);
+         case CodeConstants.CONSTANT_Utf8 -> in.readUTF();
+         case CodeConstants.CONSTANT_Integer, CodeConstants.CONSTANT_Float, CodeConstants.CONSTANT_Fieldref, CodeConstants.CONSTANT_Methodref, CodeConstants.CONSTANT_InterfaceMethodref, CodeConstants.CONSTANT_NameAndType, CodeConstants.CONSTANT_Dynamic, CodeConstants.CONSTANT_InvokeDynamic ->
+           in.discard(4);
+@@ -102,8 +103,9 @@ public class ConstantPool implements NewClassNameBuilder {
+           in.discard(8);
+           i++;
+         }
+-        case CodeConstants.CONSTANT_Class, CodeConstants.CONSTANT_String, CodeConstants.CONSTANT_MethodType -> in.discard(2);
++        case CodeConstants.CONSTANT_Class, CodeConstants.CONSTANT_String, CodeConstants.CONSTANT_MethodType, CodeConstants.CONSTANT_Module, CodeConstants.CONSTANT_Package -> in.discard(2);
+         case CodeConstants.CONSTANT_MethodHandle -> in.discard(3);
++        default -> throw new RuntimeException("Invalid Constant Pool entry #" + i + " Type: " + tag);
        }
      }
    }

--- a/FernFlower-Patches/0014-Add-better-debug-logging.patch
+++ b/FernFlower-Patches/0014-Add-better-debug-logging.patch
@@ -18,7 +18,7 @@ index 0e98490e2b4e68eaad0fce79ce4b6e3b7d636ad5..045b268134f11dbd70acdcd5b91906d7
              methodWrapper.decompiledWithErrors = true;
            }
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java b/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
-index c1126a2b7559e2f8a69a54ee0b7db2ceda3d9776..9152bdbdb93f50fdd45c2ea3c353188d82efb77d 100644
+index 614591114f548010b35893d5199afe4d022ee88f..3995b9084290b8056aa60104601dabbe14c12e66 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
 @@ -110,7 +110,7 @@ public class ClassWrapper {

--- a/FernFlower-Patches/0014-Add-better-debug-logging.patch
+++ b/FernFlower-Patches/0014-Add-better-debug-logging.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add better debug logging
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 0e98490e2b4e68eaad0fce79ce4b6e3b7d636ad5..045b268134f11dbd70acdcd5b91906d7925b4073 100644
+index 54a54ca34e7dc8222688521bd30023a543c189a9..d9ea07f150642c1528e2729dfea9f0d49b9119b3 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -824,7 +824,7 @@ public class ClassWriter {

--- a/FernFlower-Patches/0014-Add-better-debug-logging.patch
+++ b/FernFlower-Patches/0014-Add-better-debug-logging.patch
@@ -18,7 +18,7 @@ index 0e98490e2b4e68eaad0fce79ce4b6e3b7d636ad5..045b268134f11dbd70acdcd5b91906d7
              methodWrapper.decompiledWithErrors = true;
            }
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java b/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
-index 614591114f548010b35893d5199afe4d022ee88f..3995b9084290b8056aa60104601dabbe14c12e66 100644
+index 964bff5a00b35969fa08e48ca355801fe2882ce8..0c53385b28507ef4fb0ffb2ff6c58298dc9a5bde 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/ClassWrapper.java
 @@ -110,7 +110,7 @@ public class ClassWrapper {

--- a/FernFlower-Patches/0015-Add-new-command-line-argument-sef-SkipExtraFiles-To-.patch
+++ b/FernFlower-Patches/0015-Add-new-command-line-argument-sef-SkipExtraFiles-To-.patch
@@ -27,7 +27,7 @@ index 9641d4ea515d943009e87fe180a9e8a2569e8b14..8337607e067c1c7cdc803058eab4bfb0
      return Collections.unmodifiableMap(defaults);
    }
 diff --git a/src/org/jetbrains/java/decompiler/struct/ContextUnit.java b/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
-index c77cfaaebf859586a7201e481cf328044f860dcf..57c74fd4bdd195287f616c9b5138bad87b2a96da 100644
+index 9482a192692ca6a05d2bb24f3dfca06c25580d80..2d68b9418fcde253948cfa7ffc9c43519884ddce 100644
 --- a/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
 +++ b/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
 @@ -54,6 +54,8 @@ public class ContextUnit {
@@ -39,7 +39,7 @@ index c77cfaaebf859586a7201e481cf328044f860dcf..57c74fd4bdd195287f616c9b5138bad8
      otherEntries.add(new String[]{fullPath, entry});
    }
  
-@@ -153,4 +155,4 @@ public class ContextUnit {
+@@ -151,4 +153,4 @@ public class ContextUnit {
    public List<StructClass> getClasses() {
      return classes;
    }

--- a/FernFlower-Patches/0017-Enhance-Generic-Invocations-Temporarily.patch
+++ b/FernFlower-Patches/0017-Enhance-Generic-Invocations-Temporarily.patch
@@ -24,10 +24,10 @@ index 33150f76d649f124bc818036b0f7c6331d5e74be..e2f36231b51e547b4aae610c8450d83b
          left = left.resizeArrayDim(0);
          right = right.resizeArrayDim(0);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
-index f2dda05e818d680f72d73b22b56a76dd18656ece..2ce8932cb33e4881de5ed09b728781804cdced57 100644
+index 513ae5c2d5e1674694e86701e507c1e46c2f031b..cb80c8d7be08b9f3d6770541910832bb3d9a58a9 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
-@@ -298,11 +298,11 @@ public class FunctionExprent extends Exprent {
+@@ -278,11 +278,11 @@ public class FunctionExprent extends Exprent {
        VarType right = lstOperands.get(0).getInferredExprType(upperBound);
        VarType cast = lstOperands.get(1).getExprType();
  
@@ -41,7 +41,7 @@ index f2dda05e818d680f72d73b22b56a76dd18656ece..2ce8932cb33e4881de5ed09b72878180
            arrayDim = upperBound.getArrayDim();
            upperBound = upperBound.resizeArrayDim(0);
            right = right.resizeArrayDim(0);
-@@ -322,6 +322,15 @@ public class FunctionExprent extends Exprent {
+@@ -302,6 +302,15 @@ public class FunctionExprent extends Exprent {
              this.needsCast = false;
            }
          }
@@ -57,16 +57,7 @@ index f2dda05e818d680f72d73b22b56a76dd18656ece..2ce8932cb33e4881de5ed09b72878180
        }
        else { //TODO: Capture generics to make cast better?
          this.needsCast = right.getType() == CodeConstants.TYPE_NULL || !DecompilerContext.getStructContext().instanceOf(right.getValue(), cast.getValue());
-@@ -580,7 +589,7 @@ public class FunctionExprent extends Exprent {
-         TYPES[funcType - FUNCTION_I2L], Collections.emptyList()) + ")");
-     }
- 
--    //		return "<unknown function>";
-+    //        return "<unknown function>";
-     throw new RuntimeException("invalid function");
-   }
- 
-@@ -675,4 +684,4 @@ public class FunctionExprent extends Exprent {
+@@ -644,4 +653,4 @@ public class FunctionExprent extends Exprent {
      Integer type = (Integer)matchNode.getRuleValue(MatchProperties.EXPRENT_FUNCTYPE);
      return type == null || this.funcType == type;
    }
@@ -74,10 +65,10 @@ index f2dda05e818d680f72d73b22b56a76dd18656ece..2ce8932cb33e4881de5ed09b72878180
 \ No newline at end of file
 +}
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index cba6b5ab608f96de2ef6781d8c1cfec994e3a000..c1a645bfe508513263618dc04da1d66eb99e7d0e 100644
+index 7ebc36c1de0265db791b47b9558c41e303a3d7b2..28bae14b7342dd6897e638889682178248039ad7 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-@@ -408,6 +408,7 @@ public class InvocationExprent extends Exprent {
+@@ -399,6 +399,7 @@ public class InvocationExprent extends Exprent {
          isEnum = newNode.classStruct.hasModifier(CodeConstants.ACC_ENUM) && DecompilerContext.getOption(IFernflowerPreferences.DECOMPILE_ENUM);
        }
      }
@@ -85,7 +76,7 @@ index cba6b5ab608f96de2ef6781d8c1cfec994e3a000..c1a645bfe508513263618dc04da1d66e
      List<StructMethod> matches = getMatchedDescriptors();
      BitSet setAmbiguousParameters = getAmbiguousParameters(matches);
      StructMethod desc = null;
-@@ -468,7 +469,7 @@ public class InvocationExprent extends Exprent {
+@@ -459,7 +460,7 @@ public class InvocationExprent extends Exprent {
            if (stClass != null) {
              nextMethod:
              for (StructMethod mt : stClass.getMethods()) {
@@ -94,7 +85,7 @@ index cba6b5ab608f96de2ef6781d8c1cfec994e3a000..c1a645bfe508513263618dc04da1d66e
                  MethodDescriptor md = MethodDescriptor.parseDescriptor(mt.getDescriptor());
                  if (md.params.length == descriptor.params.length) {
                    for (int x = 0; x < md.params.length; x++) {
-@@ -503,7 +504,7 @@ public class InvocationExprent extends Exprent {
+@@ -494,7 +495,7 @@ public class InvocationExprent extends Exprent {
            StructClass stClass = DecompilerContext.getStructContext().getClass(className);
            if (stClass != null) {
              for (StructMethod mt : stClass.getMethods()) {
@@ -103,7 +94,7 @@ index cba6b5ab608f96de2ef6781d8c1cfec994e3a000..c1a645bfe508513263618dc04da1d66e
                  MethodDescriptor md = MethodDescriptor.parseDescriptor(mt.getDescriptor());
                  if (md.params.length == descriptor.params.length) {
                    if (md.params[i].getType() == CodeConstants.TYPE_OBJECT) {
-@@ -520,6 +521,22 @@ public class InvocationExprent extends Exprent {
+@@ -511,6 +512,22 @@ public class InvocationExprent extends Exprent {
        }
      }
  
@@ -126,7 +117,7 @@ index cba6b5ab608f96de2ef6781d8c1cfec994e3a000..c1a645bfe508513263618dc04da1d66e
  
      boolean firstParameter = true;
      for (int i = start; i < this.parameters.size(); i++) {
-@@ -684,27 +701,98 @@ public class InvocationExprent extends Exprent {
+@@ -665,27 +682,98 @@ public class InvocationExprent extends Exprent {
  
    private List<StructMethod> getMatchedDescriptors() {
      List<StructMethod> matches = new ArrayList<>();

--- a/FernFlower-Patches/0018-Add-cfg-argument-Used-to-specify-a-text-file-with-ad.patch
+++ b/FernFlower-Patches/0018-Add-cfg-argument-Used-to-specify-a-text-file-with-ad.patch
@@ -71,7 +71,7 @@ index d0ae9a7c3b20de44cb202390cc0dfd4d690fee64..c5398222893b170023afa13fa5b6c773
 \ No newline at end of file
 +}
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructContext.java b/src/org/jetbrains/java/decompiler/struct/StructContext.java
-index b039480288011a5b9bdca635f7c66e85c92eb311..1c0cd6934e9f2225ff1fa40185f0a97ac9ae4daf 100644
+index 2b6448c01968ddb6bde275304e0073837d7fa575..58290caab9b84bb73291ea8af64b6897c01b162a 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructContext.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructContext.java
 @@ -93,6 +93,7 @@ public class StructContext {

--- a/FernFlower-Patches/0020-Add-a-metadata-file-named-fernflower_abstract_parame.patch
+++ b/FernFlower-Patches/0020-Add-a-metadata-file-named-fernflower_abstract_parame.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Add a metadata file named
 Format: ClassName MethodName Descriptor Param1[ Param2...]
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 045b268134f11dbd70acdcd5b91906d7925b4073..5a06aaa68ee8df9d5ff45c670b8395d6125916fa 100644
+index d9ea07f150642c1528e2729dfea9f0d49b9119b3..c755eb4e6d618192a760d039c139e4e16de668f3 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -755,7 +755,11 @@ public class ClassWriter {

--- a/FernFlower-Patches/0020-Add-a-metadata-file-named-fernflower_abstract_parame.patch
+++ b/FernFlower-Patches/0020-Add-a-metadata-file-named-fernflower_abstract_parame.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Add a metadata file named
 Format: ClassName MethodName Descriptor Param1[ Param2...]
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index d9ea07f150642c1528e2729dfea9f0d49b9119b3..c755eb4e6d618192a760d039c139e4e16de668f3 100644
+index 045b268134f11dbd70acdcd5b91906d7925b4073..5a06aaa68ee8df9d5ff45c670b8395d6125916fa 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -755,7 +755,11 @@ public class ClassWriter {

--- a/FernFlower-Patches/0020-Add-a-metadata-file-named-fernflower_abstract_parame.patch
+++ b/FernFlower-Patches/0020-Add-a-metadata-file-named-fernflower_abstract_parame.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Add a metadata file named
 Format: ClassName MethodName Descriptor Param1[ Param2...]
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index e2545c0d094a25e13efaa554704198d7fa15e0f1..eb5a603ab6ffb2277d2c12a2d5e4a141d633964e 100644
+index 045b268134f11dbd70acdcd5b91906d7925b4073..5a06aaa68ee8df9d5ff45c670b8395d6125916fa 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -755,7 +755,11 @@ public class ClassWriter {
@@ -24,7 +24,7 @@ index e2545c0d094a25e13efaa554704198d7fa15e0f1..eb5a603ab6ffb2277d2c12a2d5e4a141
  
              paramCount++;
 diff --git a/src/org/jetbrains/java/decompiler/struct/ContextUnit.java b/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
-index 57c74fd4bdd195287f616c9b5138bad87b2a96da..c33a9aa83f61a22940b1864d6bbfcdd7ba78e38d 100644
+index 2d68b9418fcde253948cfa7ffc9c43519884ddce..7b0946ed0de6af2dbe2043332650a09880027726 100644
 --- a/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
 +++ b/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
 @@ -7,12 +7,16 @@ import org.jetbrains.java.decompiler.main.extern.IResultSaver;
@@ -70,7 +70,7 @@ index 57c74fd4bdd195287f616c9b5138bad87b2a96da..c33a9aa83f61a22940b1864d6bbfcdd7
          return;
      otherEntries.add(new String[]{fullPath, entry});
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructContext.java b/src/org/jetbrains/java/decompiler/struct/StructContext.java
-index 1c0cd6934e9f2225ff1fa40185f0a97ac9ae4daf..bbbec18e87c940d7daa6983a9ca2b5220e7e2470 100644
+index 58290caab9b84bb73291ea8af64b6897c01b162a..1274df19dd56bf8061384af8d3db78856f836928 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructContext.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructContext.java
 @@ -4,14 +4,18 @@ package org.jetbrains.java.decompiler.struct;
@@ -100,7 +100,7 @@ index 1c0cd6934e9f2225ff1fa40185f0a97ac9ae4daf..bbbec18e87c940d7daa6983a9ca2b522
  
    public StructContext(IResultSaver saver, IDecompiledData decompiledData, LazyLoader loader) {
      this.saver = saver;
-@@ -203,4 +208,24 @@ public class StructContext {
+@@ -208,4 +213,24 @@ public class StructContext {
  
      return false;
    }

--- a/FernFlower-Patches/0020-Add-a-metadata-file-named-fernflower_abstract_parame.patch
+++ b/FernFlower-Patches/0020-Add-a-metadata-file-named-fernflower_abstract_parame.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Add a metadata file named
 Format: ClassName MethodName Descriptor Param1[ Param2...]
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 045b268134f11dbd70acdcd5b91906d7925b4073..5a06aaa68ee8df9d5ff45c670b8395d6125916fa 100644
+index 410a83345e5e145962137536b95ca4f22185d678..0fb12b6d99f3c1dc7652e5ab49e36683d7a6db08 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -755,7 +755,11 @@ public class ClassWriter {

--- a/FernFlower-Patches/0021-Synthetic-getClass-Objects.requireNonNull-cleanup.patch
+++ b/FernFlower-Patches/0021-Synthetic-getClass-Objects.requireNonNull-cleanup.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Synthetic getClass/Objects.requireNonNull cleanup
 
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
-index 6ddd7caf2f8deeb0ebbe89d17ad96bf092e66cba..b744ddbb35bcc08716826324c1895ce8f860d31b 100644
+index bc8c421206b44539c2f2da859658102f2b71af73..b2963191fe5c6e162346fc98f9cefd122da23ee2 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 @@ -591,6 +591,23 @@ public class ExprProcessor implements CodeConstants {
@@ -33,10 +33,10 @@ index 6ddd7caf2f8deeb0ebbe89d17ad96bf092e66cba..b744ddbb35bcc08716826324c1895ce8
          case opc_pop2:
            if (stack.getByOffset(-1).getExprType().getStackSize() == 1) {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
-index e1bed2f0f5f501d05f93dfa6bfcd2f2b3e76b822..6d42db459055d505604728dcac4af7bb74a9e21c 100644
+index dc3d20eed5ddcac36204fc9ed75d73c53a8c9805..efa677ae6cfdc08635eff080c7241ec086e5c945 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
-@@ -73,6 +73,10 @@ public class SimplifyExprentsHelper {
+@@ -74,6 +74,10 @@ public class SimplifyExprentsHelper {
            if (changed) {
              break;
            }
@@ -47,7 +47,7 @@ index e1bed2f0f5f501d05f93dfa6bfcd2f2b3e76b822..6d42db459055d505604728dcac4af7bb
          }
  
          res |= changed;
-@@ -507,21 +511,53 @@ public class SimplifyExprentsHelper {
+@@ -508,21 +512,53 @@ public class SimplifyExprentsHelper {
      return false;
    }
  
@@ -106,7 +106,7 @@ index e1bed2f0f5f501d05f93dfa6bfcd2f2b3e76b822..6d42db459055d505604728dcac4af7bb
  
                String classname = newExpr.getNewType().getValue();
                ClassNode node = DecompilerContext.getClassProcessor().getMapRootClasses().get(classname);
-@@ -537,6 +573,27 @@ public class SimplifyExprentsHelper {
+@@ -538,6 +574,27 @@ public class SimplifyExprentsHelper {
      return false;
    }
  
@@ -135,7 +135,7 @@ index e1bed2f0f5f501d05f93dfa6bfcd2f2b3e76b822..6d42db459055d505604728dcac4af7bb
    private static boolean isConstructorInvocationRemote(List<Exprent> list, int index) {
      Exprent current = list.get(index);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index c1a645bfe508513263618dc04da1d66eb99e7d0e..e6d996ebfcd85fa0def6bc6fd1e10156fce0a44c 100644
+index 28bae14b7342dd6897e638889682178248039ad7..eda61adada8942006a5a49d5f0905ba010505fea 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -61,6 +61,7 @@ public class InvocationExprent extends Exprent {
@@ -146,7 +146,7 @@ index c1a645bfe508513263618dc04da1d66eb99e7d0e..e6d996ebfcd85fa0def6bc6fd1e10156
  
    public InvocationExprent() {
      super(EXPRENT_INVOCATION);
-@@ -163,6 +164,7 @@ public class InvocationExprent extends Exprent {
+@@ -156,6 +157,7 @@ public class InvocationExprent extends Exprent {
  
      addBytecodeOffsets(expr.bytecode);
      bootstrapArguments = expr.getBootstrapArguments();
@@ -154,7 +154,7 @@ index c1a645bfe508513263618dc04da1d66eb99e7d0e..e6d996ebfcd85fa0def6bc6fd1e10156
    }
  
    @Override
-@@ -974,6 +976,14 @@ public class InvocationExprent extends Exprent {
+@@ -955,6 +957,14 @@ public class InvocationExprent extends Exprent {
      return bootstrapArguments;
    }
  

--- a/FernFlower-Patches/0022-Fix-shortname-imports-that-are-shadowed-by-super-cla.patch
+++ b/FernFlower-Patches/0022-Fix-shortname-imports-that-are-shadowed-by-super-cla.patch
@@ -189,7 +189,7 @@ index 8337607e067c1c7cdc803058eab4bfb0ba3c9d3c..ee6f1c77f2267fed499ee60a12ef319d
      defaults.put(LOG_LEVEL, IFernflowerLogger.Severity.INFO.name());
      defaults.put(MAX_PROCESSING_METHOD, "0");
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
-index b744ddbb35bcc08716826324c1895ce8f860d31b..00ed5ce590551dc8cbe80199b4cdd90b6a50494c 100644
+index b2963191fe5c6e162346fc98f9cefd122da23ee2..f7e086c560b6e1e5d67d93813c91ecc70db49ce1 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 @@ -8,6 +8,7 @@ import org.jetbrains.java.decompiler.code.cfg.BasicBlock;
@@ -200,7 +200,7 @@ index b744ddbb35bcc08716826324c1895ce8f860d31b..00ed5ce590551dc8cbe80199b4cdd90b
  import org.jetbrains.java.decompiler.modules.decompiler.StatEdge.EdgeType;
  import org.jetbrains.java.decompiler.modules.decompiler.exps.*;
  import org.jetbrains.java.decompiler.modules.decompiler.sforms.DirectGraph;
-@@ -761,12 +762,14 @@ public class ExprProcessor implements CodeConstants {
+@@ -757,12 +758,14 @@ public class ExprProcessor implements CodeConstants {
    ) {
      List<ClassesProcessor.ClassNode> enclosingClasses = enclosingClassList();
      StringBuilder curPathBldr = new StringBuilder(type.getValue().substring(0, type.getValue().lastIndexOf('/') + 1));

--- a/FernFlower-Patches/0023-Give-nicer-output-for-float-and-double-literals.patch
+++ b/FernFlower-Patches/0023-Give-nicer-output-for-float-and-double-literals.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Give nicer output for float and double literals
 
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
-index 2b0a80c8e2f1229664e86159f6cefc74955e197e..912c46cdd5ce58333526786b20ab4bed310e6e76 100644
+index 06025ab6d1c96e8bedb91b4efcbd2e00641c477e..d6a96b7c613f8ac747149a443e996078613024a8 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
-@@ -47,6 +47,69 @@ public class ConstExprent extends Exprent {
+@@ -48,6 +48,69 @@ public class ConstExprent extends Exprent {
    );
  
    private StructMember parent;
@@ -78,63 +78,65 @@ index 2b0a80c8e2f1229664e86159f6cefc74955e197e..912c46cdd5ce58333526786b20ab4bed
    private VarType constType;
    private final Object value;
    private final boolean boolPermitted;
-@@ -189,37 +252,7 @@ public class ConstExprent extends Exprent {
-         return new TextBuffer(value.toString()).append('L');
- 
-       case CodeConstants.TYPE_FLOAT:
+@@ -185,39 +248,7 @@ public class ConstExprent extends Exprent {
+         }
+         yield new TextBuffer(value.toString()).append('L');
+       }
+-      case CodeConstants.TYPE_FLOAT -> {
 -        float floatVal = (Float)value;
 -        if (!literal) {
 -          if (Float.isNaN(floatVal) && !inConstantVariable(FLOAT_SIG, NAN)) {
--            return new FieldExprent(NAN, FLOAT_SIG, true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer);
+-            yield new FieldExprent(NAN, FLOAT_SIG, true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer);
 -          }
 -          else if (floatVal == Float.POSITIVE_INFINITY && !inConstantVariable(FLOAT_SIG, POS_INF)) {
--            return new FieldExprent(POS_INF, FLOAT_SIG, true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer);
+-            yield new FieldExprent(POS_INF, FLOAT_SIG, true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer);
 -          }
 -          else if (floatVal == Float.NEGATIVE_INFINITY && !inConstantVariable(FLOAT_SIG, NEG_INF)) {
--            return new FieldExprent(NEG_INF, FLOAT_SIG, true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer);
+-            yield new FieldExprent(NEG_INF, FLOAT_SIG, true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer);
 -          }
 -          else if (floatVal == Float.MAX_VALUE && !inConstantVariable(FLOAT_SIG, MAX_VAL)) {
--            return new FieldExprent(MAX_VAL, FLOAT_SIG, true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer);
+-            yield new FieldExprent(MAX_VAL, FLOAT_SIG, true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer);
 -          }
 -          else if (floatVal == Float.MIN_VALUE && !inConstantVariable(FLOAT_SIG, MIN_VAL)) {
--            return new FieldExprent(MIN_VAL, FLOAT_SIG, true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer);
+-            yield new FieldExprent(MIN_VAL, FLOAT_SIG, true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer);
 -          }
 -          else if (floatVal == Float.MIN_NORMAL && !inConstantVariable(FLOAT_SIG, MIN_NORM)) {
--            return new FieldExprent(MIN_NORM, FLOAT_SIG, true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer);
+-            yield new FieldExprent(MIN_NORM, FLOAT_SIG, true, null, FieldDescriptor.FLOAT_DESCRIPTOR, bytecode).toJava(0, tracer);
 -          }
 -        }
 -        else if (Float.isNaN(floatVal)) {
--          return new TextBuffer("0.0F / 0.0F");
+-          yield new TextBuffer("0.0F / 0.0F");
 -        }
 -        else if (floatVal == Float.POSITIVE_INFINITY) {
--          return new TextBuffer("1.0F / 0.0F");
+-          yield new TextBuffer("1.0F / 0.0F");
 -        }
 -        else if (floatVal == Float.NEGATIVE_INFINITY) {
--          return new TextBuffer("-1.0F / 0.0F");
+-          yield new TextBuffer("-1.0F / 0.0F");
 -        }
--        return new TextBuffer(trimZeros(value.toString())).append('F');
-+        return createFloat(literal, (Float)value, tracer);
- 
-       case CodeConstants.TYPE_DOUBLE:
+-        yield new TextBuffer(trimZeros(value.toString())).append('F');
+-      }
++      case CodeConstants.TYPE_FLOAT -> createFloat(literal, (Float)value, tracer);
+       case CodeConstants.TYPE_DOUBLE -> {
          double doubleVal = (Double)value;
-@@ -245,8 +278,31 @@ public class ConstExprent extends Exprent {
-           else if (doubleVal == Math.E  && !inConstantVariable(MATH_SIG, E)) {
-             return new FieldExprent(E, MATH_SIG, true, null, FieldDescriptor.DOUBLE_DESCRIPTOR, bytecode).toJava(0, tracer);
+         if (!literal) {
+@@ -242,8 +273,31 @@ public class ConstExprent extends Exprent {
+           else if (doubleVal == Math.E && !inConstantVariable(MATH_SIG, E)) {
+             yield new FieldExprent(E, MATH_SIG, true, null, FieldDescriptor.DOUBLE_DESCRIPTOR, bytecode).toJava(0, tracer);
            }
 -          else if (doubleVal == Math.PI && !inConstantVariable(MATH_SIG, PI)) {
--            return new FieldExprent(PI, MATH_SIG, true, null, FieldDescriptor.DOUBLE_DESCRIPTOR, bytecode).toJava(0, tracer);
+-            yield new FieldExprent(PI, MATH_SIG, true, null, FieldDescriptor.DOUBLE_DESCRIPTOR, bytecode).toJava(0, tracer);
 +          else if (doubleVal == -Double.MAX_VALUE && !inConstantVariable(DOUBLE_SIG, MAX_VAL)) {
-+            return new FieldExprent(MAX_VAL, DOUBLE_SIG, true, null, FieldDescriptor.DOUBLE_DESCRIPTOR, bytecode).toJava(0, tracer).prepend("-");
++            yield new FieldExprent(MAX_VAL, DOUBLE_SIG, true, null, FieldDescriptor.DOUBLE_DESCRIPTOR, bytecode).toJava(0, tracer).prepend("-");
 +          }
 +          else if (doubleVal == -Double.MIN_NORMAL) {
-+            return new FieldExprent(MIN_NORM, DOUBLE_SIG, true, null, FieldDescriptor.DOUBLE_DESCRIPTOR, bytecode).toJava(0, tracer).prepend("-");
++            yield new FieldExprent(MIN_NORM, DOUBLE_SIG, true, null, FieldDescriptor.DOUBLE_DESCRIPTOR, bytecode).toJava(0, tracer).prepend("-");
 +          }
 +          else if (doubleVal == -Double.MIN_VALUE) {
-+            return new FieldExprent(MIN_VAL, DOUBLE_SIG, true, null, FieldDescriptor.DOUBLE_DESCRIPTOR, bytecode).toJava(0, tracer).prepend("-");
++            yield new FieldExprent(MIN_VAL, DOUBLE_SIG, true, null, FieldDescriptor.DOUBLE_DESCRIPTOR, bytecode).toJava(0, tracer).prepend("-");
 +          }
 +          else if (PI_DOUBLES.containsKey(doubleVal)) {
 +            String[] parts = PI_DOUBLES.get(doubleVal);
-+            return getPiDouble(tracer).enclose(parts[0], parts[1]);
++            yield getPiDouble(tracer).enclose(parts[0], parts[1]);
 +          }
 +
 +          // Check for cases where a float literal has been upcasted to a double.
@@ -146,17 +148,15 @@ index 2b0a80c8e2f1229664e86159f6cefc74955e197e..912c46cdd5ce58333526786b20ab4bed
 +            // If they're the same, there's no point in the cast and such (e.g. don't decompile 1.0D as (double)1.0F).
 +            if (Float.toString(nearestFloatVal).length() < Double.toString(doubleVal).length()) {
 +              // Include a cast to prevent using the wrong method call in ambiguous cases.
-+              return createFloat(literal, nearestFloatVal, tracer).prepend("(double)");
++              yield createFloat(literal, nearestFloatVal, tracer).prepend("(double)");
 +            }
            }
          }
          else if (Double.isNaN(doubleVal)) {
-@@ -276,7 +332,71 @@ public class ConstExprent extends Exprent {
- 
-     throw new RuntimeException("invalid constant type: " + constType);
+@@ -273,6 +327,69 @@ public class ConstExprent extends Exprent {
+     };
    }
--  
-+
+ 
 +  private TextBuffer createFloat(boolean literal, float floatVal, BytecodeMappingTracer tracer) {
 +    if (!literal) {
 +      // Float constants, some of which can't be represented directly
@@ -220,7 +220,6 @@ index 2b0a80c8e2f1229664e86159f6cefc74955e197e..912c46cdd5ce58333526786b20ab4bed
 +    // java.lang.Math doesn't have a float version of pi, unfortunately
 +    return getPiDouble(tracer).prepend("(float)");
 +  }
-+
    // Different JVM implementations/version display Floats and Doubles with different number of trailing zeros.
    // This trims them all down to only the necessary amount.
    private static String trimZeros(String value) {

--- a/FernFlower-Patches/0024-Add-try-with-resource-support.patch
+++ b/FernFlower-Patches/0024-Add-try-with-resource-support.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add try with resource support
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
-index 81fed9eaea4d73a99e87545d15171033f98db3b1..cc6f6ad706aa1fcb0b129ea9da80b47fd77f0a5f 100644
+index fa4b5ed56fa58f2d864ea3acd758a36fa8e23e7a..4713a0212ee1ae4cc269dd24f2227a91a2c9beed 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
 @@ -190,6 +190,10 @@ public class MethodProcessorRunnable implements Runnable {
@@ -749,11 +749,11 @@ index 0000000000000000000000000000000000000000..cdd05cd3d40ad85380e00ddeba7e2894
 +  }
 +}
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/FlattenStatementsHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/FlattenStatementsHelper.java
-index a3ef4b8b5fdb820c520a21fcd727e08e9dfe2510..f4f8b55a68c10671beef7859540398cac541d6e2 100644
+index ccb7b3d9d0b38a5be9a6c9c727b4800bf815e715..99fc1c604cadabc1f106a3be745980b1e9b3ad3f 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/FlattenStatementsHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/FlattenStatementsHelper.java
-@@ -130,6 +130,13 @@ public class FlattenStatementsHelper {
-           case TRY_CATCH:
+@@ -128,6 +128,13 @@ public class FlattenStatementsHelper {
+           case CATCH_ALL, TRY_CATCH -> {
              DirectNode firstnd = new DirectNode(DirectNodeType.TRY, stat, stat.id + "_try");
  
 +            if (stat.type == Statement.StatementType.TRY_CATCH) {
@@ -888,7 +888,7 @@ index 7c83c48777e2dc683d1321fb297f89466f62e8ce..97c1d3f816dcfc21811da2097744bfe9
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
-index 8340673d27079b96d7aee5d32d7f61af7ed80b67..b62210af04100c66a17e17e5d5447af59a69f1bf 100644
+index cf7f00021cad6818e144342dcbf5b6198e8adeb3..ad32facfe21c854c69c16ee51aa885b8c266d7b9 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
 @@ -110,7 +110,11 @@ public class VarDefinitionHelper {
@@ -905,10 +905,10 @@ index 8340673d27079b96d7aee5d32d7f61af7ed80b67..b62210af04100c66a17e17e5d5447af5
  
        if (lstVars != null) {
 diff --git a/test/org/jetbrains/java/decompiler/SingleClassesTest.java b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
-index 256f412db7806d11c41d9f48d8e3d28361e50c39..9ee13f077fb092089bc874cee4dc53f918009d91 100644
+index 645d99f07322c311a20b5fd76a5235de6cdae74d..16ceb1e8e47c90da72ef3039cf625eec25b68223 100644
 --- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
 +++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
-@@ -142,6 +142,7 @@ public class SingleClassesTest extends SingleClassesTestBase {
+@@ -143,6 +143,7 @@ public class SingleClassesTest extends SingleClassesTestBase {
    @Test public void testRecordVararg() { doTest("records/TestRecordVararg"); }
    @Test public void testRecordGenericVararg() { doTest("records/TestRecordGenericVararg"); }
    @Test public void testRecordAnno() { doTest("records/TestRecordAnno"); }

--- a/FernFlower-Patches/0025-Prioritize-self-and-enclosing-class-when-encounterin.patch
+++ b/FernFlower-Patches/0025-Prioritize-self-and-enclosing-class-when-encounterin.patch
@@ -8,7 +8,7 @@ The compiler encodes all REFERENCED inner classes into the class. The first foun
 Fixes AccessTransformers.
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index c755eb4e6d618192a760d039c139e4e16de668f3..bbd3fcdc8fa3a4fc6a31a1e3c48eae06e1f97abd 100644
+index 5a06aaa68ee8df9d5ff45c670b8395d6125916fa..9de1e6e74f51df444b9241470619759a8d70fa47 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -1205,6 +1205,10 @@ public class ClassWriter {

--- a/FernFlower-Patches/0025-Prioritize-self-and-enclosing-class-when-encounterin.patch
+++ b/FernFlower-Patches/0025-Prioritize-self-and-enclosing-class-when-encounterin.patch
@@ -8,10 +8,10 @@ The compiler encodes all REFERENCED inner classes into the class. The first foun
 Fixes AccessTransformers.
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index eb5a603ab6ffb2277d2c12a2d5e4a141d633964e..33b0dde4582691d5e6415296a77a9be6fe2e9a01 100644
+index 5a06aaa68ee8df9d5ff45c670b8395d6125916fa..9de1e6e74f51df444b9241470619759a8d70fa47 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-@@ -1208,6 +1208,10 @@ public class ClassWriter {
+@@ -1205,6 +1205,10 @@ public class ClassWriter {
      }
    }
  
@@ -23,7 +23,7 @@ index eb5a603ab6ffb2277d2c12a2d5e4a141d633964e..33b0dde4582691d5e6415296a77a9be6
        TextBuffer buffer,
        List<String> parameters,
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
-index f0d59a81d1f40f95d21ff7699fd349e10d39278c..e0c4593576ed55313de61adde1a5e175b75d0825 100644
+index 7149145b1f3ed3583f8bbe416947a0d68de523db..2c67a4fbcdf011cc91b9166f616feb27ce9dcd4c 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 @@ -41,10 +41,20 @@ public class ClassesProcessor implements CodeConstants {

--- a/FernFlower-Patches/0025-Prioritize-self-and-enclosing-class-when-encounterin.patch
+++ b/FernFlower-Patches/0025-Prioritize-self-and-enclosing-class-when-encounterin.patch
@@ -8,7 +8,7 @@ The compiler encodes all REFERENCED inner classes into the class. The first foun
 Fixes AccessTransformers.
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 5a06aaa68ee8df9d5ff45c670b8395d6125916fa..9de1e6e74f51df444b9241470619759a8d70fa47 100644
+index c755eb4e6d618192a760d039c139e4e16de668f3..bbd3fcdc8fa3a4fc6a31a1e3c48eae06e1f97abd 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -1205,6 +1205,10 @@ public class ClassWriter {

--- a/FernFlower-Patches/0025-Prioritize-self-and-enclosing-class-when-encounterin.patch
+++ b/FernFlower-Patches/0025-Prioritize-self-and-enclosing-class-when-encounterin.patch
@@ -8,7 +8,7 @@ The compiler encodes all REFERENCED inner classes into the class. The first foun
 Fixes AccessTransformers.
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 5a06aaa68ee8df9d5ff45c670b8395d6125916fa..9de1e6e74f51df444b9241470619759a8d70fa47 100644
+index 0fb12b6d99f3c1dc7652e5ab49e36683d7a6db08..6f2f8419d41a240c6d1428be0b0ca9258f058127 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -1205,6 +1205,10 @@ public class ClassWriter {

--- a/FernFlower-Patches/0026-Fix-ambiguous-lambdas.patch
+++ b/FernFlower-Patches/0026-Fix-ambiguous-lambdas.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix ambiguous lambdas
 
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
-index 00ed5ce590551dc8cbe80199b4cdd90b6a50494c..74696110a6d8080ad606d3ef20a75dae010cacb2 100644
+index f7e086c560b6e1e5d67d93813c91ecc70db49ce1..c5b8af9d9047d9c06840dfcb95e18a8703bd0b0e 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ExprProcessor.java
-@@ -1071,6 +1071,9 @@ public class ExprProcessor implements CodeConstants {
+@@ -1067,6 +1067,9 @@ public class ExprProcessor implements CodeConstants {
        (castNull && rightType.getType() == CodeConstants.TYPE_NULL && !UNDEFINED_TYPE_STRING.equals(getTypeName(leftType, Collections.emptyList()))) ||
        (castNarrowing && isIntConstant(exprent) && isNarrowedIntType(leftType));
  
@@ -18,7 +18,7 @@ index 00ed5ce590551dc8cbe80199b4cdd90b6a50494c..74696110a6d8080ad606d3ef20a75dae
      boolean quote = cast && exprent.getPrecedence() >= FunctionExprent.getPrecedence(FunctionExprent.FUNCTION_CAST);
  
      // cast instead to 'byte' / 'short' when int constant is used as a value for 'Byte' / 'Short'
-@@ -1085,6 +1088,8 @@ public class ExprProcessor implements CodeConstants {
+@@ -1081,6 +1084,8 @@ public class ExprProcessor implements CodeConstants {
  
      if (cast) buffer.append('(').append(ExprProcessor.getCastTypeName(leftType, Collections.emptyList())).append(')');
  
@@ -27,7 +27,7 @@ index 00ed5ce590551dc8cbe80199b4cdd90b6a50494c..74696110a6d8080ad606d3ef20a75dae
      if (quote) buffer.append('(');
  
      if (exprent.type == Exprent.EXPRENT_CONST) {
-@@ -1116,4 +1121,12 @@ public class ExprProcessor implements CodeConstants {
+@@ -1110,4 +1115,12 @@ public class ExprProcessor implements CodeConstants {
    private static boolean isNarrowedIntType(VarType type) {
      return VarType.VARTYPE_INT.isStrictSuperset(type) || type.equals(VarType.VARTYPE_BYTE_OBJ) || type.equals(VarType.VARTYPE_SHORT_OBJ);
    }
@@ -41,10 +41,10 @@ index 00ed5ce590551dc8cbe80199b4cdd90b6a50494c..74696110a6d8080ad606d3ef20a75dae
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index e6d996ebfcd85fa0def6bc6fd1e10156fce0a44c..6fab98e2cbf3a2168daf3f80063123be60caad7b 100644
+index eda61adada8942006a5a49d5f0905ba010505fea..01ce4f5c3d827e51934de816723ccac236ed9e18 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-@@ -810,7 +810,8 @@ public class InvocationExprent extends Exprent {
+@@ -791,7 +791,8 @@ public class InvocationExprent extends Exprent {
        if (md.params.length == parameters.size()) {
          boolean exact = true;
          for (int i = 0; i < md.params.length; i++) {
@@ -54,7 +54,7 @@ index e6d996ebfcd85fa0def6bc6fd1e10156fce0a44c..6fab98e2cbf3a2168daf3f80063123be
              exact = false;
              missed.set(i);
            }
-@@ -824,7 +825,8 @@ public class InvocationExprent extends Exprent {
+@@ -805,7 +806,8 @@ public class InvocationExprent extends Exprent {
        boolean failed = false;
        MethodDescriptor md = MethodDescriptor.parseDescriptor(mtt.getDescriptor());
        for (int i = 0; i < parameters.size(); i++) {
@@ -64,7 +64,7 @@ index e6d996ebfcd85fa0def6bc6fd1e10156fce0a44c..6fab98e2cbf3a2168daf3f80063123be
          if (!missed.get(i)) {
            if (!md.params[i].equals(ptype)) {
              failed = true;
-@@ -832,6 +834,17 @@ public class InvocationExprent extends Exprent {
+@@ -813,6 +815,17 @@ public class InvocationExprent extends Exprent {
            }
          }
          else {
@@ -82,7 +82,7 @@ index e6d996ebfcd85fa0def6bc6fd1e10156fce0a44c..6fab98e2cbf3a2168daf3f80063123be
            if (md.params[i].getType() == CodeConstants.TYPE_OBJECT) {
              if (ptype.getType() != CodeConstants.TYPE_NULL) {
                if (!DecompilerContext.getStructContext().instanceOf(ptype.getValue(), md.params[i].getValue())) {
-@@ -859,7 +872,10 @@ public class InvocationExprent extends Exprent {
+@@ -840,7 +853,10 @@ public class InvocationExprent extends Exprent {
  
          GenericMethodDescriptor gen = mtt.getSignature(); //TODO: Find synthetic flags for params, as Enum generic signatures do no contain the String,int params
          if (gen != null && gen.parameterTypes.size() > i && gen.parameterTypes.get(i).isGeneric()) {

--- a/FernFlower-Patches/0027-Fix-field-initalizers.patch
+++ b/FernFlower-Patches/0027-Fix-field-initalizers.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix field initalizers
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/InitializerProcessor.java b/src/org/jetbrains/java/decompiler/main/InitializerProcessor.java
-index 34be3854cad1675d54a32929d5e1fe1641f1a929..686298a19d1ea4df848ff1ffd737f0ae70e92722 100644
+index b44a78019f0717213822ef5572c5d7ecde6d4ee3..20d3f0391343689eb604b8b953cabb26fc90e1bd 100644
 --- a/src/org/jetbrains/java/decompiler/main/InitializerProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/InitializerProcessor.java
 @@ -3,6 +3,7 @@ package org.jetbrains.java.decompiler.main;
@@ -164,7 +164,7 @@ index 34be3854cad1675d54a32929d5e1fe1641f1a929..686298a19d1ea4df848ff1ffd737f0ae
  
          for (List<Exprent> lst : lstFirst) {
            lst.remove(isAnonymous ? 0 : 1);
-@@ -273,7 +323,7 @@ public final class InitializerProcessor {
+@@ -273,14 +323,14 @@ public final class InitializerProcessor {
      }
    }
  
@@ -173,12 +173,20 @@ index 34be3854cad1675d54a32929d5e1fe1641f1a929..686298a19d1ea4df848ff1ffd737f0ae
      List<Exprent> lst = exprent.getAllExprents(true);
      lst.add(exprent);
  
-@@ -289,10 +339,65 @@ public final class InitializerProcessor {
+     for (Exprent expr : lst) {
+       switch (expr.type) {
+         case Exprent.EXPRENT_VAR -> {
+-          VarVersionPair varPair = new VarVersionPair((VarExprent)expr);
++          VarVersionPair varPair = new VarVersionPair((VarExprent) expr);
+           if (!method.varproc.getExternalVars().contains(varPair)) {
+             String varName = method.varproc.getVarName(varPair);
+             if (!varName.equals("this") && !varName.endsWith(".this")) { // FIXME: remove direct comparison with strings
+@@ -289,11 +339,63 @@ public final class InitializerProcessor {
            }
-           break;
-         case Exprent.EXPRENT_FIELD:
+         }
+         case Exprent.EXPRENT_FIELD -> {
 -          return false;
-+          FieldExprent fexpr = (FieldExprent)expr;
++          FieldExprent fexpr = (FieldExprent) expr;
 +          if (cl.hasField(fexpr.getName(), fexpr.getDescriptor().descriptorString)) {
 +            String key = InterpreterUtil.makeUniqueKey(fexpr.getName(), fexpr.getDescriptor().descriptorString);
 +            if (isStatic) {
@@ -195,13 +203,11 @@ index 34be3854cad1675d54a32929d5e1fe1641f1a929..686298a19d1ea4df848ff1ffd737f0ae
 +                return false;
 +              }
 +            }
-+          }
-+          else if (!fexpr.isStatic() && fexpr.getInstance() == null) {
++          } else if (!fexpr.isStatic() && fexpr.getInstance() == null) {
 +            return false;
 +          }
-+          break;
-+        case Exprent.EXPRENT_NEW:
-+          makeLaterFieldsInLambdaQualified((NewExprent)expr, cl, fidx);
+         }
++        case Exprent.EXPRENT_NEW -> makeLaterFieldsInLambdaQualified((NewExprent)expr, cl, fidx);
        }
      }
  

--- a/FernFlower-Patches/0028-Improve-inferred-generic-types.patch
+++ b/FernFlower-Patches/0028-Improve-inferred-generic-types.patch
@@ -265,7 +265,7 @@ index cb80c8d7be08b9f3d6770541910832bb3d9a58a9..c2136584b0ae2a5c7ba34370666bd8b5
    public void getBytecodeRange(BitSet values) {
      measureBytecode(values, lstOperands);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 01ce4f5c3d827e51934de816723ccac236ed9e18..3e6ce9270be0fccd24fc247abd5fdff1e3a4777f 100644
+index 01ce4f5c3d827e51934de816723ccac236ed9e18..962b7a9b85ef5fd29bce0c2953748a6cd3a87ea7 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -32,6 +32,7 @@ import org.jetbrains.java.decompiler.util.TextUtil;
@@ -424,7 +424,7 @@ index 01ce4f5c3d827e51934de816723ccac236ed9e18..3e6ce9270be0fccd24fc247abd5fdff1
 +              tempMap.forEach((from, to) -> {
 +                if (!fparams.contains(from.getValue())) {
 +                  processGenericMapping(from, to, named, bounds);
-+                }
+                 }
 +              });
 +              tempMap.clear();
 +            }
@@ -443,11 +443,13 @@ index 01ce4f5c3d827e51934de816723ccac236ed9e18..3e6ce9270be0fccd24fc247abd5fdff1
 +              Map<String, Map<VarType, VarType>> hierarchy = currentCls.classStruct.getAllGenerics();
 +              if (hierarchy.containsKey(mthCls.qualifiedName)) {
 +                hierarchy.get(mthCls.qualifiedName).forEach(genericsMap::put);
-+              }
-+            }
+               }
+             }
 +          }
 +        }
-+
+ 
+-            if (!map.isEmpty()) {
+-              ret = ret.remap(map);
 +        if (!isInvocationInstance) {
 +          upperBoundsMap.forEach((k, v) -> {
 +            if (fparams.contains(k.getValue()) && !GenericType.DUMMY_VAR.equals(v) && !genericsMap.containsKey(k)) {
@@ -572,12 +574,16 @@ index 01ce4f5c3d827e51934de816723ccac236ed9e18..3e6ce9270be0fccd24fc247abd5fdff1
 +                    paramGenerics.add(paramType);
 +                  }
 +                  processGenericMapping(paramType, argtype, named, bounds);
-                 }
-               }
++                }
++              }
              }
-+          }
-+        }
-+
+           }
+         }
+-      }
+ 
+-      VarType _new = this.gatherGenerics(upperBound, ret, desc.getSignature().typeParameters, genericArgs);
+-      if (desc.getSignature().returnType != _new) {
+-        return _new;
 +        upperBoundsMap.forEach((k, v) -> {
 +          if (fparams.contains(k.getValue()) && !GenericType.DUMMY_VAR.equals(v)) {
 +            processGenericMapping(k, v ,named, bounds);
@@ -586,9 +592,7 @@ index 01ce4f5c3d827e51934de816723ccac236ed9e18..3e6ce9270be0fccd24fc247abd5fdff1
 +
 +        if (!genericsMap.isEmpty()) {
 +          VarType newRet = ret.remap(hierarchyMap);
- 
--            if (!map.isEmpty()) {
--              ret = ret.remap(map);
++
 +          boolean skipArgs = true;
 +          if (!fparams.isEmpty() && newRet.isGeneric()) {
 +            for (VarType genVar : ((GenericType)newRet).getAllGenericVars()) {
@@ -596,8 +600,8 @@ index 01ce4f5c3d827e51934de816723ccac236ed9e18..3e6ce9270be0fccd24fc247abd5fdff1
 +                skipArgs = false;
 +                break;
 +              }
-             }
-           }
++            }
++          }
 +
 +          newRet = newRet.remap(genericsMap);
 +          if (newRet == null) {
@@ -630,12 +634,8 @@ index 01ce4f5c3d827e51934de816723ccac236ed9e18..3e6ce9270be0fccd24fc247abd5fdff1
 +          if (newRet != ret && !(newRet.isGeneric() && ((GenericType)newRet).hasUnknownGenericType(named.keySet()))) {
 +            return newRet;
 +          }
-         }
--      }
- 
--      VarType _new = this.gatherGenerics(upperBound, ret, desc.getSignature().typeParameters, genericArgs);
--      if (desc.getSignature().returnType != _new) {
--        return _new;
++        }
++
 +        if (ret.isGeneric() && ((GenericType)ret).getAllGenericVars().isEmpty()) {
 +          return ret;
 +        }
@@ -723,7 +723,7 @@ index 01ce4f5c3d827e51934de816723ccac236ed9e18..3e6ce9270be0fccd24fc247abd5fdff1
  
      // omit 'new Type[] {}' for the last parameter of a vararg method call
      if (parameters.size() == descriptor.params.length && isVarArgCall()) {
-@@ -514,20 +796,32 @@ public class InvocationExprent extends Exprent {
+@@ -514,20 +796,42 @@ public class InvocationExprent extends Exprent {
        }
      }
  
@@ -756,11 +756,21 @@ index 01ce4f5c3d827e51934de816723ccac236ed9e18..3e6ce9270be0fccd24fc247abd5fdff1
 +      }
 +    }
 +    if (desc != null && desc.getSignature() != null) {
++      Map<VarType, VarType> hierarchyMap = new HashMap<>();
++      if (!className.equals(desc.getClassQualifiedName())) {
++        StructClass mthCls = DecompilerContext.getStructContext().getClass(className);
++        if (mthCls != null) {
++          Map<String, Map<VarType, VarType>> hierarchy = mthCls.getAllGenerics();
++          if (hierarchy.containsKey(desc.getClassQualifiedName())) {
++            hierarchyMap = hierarchy.get(desc.getClassQualifiedName());
++          }
++        }
++      }
 +      Set<VarType> namedGens = getNamedGenerics().keySet();
 +      int y = 0;
 +      for (int x = start; x < types.length; x++) {
 +        if (mask == null || mask.get(x) == null) {
-+          VarType type = desc.getSignature().parameterTypes.get(y++).remap(genericsMap);
++          VarType type = desc.getSignature().parameterTypes.get(y++).remap(hierarchyMap).remap(genericsMap);
 +          if (type != null && !(type.isGeneric() && ((GenericType)type).hasUnknownGenericType(namedGens))) {
 +            types[x] = type;
 +          }
@@ -769,7 +779,7 @@ index 01ce4f5c3d827e51934de816723ccac236ed9e18..3e6ce9270be0fccd24fc247abd5fdff1
      }
  
  
-@@ -565,6 +859,10 @@ public class InvocationExprent extends Exprent {
+@@ -565,6 +869,10 @@ public class InvocationExprent extends Exprent {
          }
          */
  
@@ -780,7 +790,7 @@ index 01ce4f5c3d827e51934de816723ccac236ed9e18..3e6ce9270be0fccd24fc247abd5fdff1
          // 'byte' and 'short' literals need an explicit narrowing type cast when used as a parameter
          ExprProcessor.getCastedExprent(this.parameters.get(i), types[i], buff, indent, true, ambiguous, true, true, tracer);
  
-@@ -580,8 +878,6 @@ public class InvocationExprent extends Exprent {
+@@ -580,8 +888,6 @@ public class InvocationExprent extends Exprent {
        }
      }
  
@@ -789,7 +799,7 @@ index 01ce4f5c3d827e51934de816723ccac236ed9e18..3e6ce9270be0fccd24fc247abd5fdff1
      return buf;
    }
  
-@@ -869,6 +1165,162 @@ public class InvocationExprent extends Exprent {
+@@ -869,6 +1175,162 @@ public class InvocationExprent extends Exprent {
      return ambiguous;
    }
  
@@ -952,7 +962,7 @@ index 01ce4f5c3d827e51934de816723ccac236ed9e18..3e6ce9270be0fccd24fc247abd5fdff1
    @Override
    public void replaceExprent(Exprent oldExpr, Exprent newExpr) {
      if (oldExpr == instance) {
-@@ -981,6 +1433,19 @@ public class InvocationExprent extends Exprent {
+@@ -981,6 +1443,19 @@ public class InvocationExprent extends Exprent {
      return isSyntheticNullCheck;
    }
  

--- a/FernFlower-Patches/0028-Improve-inferred-generic-types.patch
+++ b/FernFlower-Patches/0028-Improve-inferred-generic-types.patch
@@ -47,7 +47,7 @@ index 88b429ca3bc60303f9075eab36e279f9c58f4520..b03bcfc45ba7d58bcfc92612460c7f3d
    public int getExprentUse() {
      return array.getExprentUse() & index.getExprentUse() & Exprent.MULTIPLE_USES;
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
-index 912c46cdd5ce58333526786b20ab4bed310e6e76..c1443e44c5ee72ae04faa1aaedc1c7912879cc91 100644
+index d6a96b7c613f8ac747149a443e996078613024a8..aa922882d5abd2395921bdea4173305810d88335 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
 @@ -4,6 +4,7 @@ package org.jetbrains.java.decompiler.modules.decompiler.exps;
@@ -58,7 +58,7 @@ index 912c46cdd5ce58333526786b20ab4bed310e6e76..c1443e44c5ee72ae04faa1aaedc1c791
  import org.jetbrains.java.decompiler.main.collectors.BytecodeMappingTracer;
  import org.jetbrains.java.decompiler.main.extern.IFernflowerPreferences;
  import org.jetbrains.java.decompiler.modules.decompiler.ExprProcessor;
-@@ -133,6 +134,12 @@ public class ConstExprent extends Exprent {
+@@ -134,6 +135,12 @@ public class ConstExprent extends Exprent {
      this.value = value;
      this.boolPermitted = boolPermitted;
      addBytecodeOffsets(bytecodeOffsets);
@@ -231,10 +231,10 @@ index be789c6f999339fc4d755850dfd888f600f73a45..66ea2304968dae841fdd736c81e7332c
  
      return getExprType();
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
-index 2ce8932cb33e4881de5ed09b728781804cdced57..90cfbde63ada4d96eb78c7192ed0e1fc940f5843 100644
+index cb80c8d7be08b9f3d6770541910832bb3d9a58a9..c2136584b0ae2a5c7ba34370666bd8b5f4276aaa 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
-@@ -336,6 +336,11 @@ public class FunctionExprent extends Exprent {
+@@ -316,6 +316,11 @@ public class FunctionExprent extends Exprent {
          this.needsCast = right.getType() == CodeConstants.TYPE_NULL || !DecompilerContext.getStructContext().instanceOf(right.getValue(), cast.getValue());
        }
      }
@@ -246,7 +246,7 @@ index 2ce8932cb33e4881de5ed09b728781804cdced57..90cfbde63ada4d96eb78c7192ed0e1fc
      return getExprType();
    }
  
-@@ -665,6 +670,17 @@ public class FunctionExprent extends Exprent {
+@@ -634,6 +639,17 @@ public class FunctionExprent extends Exprent {
      this.implicitType = implicitType;
    }
  
@@ -265,7 +265,7 @@ index 2ce8932cb33e4881de5ed09b728781804cdced57..90cfbde63ada4d96eb78c7192ed0e1fc
    public void getBytecodeRange(BitSet values) {
      measureBytecode(values, lstOperands);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 6fab98e2cbf3a2168daf3f80063123be60caad7b..39c598c178c31c2b696946fb252360baa5fcddc9 100644
+index 01ce4f5c3d827e51934de816723ccac236ed9e18..3e6ce9270be0fccd24fc247abd5fdff1e3a4777f 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -32,6 +32,7 @@ import org.jetbrains.java.decompiler.util.TextUtil;
@@ -293,7 +293,7 @@ index 6fab98e2cbf3a2168daf3f80063123be60caad7b..39c598c178c31c2b696946fb252360ba
    private boolean forceBoxing = false;
    private boolean forceUnboxing = false;
    private boolean isSyntheticNullCheck = false;
-@@ -175,45 +179,326 @@ public class InvocationExprent extends Exprent {
+@@ -168,45 +172,326 @@ public class InvocationExprent extends Exprent {
  
    @Override
    public VarType getInferredExprType(VarType upperBound) {
@@ -424,7 +424,7 @@ index 6fab98e2cbf3a2168daf3f80063123be60caad7b..39c598c178c31c2b696946fb252360ba
 +              tempMap.forEach((from, to) -> {
 +                if (!fparams.contains(from.getValue())) {
 +                  processGenericMapping(from, to, named, bounds);
-                 }
++                }
 +              });
 +              tempMap.clear();
 +            }
@@ -443,13 +443,11 @@ index 6fab98e2cbf3a2168daf3f80063123be60caad7b..39c598c178c31c2b696946fb252360ba
 +              Map<String, Map<VarType, VarType>> hierarchy = currentCls.classStruct.getAllGenerics();
 +              if (hierarchy.containsKey(mthCls.qualifiedName)) {
 +                hierarchy.get(mthCls.qualifiedName).forEach(genericsMap::put);
-               }
-             }
++              }
++            }
 +          }
 +        }
- 
--            if (!map.isEmpty()) {
--              ret = ret.remap(map);
++
 +        if (!isInvocationInstance) {
 +          upperBoundsMap.forEach((k, v) -> {
 +            if (fparams.contains(k.getValue()) && !GenericType.DUMMY_VAR.equals(v) && !genericsMap.containsKey(k)) {
@@ -574,16 +572,12 @@ index 6fab98e2cbf3a2168daf3f80063123be60caad7b..39c598c178c31c2b696946fb252360ba
 +                    paramGenerics.add(paramType);
 +                  }
 +                  processGenericMapping(paramType, argtype, named, bounds);
-+                }
-+              }
+                 }
+               }
              }
-           }
-         }
--      }
- 
--      VarType _new = this.gatherGenerics(upperBound, ret, desc.getSignature().typeParameters, genericArgs);
--      if (desc.getSignature().returnType != _new) {
--        return _new;
++          }
++        }
++
 +        upperBoundsMap.forEach((k, v) -> {
 +          if (fparams.contains(k.getValue()) && !GenericType.DUMMY_VAR.equals(v)) {
 +            processGenericMapping(k, v ,named, bounds);
@@ -592,7 +586,9 @@ index 6fab98e2cbf3a2168daf3f80063123be60caad7b..39c598c178c31c2b696946fb252360ba
 +
 +        if (!genericsMap.isEmpty()) {
 +          VarType newRet = ret.remap(hierarchyMap);
-+
+ 
+-            if (!map.isEmpty()) {
+-              ret = ret.remap(map);
 +          boolean skipArgs = true;
 +          if (!fparams.isEmpty() && newRet.isGeneric()) {
 +            for (VarType genVar : ((GenericType)newRet).getAllGenericVars()) {
@@ -600,8 +596,8 @@ index 6fab98e2cbf3a2168daf3f80063123be60caad7b..39c598c178c31c2b696946fb252360ba
 +                skipArgs = false;
 +                break;
 +              }
-+            }
-+          }
+             }
+           }
 +
 +          newRet = newRet.remap(genericsMap);
 +          if (newRet == null) {
@@ -634,15 +630,19 @@ index 6fab98e2cbf3a2168daf3f80063123be60caad7b..39c598c178c31c2b696946fb252360ba
 +          if (newRet != ret && !(newRet.isGeneric() && ((GenericType)newRet).hasUnknownGenericType(named.keySet()))) {
 +            return newRet;
 +          }
-+        }
-+
+         }
+-      }
+ 
+-      VarType _new = this.gatherGenerics(upperBound, ret, desc.getSignature().typeParameters, genericArgs);
+-      if (desc.getSignature().returnType != _new) {
+-        return _new;
 +        if (ret.isGeneric() && ((GenericType)ret).getAllGenericVars().isEmpty()) {
 +          return ret;
 +        }
        }
      }
  
-@@ -316,7 +601,19 @@ public class InvocationExprent extends Exprent {
+@@ -309,7 +594,19 @@ public class InvocationExprent extends Exprent {
            TextUtil.writeQualifiedSuper(buf, super_qualifier);
          }
          else if (instance != null) {
@@ -662,7 +662,7 @@ index 6fab98e2cbf3a2168daf3f80063123be60caad7b..39c598c178c31c2b696946fb252360ba
            if (isUnboxingCall() && !forceUnboxing) {
              // we don't print the unboxing call - no need to bother with the instance wrapping / casting
              if (instance.type == Exprent.EXPRENT_FUNCTION) {
-@@ -345,7 +642,8 @@ public class InvocationExprent extends Exprent {
+@@ -338,7 +635,8 @@ public class InvocationExprent extends Exprent {
  
            TextBuffer res = instance.toJava(indent, tracer);
  
@@ -672,7 +672,7 @@ index 6fab98e2cbf3a2168daf3f80063123be60caad7b..39c598c178c31c2b696946fb252360ba
  
            if (rightType.equals(VarType.VARTYPE_OBJECT) && !leftType.equals(rightType)) {
              buf.append("((").append(ExprProcessor.getCastTypeName(leftType, Collections.emptyList())).append(")");
-@@ -355,7 +653,7 @@ public class InvocationExprent extends Exprent {
+@@ -348,7 +646,7 @@ public class InvocationExprent extends Exprent {
              }
              buf.append(res).append(")");
            }
@@ -681,8 +681,8 @@ index 6fab98e2cbf3a2168daf3f80063123be60caad7b..39c598c178c31c2b696946fb252360ba
              buf.append("(").append(res).append(")");
            }
            else {
-@@ -401,6 +699,12 @@ public class InvocationExprent extends Exprent {
-         }
+@@ -392,6 +690,12 @@ public class InvocationExprent extends Exprent {
+       }
      }
  
 +    buf.append(appendParamList(indent, tracer)).append(')');
@@ -694,7 +694,7 @@ index 6fab98e2cbf3a2168daf3f80063123be60caad7b..39c598c178c31c2b696946fb252360ba
      List<VarVersionPair> mask = null;
      boolean isEnum = false;
      if (funcType == TYPE_INIT) {
-@@ -413,28 +717,6 @@ public class InvocationExprent extends Exprent {
+@@ -404,28 +708,6 @@ public class InvocationExprent extends Exprent {
      ClassNode currCls = ((ClassNode)DecompilerContext.getProperty(DecompilerContext.CURRENT_CLASS_NODE));
      List<StructMethod> matches = getMatchedDescriptors();
      BitSet setAmbiguousParameters = getAmbiguousParameters(matches);
@@ -723,7 +723,7 @@ index 6fab98e2cbf3a2168daf3f80063123be60caad7b..39c598c178c31c2b696946fb252360ba
  
      // omit 'new Type[] {}' for the last parameter of a vararg method call
      if (parameters.size() == descriptor.params.length && isVarArgCall()) {
-@@ -523,20 +805,42 @@ public class InvocationExprent extends Exprent {
+@@ -514,20 +796,32 @@ public class InvocationExprent extends Exprent {
        }
      }
  
@@ -756,21 +756,11 @@ index 6fab98e2cbf3a2168daf3f80063123be60caad7b..39c598c178c31c2b696946fb252360ba
 +      }
 +    }
 +    if (desc != null && desc.getSignature() != null) {
-+      Map<VarType, VarType> hierarchyMap = new HashMap<>();
-+      if (!className.equals(desc.getClassQualifiedName())) {
-+        StructClass mthCls = DecompilerContext.getStructContext().getClass(className);
-+        if (mthCls != null) {
-+          Map<String, Map<VarType, VarType>> hierarchy = mthCls.getAllGenerics();
-+          if (hierarchy.containsKey(desc.getClassQualifiedName())) {
-+            hierarchyMap = hierarchy.get(desc.getClassQualifiedName());
-+          }
-+        }
-+      }
 +      Set<VarType> namedGens = getNamedGenerics().keySet();
 +      int y = 0;
 +      for (int x = start; x < types.length; x++) {
 +        if (mask == null || mask.get(x) == null) {
-+          VarType type = desc.getSignature().parameterTypes.get(y++).remap(hierarchyMap).remap(genericsMap);
++          VarType type = desc.getSignature().parameterTypes.get(y++).remap(genericsMap);
 +          if (type != null && !(type.isGeneric() && ((GenericType)type).hasUnknownGenericType(namedGens))) {
 +            types[x] = type;
 +          }
@@ -779,7 +769,7 @@ index 6fab98e2cbf3a2168daf3f80063123be60caad7b..39c598c178c31c2b696946fb252360ba
      }
  
  
-@@ -574,6 +878,10 @@ public class InvocationExprent extends Exprent {
+@@ -565,6 +859,10 @@ public class InvocationExprent extends Exprent {
          }
          */
  
@@ -790,7 +780,7 @@ index 6fab98e2cbf3a2168daf3f80063123be60caad7b..39c598c178c31c2b696946fb252360ba
          // 'byte' and 'short' literals need an explicit narrowing type cast when used as a parameter
          ExprProcessor.getCastedExprent(this.parameters.get(i), types[i], buff, indent, true, ambiguous, true, true, tracer);
  
-@@ -589,8 +897,6 @@ public class InvocationExprent extends Exprent {
+@@ -580,8 +878,6 @@ public class InvocationExprent extends Exprent {
        }
      }
  
@@ -799,7 +789,7 @@ index 6fab98e2cbf3a2168daf3f80063123be60caad7b..39c598c178c31c2b696946fb252360ba
      return buf;
    }
  
-@@ -888,6 +1194,162 @@ public class InvocationExprent extends Exprent {
+@@ -869,6 +1165,162 @@ public class InvocationExprent extends Exprent {
      return ambiguous;
    }
  
@@ -962,7 +952,7 @@ index 6fab98e2cbf3a2168daf3f80063123be60caad7b..39c598c178c31c2b696946fb252360ba
    @Override
    public void replaceExprent(Exprent oldExpr, Exprent newExpr) {
      if (oldExpr == instance) {
-@@ -1000,6 +1462,19 @@ public class InvocationExprent extends Exprent {
+@@ -981,6 +1433,19 @@ public class InvocationExprent extends Exprent {
      return isSyntheticNullCheck;
    }
  
@@ -1518,10 +1508,10 @@ index 4115efedd42ef96e61425d05dc83153e20ebf9a2..969d6feb0133be481210b4e24a3db726
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructContext.java b/src/org/jetbrains/java/decompiler/struct/StructContext.java
-index bbbec18e87c940d7daa6983a9ca2b5220e7e2470..0f3dc610ec134a438e81561ee2b15bb97edc3fb3 100644
+index 1274df19dd56bf8061384af8d3db78856f836928..80ad6c5234031d18947bebfb87eda7895ace2550 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructContext.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructContext.java
-@@ -209,6 +209,24 @@ public class StructContext {
+@@ -214,6 +214,24 @@ public class StructContext {
      return false;
    }
  
@@ -1547,10 +1537,10 @@ index bbbec18e87c940d7daa6983a9ca2b5220e7e2470..0f3dc610ec134a438e81561ee2b15bb9
      for (String line : string.split("\n")) {
        String[] pts = line.split(" ");
 diff --git a/src/org/jetbrains/java/decompiler/struct/gen/VarType.java b/src/org/jetbrains/java/decompiler/struct/gen/VarType.java
-index d8388e50f6c88e91a0007854400e756153cdb4a6..ab44a6ab25070cb0069c2f55584a992736051420 100644
+index 44d120256a8020b833567fe0f24c7b2c67caafde..1aabd99f31376417b6b72f3150af3823b04f9de8 100644
 --- a/src/org/jetbrains/java/decompiler/struct/gen/VarType.java
 +++ b/src/org/jetbrains/java/decompiler/struct/gen/VarType.java
-@@ -445,8 +445,10 @@ public class VarType implements Type {  // TODO: optimize switch
+@@ -390,8 +390,10 @@ public class VarType implements Type {  // TODO: optimize switch
    }
  
    public VarType remap(Map<VarType, VarType> map) {
@@ -1564,7 +1554,7 @@ index d8388e50f6c88e91a0007854400e756153cdb4a6..ab44a6ab25070cb0069c2f55584a9927
      return this;
    }
 diff --git a/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericType.java b/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericType.java
-index 077ebbd169338e0cf4db79bb75100a944026dfd3..dc8ef5e1205598b7f50bca3b3fb24a2cf0d422fb 100644
+index e430a99b30757bb0ba5b8dda66e0790383ab8d75..3343efecd7fd33b16ef02bc3885bb053925c72ad 100644
 --- a/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericType.java
 +++ b/src/org/jetbrains/java/decompiler/struct/gen/generics/GenericType.java
 @@ -5,15 +5,19 @@ import org.jetbrains.java.decompiler.code.CodeConstants;
@@ -1596,7 +1586,7 @@ index 077ebbd169338e0cf4db79bb75100a944026dfd3..dc8ef5e1205598b7f50bca3b3fb24a2c
    public GenericType(int type, int arrayDim, String value, VarType parent, List<VarType> arguments, int wildcard) {
      super(type, arrayDim, value, getFamily(type, arrayDim), getStackSize(type, arrayDim), false);
      this.parent = parent;
-@@ -243,6 +249,14 @@ public class GenericType extends VarType implements Type {
+@@ -233,6 +239,14 @@ public class GenericType extends VarType implements Type {
      return value.substring(0, index + 1);
    }
  
@@ -1611,7 +1601,7 @@ index 077ebbd169338e0cf4db79bb75100a944026dfd3..dc8ef5e1205598b7f50bca3b3fb24a2c
    @Override
    public GenericType decreaseArrayDim() {
      assert getArrayDim() > 0 : this;
-@@ -264,7 +278,7 @@ public class GenericType extends VarType implements Type {
+@@ -254,7 +268,7 @@ public class GenericType extends VarType implements Type {
  
    @Override
    public boolean isGeneric() {
@@ -1620,7 +1610,7 @@ index 077ebbd169338e0cf4db79bb75100a944026dfd3..dc8ef5e1205598b7f50bca3b3fb24a2c
    }
  
    public int getWildcard() {
-@@ -347,6 +361,10 @@ public class GenericType extends VarType implements Type {
+@@ -337,6 +351,10 @@ public class GenericType extends VarType implements Type {
    public VarType remap(Map<VarType, VarType> map) {
      VarType main = super.remap(map);
      if (main != this) {
@@ -1631,7 +1621,7 @@ index 077ebbd169338e0cf4db79bb75100a944026dfd3..dc8ef5e1205598b7f50bca3b3fb24a2c
        return main;
      }
      boolean changed = false;
-@@ -373,4 +391,267 @@ public class GenericType extends VarType implements Type {
+@@ -363,4 +381,267 @@ public class GenericType extends VarType implements Type {
      }
      return this;
    }

--- a/FernFlower-Patches/0029-Improve-stack-var-processor-output.patch
+++ b/FernFlower-Patches/0029-Improve-stack-var-processor-output.patch
@@ -24,7 +24,7 @@ index 4713a0212ee1ae4cc269dd24f2227a91a2c9beed..9ae846d540337db99dc054ec1a43271e
  
        if (TryHelper.enhanceTryStats(root, mt)) {
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-index 4fb8a34372213f8edbc240f0d5b640cae87255f9..7ff8189c79027ace17746cd11bddfb3de63f8e9a 100644
+index 866cea112a60907c3ef02160a3b6c0bac1a075ae..1b2401d38d63dcca4eb4b4d7ed24aa23da9c98fb 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 @@ -141,6 +141,9 @@ public class NestedClassProcessor {

--- a/FernFlower-Patches/0029-Improve-stack-var-processor-output.patch
+++ b/FernFlower-Patches/0029-Improve-stack-var-processor-output.patch
@@ -318,7 +318,7 @@ index d8fd9bdf784704836e69cfdd1596ae29b2732232..139ccdb55347a5d66627c1489ee73910
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 3e6ce9270be0fccd24fc247abd5fdff1e3a4777f..f6716268e432d3f7061e58b7bbdb5ecec61520c8 100644
+index 962b7a9b85ef5fd29bce0c2953748a6cd3a87ea7..ee533a7ab76350ce982406120e439919070fa18f 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -162,6 +162,11 @@ public class InvocationExprent extends Exprent {

--- a/FernFlower-Patches/0029-Improve-stack-var-processor-output.patch
+++ b/FernFlower-Patches/0029-Improve-stack-var-processor-output.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Improve stack var processor output
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
-index cc6f6ad706aa1fcb0b129ea9da80b47fd77f0a5f..dbee9d14a323279ca226e5e6f32f0f4182d22dc9 100644
+index 4713a0212ee1ae4cc269dd24f2227a91a2c9beed..9ae846d540337db99dc054ec1a43271e2d41ab7d 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
 @@ -183,11 +183,12 @@ public class MethodProcessorRunnable implements Runnable {
@@ -24,7 +24,7 @@ index cc6f6ad706aa1fcb0b129ea9da80b47fd77f0a5f..dbee9d14a323279ca226e5e6f32f0f41
  
        if (TryHelper.enhanceTryStats(root, mt)) {
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-index 52575665f1021b39a09412a774587b10dad34812..11d8ee5bda5802de54f689c797e8a06f11c1627f 100644
+index 866cea112a60907c3ef02160a3b6c0bac1a075ae..1b2401d38d63dcca4eb4b4d7ed24aa23da9c98fb 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 @@ -141,6 +141,9 @@ public class NestedClassProcessor {
@@ -38,10 +38,10 @@ index 52575665f1021b39a09412a774587b10dad34812..11d8ee5bda5802de54f689c797e8a06f
                }
                else {
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
-index 6d42db459055d505604728dcac4af7bb74a9e21c..80c7722f9a189acab1af7d8a8b5666b7fc0a66fe 100644
+index efa677ae6cfdc08635eff080c7241ec086e5c945..36cc1c986f5a5aeeea6f4cfe3897666ed2fbf847 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SimplifyExprentsHelper.java
-@@ -134,6 +134,11 @@ public class SimplifyExprentsHelper {
+@@ -135,6 +135,11 @@ public class SimplifyExprentsHelper {
        }
  
        Exprent next = list.get(index + 1);
@@ -53,7 +53,7 @@ index 6d42db459055d505604728dcac4af7bb74a9e21c..80c7722f9a189acab1af7d8a8b5666b7
  
        // constructor invocation
        if (isConstructorInvocationRemote(list, index)) {
-@@ -341,6 +346,27 @@ public class SimplifyExprentsHelper {
+@@ -342,6 +347,27 @@ public class SimplifyExprentsHelper {
      return 0;
    }
  
@@ -318,10 +318,10 @@ index d8fd9bdf784704836e69cfdd1596ae29b2732232..139ccdb55347a5d66627c1489ee73910
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 39c598c178c31c2b696946fb252360baa5fcddc9..bb9986f561c0e13db9971ffbedf5f3fd14e26a10 100644
+index 3e6ce9270be0fccd24fc247abd5fdff1e3a4777f..f6716268e432d3f7061e58b7bbdb5ecec61520c8 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-@@ -169,6 +169,11 @@ public class InvocationExprent extends Exprent {
+@@ -162,6 +162,11 @@ public class InvocationExprent extends Exprent {
      addBytecodeOffsets(expr.bytecode);
      bootstrapArguments = expr.getBootstrapArguments();
      isSyntheticNullCheck = expr.isSyntheticNullCheck();
@@ -369,7 +369,7 @@ index 4f8602a2c55bc1be876d254346fdc38b15c5a2f5..135c633ac8ed35d6ccb4d24131395ec6
      VarVersionPair pair = getVarVersionPair();
      if (lvt != null)
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java
-index 3917ae87c6d147e808768ffc717cc24b08b3f433..425835112eb41eef31457d309e8c66332402e9cc 100644
+index 82e8870671180ade3be93bbb54920b0321a9912b..e269d88570f392511ecc19984feeec2dee66019b 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAConstructorSparseEx.java
 @@ -98,7 +98,7 @@ public class SSAConstructorSparseEx {
@@ -391,7 +391,7 @@ index 3917ae87c6d147e808768ffc717cc24b08b3f433..425835112eb41eef31457d309e8c6633
              else {
                varmapFalse = varmaparr[1];
 @@ -175,7 +175,7 @@ public class SSAConstructorSparseEx {
-           case FunctionExprent.FUNCTION_CADD:
+           case FunctionExprent.FUNCTION_CADD -> {
              processExprent(func.getLstOperands().get(0), varmaparr);
  
 -            SFormsFastMapDirect[] varmaparrAnd = new SFormsFastMapDirect[]{new SFormsFastMapDirect(varmaparr[0]), null};
@@ -408,7 +408,7 @@ index 3917ae87c6d147e808768ffc717cc24b08b3f433..425835112eb41eef31457d309e8c6633
  
              processExprent(func.getLstOperands().get(1), varmaparrOr);
  
-@@ -239,7 +239,7 @@ public class SSAConstructorSparseEx {
+@@ -241,7 +241,7 @@ public class SSAConstructorSparseEx {
        Integer varindex = vardest.getIndex();
        FastSparseSet<Integer> vers = varmap.get(varindex);
  
@@ -417,7 +417,7 @@ index 3917ae87c6d147e808768ffc717cc24b08b3f433..425835112eb41eef31457d309e8c6633
        if (cardinality == 1) { // == 1
          // set version
          Integer it = vers.iterator().next();
-@@ -264,7 +264,17 @@ public class SSAConstructorSparseEx {
+@@ -266,7 +266,17 @@ public class SSAConstructorSparseEx {
            // create new phi node
            phi.put(new VarVersionPair(varindex, nextver), vers);
          }
@@ -437,7 +437,7 @@ index 3917ae87c6d147e808768ffc717cc24b08b3f433..425835112eb41eef31457d309e8c6633
    }
  
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java
-index d233d671b4d1bdeb14327bb155310d3b792b932d..e6a75ccc4e43e43ae12cd641942d029a338ee485 100644
+index 5e1e323a6e2043d776c513e800056be200ab2971..0262a3378080ce4a283ee12a44d11e921fca5777 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/sforms/SSAUConstructorSparseEx.java
 @@ -64,6 +64,9 @@ public class SSAUConstructorSparseEx {
@@ -469,7 +469,7 @@ index d233d671b4d1bdeb14327bb155310d3b792b932d..e6a75ccc4e43e43ae12cd641942d029a
              else {
                varmapFalse = varmaparr[1];
 @@ -194,7 +197,7 @@ public class SSAUConstructorSparseEx {
-           case FunctionExprent.FUNCTION_CADD:
+           case FunctionExprent.FUNCTION_CADD -> {
              processExprent(func.getLstOperands().get(0), varmaparr, stat, calcLiveVars);
  
 -            SFormsFastMapDirect[] varmaparrAnd = new SFormsFastMapDirect[]{new SFormsFastMapDirect(varmaparr[0]), null};
@@ -486,7 +486,7 @@ index d233d671b4d1bdeb14327bb155310d3b792b932d..e6a75ccc4e43e43ae12cd641942d029a
  
              processExprent(func.getLstOperands().get(1), varmaparrOr, stat, calcLiveVars);
  
-@@ -288,7 +291,7 @@ public class SSAUConstructorSparseEx {
+@@ -290,7 +293,7 @@ public class SSAUConstructorSparseEx {
          varassign.setVersion(nextver);
  
          // ssu graph
@@ -495,7 +495,7 @@ index d233d671b4d1bdeb14327bb155310d3b792b932d..e6a75ccc4e43e43ae12cd641942d029a
  
          setCurrentVar(varmap, varindex, nextver);
        }
-@@ -298,6 +301,17 @@ public class SSAUConstructorSparseEx {
+@@ -300,6 +303,17 @@ public class SSAUConstructorSparseEx {
          }
          setCurrentVar(varmap, varindex, varassign.getVersion());
        }
@@ -513,7 +513,7 @@ index d233d671b4d1bdeb14327bb155310d3b792b932d..e6a75ccc4e43e43ae12cd641942d029a
      }
      else if (expr.type == Exprent.EXPRENT_FUNCTION) { // MM or PP function
        FunctionExprent func = (FunctionExprent)expr;
-@@ -353,7 +367,7 @@ public class SSAUConstructorSparseEx {
+@@ -352,7 +366,7 @@ public class SSAUConstructorSparseEx {
  
        FastSparseSet<Integer> vers = varmap.get(varindex);
  
@@ -522,7 +522,7 @@ index d233d671b4d1bdeb14327bb155310d3b792b932d..e6a75ccc4e43e43ae12cd641942d029a
        if (cardinality == 1) { // size == 1
          if (current_vers != 0) {
            if (calcLiveVars) {
-@@ -401,7 +415,21 @@ public class SSAUConstructorSparseEx {
+@@ -400,7 +414,21 @@ public class SSAUConstructorSparseEx {
          }
  
          createOrUpdatePhiNode(new VarVersionPair(varindex, current_vers), vers, stat);
@@ -545,7 +545,7 @@ index d233d671b4d1bdeb14327bb155310d3b792b932d..e6a75ccc4e43e43ae12cd641942d029a
      }
    }
  
-@@ -472,7 +500,7 @@ public class SSAUConstructorSparseEx {
+@@ -467,7 +495,7 @@ public class SSAUConstructorSparseEx {
  
      VarVersionNode node = nodes.getWithKey(varpaar);
  
@@ -554,7 +554,7 @@ index d233d671b4d1bdeb14327bb155310d3b792b932d..e6a75ccc4e43e43ae12cd641942d029a
    }
  
    private Integer getNextFreeVersion(Integer var, Statement stat) {
-@@ -816,4 +844,8 @@ public class SSAUConstructorSparseEx {
+@@ -810,4 +838,8 @@ public class SSAUConstructorSparseEx {
    public HashMap<Integer, Integer> getMapFieldVars() {
      return mapFieldVars;
    }
@@ -564,7 +564,7 @@ index d233d671b4d1bdeb14327bb155310d3b792b932d..e6a75ccc4e43e43ae12cd641942d029a
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
-index b62210af04100c66a17e17e5d5447af59a69f1bf..8818f4354710b8c832a875900223b7f521c53719 100644
+index ad32facfe21c854c69c16ee51aa885b8c266d7b9..c4c7253e1062be0bae6a15dbd02678ee7c36fee7 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/vars/VarDefinitionHelper.java
 @@ -11,6 +11,7 @@ import org.jetbrains.java.decompiler.modules.decompiler.exps.ConstExprent;
@@ -583,7 +583,7 @@ index b62210af04100c66a17e17e5d5447af59a69f1bf..8818f4354710b8c832a875900223b7f5
    }
  
  
-@@ -1133,4 +1135,79 @@ public class VarDefinitionHelper {
+@@ -1127,4 +1129,79 @@ public class VarDefinitionHelper {
      }
      return false;
    }

--- a/FernFlower-Patches/0029-Improve-stack-var-processor-output.patch
+++ b/FernFlower-Patches/0029-Improve-stack-var-processor-output.patch
@@ -24,7 +24,7 @@ index 4713a0212ee1ae4cc269dd24f2227a91a2c9beed..9ae846d540337db99dc054ec1a43271e
  
        if (TryHelper.enhanceTryStats(root, mt)) {
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-index 866cea112a60907c3ef02160a3b6c0bac1a075ae..1b2401d38d63dcca4eb4b4d7ed24aa23da9c98fb 100644
+index 4fb8a34372213f8edbc240f0d5b640cae87255f9..7ff8189c79027ace17746cd11bddfb3de63f8e9a 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 @@ -141,6 +141,9 @@ public class NestedClassProcessor {

--- a/FernFlower-Patches/0030-Fix-finally-processor-instruction-comparison.patch
+++ b/FernFlower-Patches/0030-Fix-finally-processor-instruction-comparison.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix finally processor instruction comparison
 
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java
-index 362e11b75c647920c328b16cb9f2778537fca275..8ba1c6311feb0993a5603be756dd273cb7b35185 100644
+index b240e83853cff82f917a7fc9f80dab661dd7ceb9..13317a543c5122c97c86801e63e0872a49df8f77 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java
-@@ -852,13 +852,17 @@ public class FinallyProcessor {
+@@ -799,13 +799,17 @@ public class FinallyProcessor {
          int secondOp = second.operand(i);
          if (firstOp != secondOp) {
            // a-load/store instructions

--- a/FernFlower-Patches/0031-Simple-lambda-syntax-support-isl-0-to-disable.patch
+++ b/FernFlower-Patches/0031-Simple-lambda-syntax-support-isl-0-to-disable.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Simple lambda syntax support, --isl=0 to disable.
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 9de1e6e74f51df444b9241470619759a8d70fa47..422863d638ad16ced4ec94e65636652f700ad2b5 100644
+index 6f2f8419d41a240c6d1428be0b0ca9258f058127..d9c338ff9189953329a0812250fb494656eb749a 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -10,14 +10,19 @@ import org.jetbrains.java.decompiler.main.rels.ClassWrapper;

--- a/FernFlower-Patches/0031-Simple-lambda-syntax-support-isl-0-to-disable.patch
+++ b/FernFlower-Patches/0031-Simple-lambda-syntax-support-isl-0-to-disable.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Simple lambda syntax support, --isl=0 to disable.
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 9de1e6e74f51df444b9241470619759a8d70fa47..422863d638ad16ced4ec94e65636652f700ad2b5 100644
+index bbd3fcdc8fa3a4fc6a31a1e3c48eae06e1f97abd..da360b1311981ff45f23a17e6b9ba11ef7f028a4 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -10,14 +10,19 @@ import org.jetbrains.java.decompiler.main.rels.ClassWrapper;

--- a/FernFlower-Patches/0031-Simple-lambda-syntax-support-isl-0-to-disable.patch
+++ b/FernFlower-Patches/0031-Simple-lambda-syntax-support-isl-0-to-disable.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Simple lambda syntax support, --isl=0 to disable.
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 33b0dde4582691d5e6415296a77a9be6fe2e9a01..8b361f06964c228b813a83c5a5bbbe8ab251233a 100644
+index 9de1e6e74f51df444b9241470619759a8d70fa47..422863d638ad16ced4ec94e65636652f700ad2b5 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -10,14 +10,19 @@ import org.jetbrains.java.decompiler.main.rels.ClassWrapper;
@@ -140,16 +140,16 @@ index 9bad04ab4c0cee5afc2623722674e929058062f0..1e1d3bd20fe462b6df4dad18a4dea2b6
      defaults.put(LOG_LEVEL, IFernflowerLogger.Severity.INFO.name());
      defaults.put(MAX_PROCESSING_METHOD, "0");
 diff --git a/test/org/jetbrains/java/decompiler/SingleClassesTest.java b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
-index 9ee13f077fb092089bc874cee4dc53f918009d91..0313a69f077750a99fde54677176ba2eba0ca24f 100644
+index 16ceb1e8e47c90da72ef3039cf625eec25b68223..c78c9554df9788b87028bcf181fc243db7a29f3f 100644
 --- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
 +++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
-@@ -23,7 +23,8 @@ public class SingleClassesTest extends SingleClassesTestBase {
-       IFernflowerPreferences.DUMP_ORIGINAL_LINES, "1",
-       IFernflowerPreferences.IGNORE_INVALID_BYTECODE, "1",
-       IFernflowerPreferences.VERIFY_ANONYMOUS_CLASSES, "1",
--      IFernflowerPreferences.INCLUDE_ENTIRE_CLASSPATH, "1"
-+      IFernflowerPreferences.INCLUDE_ENTIRE_CLASSPATH, "1",
-+      IFernflowerPreferences.INLINE_SIMPLE_LAMBDAS, "0"
-     };
+@@ -24,7 +24,8 @@ public class SingleClassesTest extends SingleClassesTestBase {
+                          IFernflowerPreferences.DUMP_ORIGINAL_LINES, "1",
+                          IFernflowerPreferences.IGNORE_INVALID_BYTECODE, "1",
+                          IFernflowerPreferences.VERIFY_ANONYMOUS_CLASSES, "1",
+-                         IFernflowerPreferences.INCLUDE_ENTIRE_CLASSPATH, "1"
++                         IFernflowerPreferences.INCLUDE_ENTIRE_CLASSPATH, "1",
++                         IFernflowerPreferences.INLINE_SIMPLE_LAMBDAS, "0"
+ );
    }
  

--- a/FernFlower-Patches/0031-Simple-lambda-syntax-support-isl-0-to-disable.patch
+++ b/FernFlower-Patches/0031-Simple-lambda-syntax-support-isl-0-to-disable.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Simple lambda syntax support, --isl=0 to disable.
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index bbd3fcdc8fa3a4fc6a31a1e3c48eae06e1f97abd..da360b1311981ff45f23a17e6b9ba11ef7f028a4 100644
+index 9de1e6e74f51df444b9241470619759a8d70fa47..422863d638ad16ced4ec94e65636652f700ad2b5 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -10,14 +10,19 @@ import org.jetbrains.java.decompiler.main.rels.ClassWrapper;

--- a/FernFlower-Patches/0032-Add-explicit-cast-to-invocations-of-java-nio-Buffer-.patch
+++ b/FernFlower-Patches/0032-Add-explicit-cast-to-invocations-of-java-nio-Buffer-.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Add explicit cast to invocations of java/nio/Buffer
 Java 9+ added overrides to these functions to return the specific subclass, however, when there is a compiler "bug" that when targeting release * or below, it will still reference these new methods, causing exceptions at runtime on Java 8.
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index bb9986f561c0e13db9971ffbedf5f3fd14e26a10..e98c97e61097b448de85182294006fa5603db421 100644
+index f6716268e432d3f7061e58b7bbdb5ecec61520c8..3cd5c4fe54755a06c7485aad5339e689e7b482d4 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -47,6 +47,8 @@ public class InvocationExprent extends Exprent {
@@ -19,7 +19,7 @@ index bb9986f561c0e13db9971ffbedf5f3fd14e26a10..e98c97e61097b448de85182294006fa5
    private String name;
    private String className;
    private boolean isStatic;
-@@ -661,6 +663,12 @@ public class InvocationExprent extends Exprent {
+@@ -654,6 +656,12 @@ public class InvocationExprent extends Exprent {
            else if (instance.getPrecedence() > getPrecedence() && !skippedCast) {
              buf.append("(").append(res).append(")");
            }

--- a/FernFlower-Patches/0032-Add-explicit-cast-to-invocations-of-java-nio-Buffer-.patch
+++ b/FernFlower-Patches/0032-Add-explicit-cast-to-invocations-of-java-nio-Buffer-.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Add explicit cast to invocations of java/nio/Buffer
 Java 9+ added overrides to these functions to return the specific subclass, however, when there is a compiler "bug" that when targeting release * or below, it will still reference these new methods, causing exceptions at runtime on Java 8.
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index f6716268e432d3f7061e58b7bbdb5ecec61520c8..3cd5c4fe54755a06c7485aad5339e689e7b482d4 100644
+index ee533a7ab76350ce982406120e439919070fa18f..fd4fb8c060432591710e25e2941d99c538b547b6 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -47,6 +47,8 @@ public class InvocationExprent extends Exprent {

--- a/FernFlower-Patches/0034-Add-only-argument-It-will-filter-what-classes-are-de.patch
+++ b/FernFlower-Patches/0034-Add-only-argument-It-will-filter-what-classes-are-de.patch
@@ -8,7 +8,7 @@ Uses a prefix system, so -only=net/minecraft/block/ will decompile all classes i
 Useful for debugging to limit scope/runtime.
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
-index e0c4593576ed55313de61adde1a5e175b75d0825..28bc5654aa5167f0e1e99a599d73cb6017cd7f2b 100644
+index 2c67a4fbcdf011cc91b9166f616feb27ce9dcd4c..3e168efbd10b661519a01fb48a3aabc16460f840 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 @@ -36,6 +36,7 @@ public class ClassesProcessor implements CodeConstants {

--- a/FernFlower-Patches/0036-Do-not-rebuild-variable-names-in-lambdas.patch
+++ b/FernFlower-Patches/0036-Do-not-rebuild-variable-names-in-lambdas.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Do not rebuild variable names in lambdas.
 Breaks outer this references. Code existed before my time, no idea what it's intention is.
 
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-index 7ff8189c79027ace17746cd11bddfb3de63f8e9a..dae076784729d46291005ad024d02816ab4a5806 100644
+index 1b2401d38d63dcca4eb4b4d7ed24aa23da9c98fb..5a52b4d9b2c4810cceeb7df3e2271a3dd6ddbe7f 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 @@ -163,7 +163,7 @@ public class NestedClassProcessor {

--- a/FernFlower-Patches/0036-Do-not-rebuild-variable-names-in-lambdas.patch
+++ b/FernFlower-Patches/0036-Do-not-rebuild-variable-names-in-lambdas.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Do not rebuild variable names in lambdas.
 Breaks outer this references. Code existed before my time, no idea what it's intention is.
 
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-index 1b2401d38d63dcca4eb4b4d7ed24aa23da9c98fb..5a52b4d9b2c4810cceeb7df3e2271a3dd6ddbe7f 100644
+index 7ff8189c79027ace17746cd11bddfb3de63f8e9a..dae076784729d46291005ad024d02816ab4a5806 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 @@ -163,7 +163,7 @@ public class NestedClassProcessor {

--- a/FernFlower-Patches/0036-Do-not-rebuild-variable-names-in-lambdas.patch
+++ b/FernFlower-Patches/0036-Do-not-rebuild-variable-names-in-lambdas.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Do not rebuild variable names in lambdas.
 Breaks outer this references. Code existed before my time, no idea what it's intention is.
 
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-index 11d8ee5bda5802de54f689c797e8a06f11c1627f..b531db78bf55aed572f05215033c290bbb9e05c0 100644
+index 1b2401d38d63dcca4eb4b4d7ed24aa23da9c98fb..5a52b4d9b2c4810cceeb7df3e2271a3dd6ddbe7f 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 @@ -163,7 +163,7 @@ public class NestedClassProcessor {

--- a/FernFlower-Patches/0037-Add-toString-to-MethodDescriptor.patch
+++ b/FernFlower-Patches/0037-Add-toString-to-MethodDescriptor.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add toString to MethodDescriptor
 
 
 diff --git a/src/org/jetbrains/java/decompiler/struct/gen/MethodDescriptor.java b/src/org/jetbrains/java/decompiler/struct/gen/MethodDescriptor.java
-index 8044f348e8aad96f451a47ef24f54972e171b9c7..10a2e187ab1d877e7adca38628c197183b4d8352 100644
+index 49494925b2d67b95920bb2b8c8371e886341492f..9b0d6157a3827b0b269a4e396cd91ff93bdf2261 100644
 --- a/src/org/jetbrains/java/decompiler/struct/gen/MethodDescriptor.java
 +++ b/src/org/jetbrains/java/decompiler/struct/gen/MethodDescriptor.java
 @@ -19,11 +19,13 @@ import java.util.Objects;
@@ -23,7 +23,7 @@ index 8044f348e8aad96f451a47ef24f54972e171b9c7..10a2e187ab1d877e7adca38628c19718
    }
  
    public static MethodDescriptor parseDescriptor(String descriptor) {
-@@ -70,7 +72,7 @@ public final class MethodDescriptor {
+@@ -71,7 +73,7 @@ public final class MethodDescriptor {
  
      VarType ret = new VarType(descriptor.substring(parenth + 1));
  
@@ -32,7 +32,7 @@ index 8044f348e8aad96f451a47ef24f54972e171b9c7..10a2e187ab1d877e7adca38628c19718
    }
  
    public static MethodDescriptor parseDescriptor(StructMethod struct, ClassNode node) {
-@@ -155,6 +157,11 @@ public final class MethodDescriptor {
+@@ -150,6 +152,11 @@ public final class MethodDescriptor {
      return null;
    }
  

--- a/FernFlower-Patches/0038-Make-decomp-threaded.patch
+++ b/FernFlower-Patches/0038-Make-decomp-threaded.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Make decomp threaded
 `-thr AUTO` to auto select, (default)
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
-index 28bc5654aa5167f0e1e99a599d73cb6017cd7f2b..9776ab40a5d1a4df0fc84ace958815cbfac00dff 100644
+index 3e168efbd10b661519a01fb48a3aabc16460f840..573e8342b16e51b8c9a945b4513657c6f64f17c2 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassesProcessor.java
 @@ -30,12 +30,13 @@ import org.jetbrains.java.decompiler.util.TextBuffer;
@@ -25,7 +25,7 @@ index 28bc5654aa5167f0e1e99a599d73cb6017cd7f2b..9776ab40a5d1a4df0fc84ace958815cb
    private final Set<String> whitelist = new HashSet<>();
  
    private static class Inner {
-@@ -399,7 +400,7 @@ public class ClassesProcessor implements CodeConstants {
+@@ -396,7 +397,7 @@ public class ClassesProcessor implements CodeConstants {
      return true;
    }
  
@@ -34,7 +34,7 @@ index 28bc5654aa5167f0e1e99a599d73cb6017cd7f2b..9776ab40a5d1a4df0fc84ace958815cb
      ClassNode root = mapRootClasses.get(cl.qualifiedName);
      if (root.type != ClassNode.CLASS_ROOT) {
        return;
-@@ -408,25 +409,12 @@ public class ClassesProcessor implements CodeConstants {
+@@ -405,25 +406,12 @@ public class ClassesProcessor implements CodeConstants {
      boolean packageInfo = cl.isSynthetic() && "package-info".equals(root.simpleName);
      boolean moduleInfo = cl.hasModifier(CodeConstants.ACC_MODULE) && cl.hasAttribute(StructGeneralAttribute.ATTRIBUTE_MODULE);
  
@@ -63,7 +63,7 @@ index 28bc5654aa5167f0e1e99a599d73cb6017cd7f2b..9776ab40a5d1a4df0fc84ace958815cb
          new LambdaProcessor().processClass(root);
  
          // add simple class names to implicit import
-@@ -438,7 +426,36 @@ public class ClassesProcessor implements CodeConstants {
+@@ -435,7 +423,36 @@ public class ClassesProcessor implements CodeConstants {
          new NestedClassProcessor().processClass(root, root);
  
          new NestedMemberAccess().propagateMemberAccess(root);
@@ -100,7 +100,7 @@ index 28bc5654aa5167f0e1e99a599d73cb6017cd7f2b..9776ab40a5d1a4df0fc84ace958815cb
          TextBuffer classBuffer = new TextBuffer(AVERAGE_CLASS_SIZE);
          new ClassWriter().classToJava(root, classBuffer, 0, null);
  
-@@ -448,7 +465,7 @@ public class ClassesProcessor implements CodeConstants {
+@@ -445,7 +462,7 @@ public class ClassesProcessor implements CodeConstants {
            buffer.append("package ").append(packageName).append(';').appendLineSeparator().appendLineSeparator();
          }
  
@@ -671,7 +671,7 @@ index 1e1d3bd20fe462b6df4dad18a4dea2b611376298..e9aa42e6801916d0acad2541d88b8ad7
      defaults.put(LOG_LEVEL, IFernflowerLogger.Severity.INFO.name());
      defaults.put(MAX_PROCESSING_METHOD, "0");
 diff --git a/src/org/jetbrains/java/decompiler/struct/ContextUnit.java b/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
-index c33a9aa83f61a22940b1864d6bbfcdd7ba78e38d..4e64b70da8fe886801e027a7ae6c0e59f94cf62a 100644
+index 7b0946ed0de6af2dbe2043332650a09880027726..7d44617f437ad6e78e204d56c394be5e0d5962c4 100644
 --- a/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
 +++ b/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
 @@ -14,8 +14,14 @@ import java.io.IOException;
@@ -701,7 +701,7 @@ index c33a9aa83f61a22940b1864d6bbfcdd7ba78e38d..4e64b70da8fe886801e027a7ae6c0e59
              if (content != null) {
                int[] mapping = null;
                if (DecompilerContext.getOption(IFernflowerPreferences.BYTECODE_SOURCE_MAPPING)) {
-@@ -152,13 +161,51 @@ public class ContextUnit {
+@@ -149,13 +158,51 @@ public class ContextUnit {
            }
          }
  
@@ -759,7 +759,7 @@ index c33a9aa83f61a22940b1864d6bbfcdd7ba78e38d..4e64b70da8fe886801e027a7ae6c0e59
            }
          }
  
-@@ -166,6 +213,16 @@ public class ContextUnit {
+@@ -164,6 +211,16 @@ public class ContextUnit {
      }
    }
  
@@ -776,7 +776,7 @@ index c33a9aa83f61a22940b1864d6bbfcdd7ba78e38d..4e64b70da8fe886801e027a7ae6c0e59
    public void setManifest(Manifest manifest) {
      this.manifest = manifest;
    }
-@@ -177,4 +234,18 @@ public class ContextUnit {
+@@ -175,4 +232,18 @@ public class ContextUnit {
    public List<StructClass> getClasses() {
      return classes;
    }

--- a/FernFlower-Patches/0039-Expose-line-mapping-information-in-archive-mode.patch
+++ b/FernFlower-Patches/0039-Expose-line-mapping-information-in-archive-mode.patch
@@ -211,10 +211,10 @@ index cf03900654e427bd435ba6dc2d5a0cec8c8708e4..017d3975a3cbe06e485b65ca1b75d6c6
 +  }
  }
 diff --git a/src/org/jetbrains/java/decompiler/struct/ContextUnit.java b/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
-index 4e64b70da8fe886801e027a7ae6c0e59f94cf62a..5b669d8b71d9601769988c41f64650926cadfc5f 100644
+index 7d44617f437ad6e78e204d56c394be5e0d5962c4..32a48812223687f21030a448926e45a3f89061cb 100644
 --- a/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
 +++ b/src/org/jetbrains/java/decompiler/struct/ContextUnit.java
-@@ -196,6 +196,9 @@ public class ContextUnit {
+@@ -193,6 +193,9 @@ public class ContextUnit {
              futures.add(executor.submit(() -> {
                DecompilerContext.setCurrentContext(clCtx.ctx);
                clCtx.classContent = decompiledData.getClassContent(clCtx.cl);
@@ -224,7 +224,7 @@ index 4e64b70da8fe886801e027a7ae6c0e59f94cf62a..5b669d8b71d9601769988c41f6465092
                DecompilerContext.setCurrentContext(null);
              }));
            }
-@@ -205,7 +208,7 @@ public class ContextUnit {
+@@ -202,7 +205,7 @@ public class ContextUnit {
  
          for (final ClassContext clCtx : toProcess) {
            if (clCtx.shouldContinue) {
@@ -233,7 +233,7 @@ index 4e64b70da8fe886801e027a7ae6c0e59f94cf62a..5b669d8b71d9601769988c41f6465092
            }
          }
  
-@@ -241,6 +244,7 @@ public class ContextUnit {
+@@ -239,6 +242,7 @@ public class ContextUnit {
      public boolean shouldContinue;
      public DecompilerContext ctx;
      String classContent;
@@ -242,10 +242,10 @@ index 4e64b70da8fe886801e027a7ae6c0e59f94cf62a..5b669d8b71d9601769988c41f6465092
      private ClassContext(StructClass cl, String entryName) {
        this.cl = cl;
 diff --git a/test/org/jetbrains/java/decompiler/MinecraftTest.java b/test/org/jetbrains/java/decompiler/MinecraftTest.java
-index c00385f0f59014289ddb152e4dc4e908a8427fb6..a4d18cddb429e22c18519e65267366578b73bbf1 100644
+index 1f9a9dd03dab30cdb464bfc4901b9c592d558b8f..1e60f70430e50430928ac902c8dd7bfb63ef0c8c 100644
 --- a/test/org/jetbrains/java/decompiler/MinecraftTest.java
 +++ b/test/org/jetbrains/java/decompiler/MinecraftTest.java
-@@ -68,7 +68,7 @@ public class MinecraftTest  extends SingleClassesTestBase {
+@@ -65,7 +65,7 @@ public class MinecraftTest extends SingleClassesTestBase {
            }
  
            @Override

--- a/FernFlower-Patches/0040-Fixup-J9-string-concat.patch
+++ b/FernFlower-Patches/0040-Fixup-J9-string-concat.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fixup J9 string concat
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
-index dbee9d14a323279ca226e5e6f32f0f4182d22dc9..6e642b683d504ade9edef4ea32c154fbd4a219c9 100644
+index 9ae846d540337db99dc054ec1a43271e2d41ab7d..74532a087d53613065490b1bd3bf545719e4b3e7 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
 @@ -161,6 +161,10 @@ public class MethodProcessorRunnable implements Runnable {
@@ -20,7 +20,7 @@ index dbee9d14a323279ca226e5e6f32f0f4182d22dc9..6e642b683d504ade9edef4ea32c154fb
        LabelHelper.cleanUpEdges(root);
  
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/ConcatenationHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/ConcatenationHelper.java
-index f1f3e7c7e903dd0571c2a18f1ed976999cff99da..e44fa1ffd3929428524c31fdac14f1df2e6a6431 100644
+index d85dead7cab48a9f551cb1226ef952807a067ec8..2aa9f91fc062ba76939d915428e84f6183fb7f71 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/ConcatenationHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/ConcatenationHelper.java
 @@ -4,6 +4,7 @@ package org.jetbrains.java.decompiler.modules.decompiler;
@@ -70,7 +70,7 @@ index f1f3e7c7e903dd0571c2a18f1ed976999cff99da..e44fa1ffd3929428524c31fdac14f1df
  
    public static Exprent contractStringConcat(Exprent expr) {
  
-@@ -150,6 +183,7 @@ public final class ConcatenationHelper {
+@@ -151,6 +184,7 @@ public final class ConcatenationHelper {
          StringBuilder acc = new StringBuilder();
          int parameterId = 0;
          int bootstrapArgumentId = 1;
@@ -78,7 +78,7 @@ index f1f3e7c7e903dd0571c2a18f1ed976999cff99da..e44fa1ffd3929428524c31fdac14f1df
          for (int i = 0; i < recipe.length(); i++) {
            char c = recipe.charAt(i);
  
-@@ -172,13 +206,12 @@ public final class ConcatenationHelper {
+@@ -173,13 +207,12 @@ public final class ConcatenationHelper {
              if (c == TAG_ARG) {
                Exprent exprent = parameters.get(parameterId++);
  

--- a/FernFlower-Patches/0041-Fix-compound-assignments.patch
+++ b/FernFlower-Patches/0041-Fix-compound-assignments.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix compound assignments
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
-index 6e642b683d504ade9edef4ea32c154fbd4a219c9..417f21f05257086df8f9f5974216d0e40e58c960 100644
+index 74532a087d53613065490b1bd3bf545719e4b3e7..f66e835ab7cd7b03ada0a433b1edf357f5d6efcd 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
 @@ -228,6 +228,8 @@ public class MethodProcessorRunnable implements Runnable {
@@ -18,10 +18,10 @@ index 6e642b683d504ade9edef4ea32c154fbd4a219c9..417f21f05257086df8f9f5974216d0e4
      // FIXME: new edge type needed
      LabelHelper.replaceContinueWithBreak(root);
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/SecondaryFunctionsHelper.java b/src/org/jetbrains/java/decompiler/modules/decompiler/SecondaryFunctionsHelper.java
-index ed57b52d919ea3c2cb774f28a04b0893e1eb5c7f..26adff36fff4172f2a195ded8246effacd04de4e 100644
+index 4a1ad182cf4a3ac6ba57f498f87a9c3486b6f08c..5f53e116b874efa1053fdb94bb3b513b9647597b 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/SecondaryFunctionsHelper.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/SecondaryFunctionsHelper.java
-@@ -428,4 +428,46 @@ public final class SecondaryFunctionsHelper {
+@@ -417,4 +417,46 @@ public final class SecondaryFunctionsHelper {
  
      return null;
    }
@@ -69,10 +69,10 @@ index ed57b52d919ea3c2cb774f28a04b0893e1eb5c7f..26adff36fff4172f2a195ded8246effa
 +  }
  }
 diff --git a/test/org/jetbrains/java/decompiler/SingleClassesTest.java b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
-index 0313a69f077750a99fde54677176ba2eba0ca24f..7a8bb7a852b3bf074a4df3c9539bed289434d25b 100644
+index c78c9554df9788b87028bcf181fc243db7a29f3f..58400b28b85b170d589655eae8355b5b11b4e722 100644
 --- a/test/org/jetbrains/java/decompiler/SingleClassesTest.java
 +++ b/test/org/jetbrains/java/decompiler/SingleClassesTest.java
-@@ -212,4 +212,5 @@ public class SingleClassesTest extends SingleClassesTestBase {
+@@ -213,4 +213,5 @@ public class SingleClassesTest extends SingleClassesTestBase {
  
    @Test(expected = ClassFormatException.class)
    public void testUnsupportedConstantPoolEntry() { doTest("java11/TestUnsupportedConstantPoolEntry"); }

--- a/FernFlower-Patches/0042-Filter-out-generated-Record-getters-and-constructor..patch
+++ b/FernFlower-Patches/0042-Filter-out-generated-Record-getters-and-constructor..patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Filter out generated Record getters and constructor. Make
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index da360b1311981ff45f23a17e6b9ba11ef7f028a4..efce8c8e2f829262c6ca4edeb118db2c3d26ffaf 100644
+index 422863d638ad16ced4ec94e65636652f700ad2b5..e80d0f053894394aa40332e1d13d36ff52909601 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -355,6 +355,18 @@ public class ClassWriter {

--- a/FernFlower-Patches/0042-Filter-out-generated-Record-getters-and-constructor..patch
+++ b/FernFlower-Patches/0042-Filter-out-generated-Record-getters-and-constructor..patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Filter out generated Record getters and constructor. Make
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 8b361f06964c228b813a83c5a5bbbe8ab251233a..e4e3ae3e7c35ebf6bf9b8383d534e47a6c9cfcd8 100644
+index 422863d638ad16ced4ec94e65636652f700ad2b5..e80d0f053894394aa40332e1d13d36ff52909601 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -355,6 +355,18 @@ public class ClassWriter {
@@ -28,12 +28,12 @@ index 8b361f06964c228b813a83c5a5bbbe8ab251233a..e4e3ae3e7c35ebf6bf9b8383d534e47a
      }
      return false;
    }
-@@ -681,7 +693,7 @@ public class ClassWriter {
+@@ -680,7 +692,7 @@ public class ClassWriter {
+       boolean isInterface = cl.hasModifier(CodeConstants.ACC_INTERFACE);
        boolean isAnnotation = cl.hasModifier(CodeConstants.ACC_ANNOTATION);
-       boolean isEnum = cl.hasModifier(CodeConstants.ACC_ENUM) && DecompilerContext.getOption(IFernflowerPreferences.DECOMPILE_ENUM);
        boolean isDeprecated = mt.hasAttribute(StructGeneralAttribute.ATTRIBUTE_DEPRECATED);
--      boolean clInit = false, init = false, dInit = false;
-+      boolean clInit = false, init = false, dInit = false, compact = false;
+-      boolean clInit = false, dInit = false;
++      boolean clInit = false, dInit = false, compact = false;
  
        MethodDescriptor md = MethodDescriptor.parseDescriptor(mt, node);
  

--- a/FernFlower-Patches/0042-Filter-out-generated-Record-getters-and-constructor..patch
+++ b/FernFlower-Patches/0042-Filter-out-generated-Record-getters-and-constructor..patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Filter out generated Record getters and constructor. Make
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 422863d638ad16ced4ec94e65636652f700ad2b5..e80d0f053894394aa40332e1d13d36ff52909601 100644
+index d9c338ff9189953329a0812250fb494656eb749a..f217e235da064b672d7ec6b40f6d4bdce27cc65a 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -355,6 +355,18 @@ public class ClassWriter {

--- a/FernFlower-Patches/0042-Filter-out-generated-Record-getters-and-constructor..patch
+++ b/FernFlower-Patches/0042-Filter-out-generated-Record-getters-and-constructor..patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Filter out generated Record getters and constructor. Make
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/ClassWriter.java b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
-index 422863d638ad16ced4ec94e65636652f700ad2b5..e80d0f053894394aa40332e1d13d36ff52909601 100644
+index da360b1311981ff45f23a17e6b9ba11ef7f028a4..efce8c8e2f829262c6ca4edeb118db2c3d26ffaf 100644
 --- a/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 +++ b/src/org/jetbrains/java/decompiler/main/ClassWriter.java
 @@ -355,6 +355,18 @@ public class ClassWriter {

--- a/FernFlower-Patches/0043-Fix-variables-in-finally-blocks-not-getting-renamed.patch
+++ b/FernFlower-Patches/0043-Fix-variables-in-finally-blocks-not-getting-renamed.patch
@@ -5,11 +5,11 @@ Subject: [PATCH] Fix variables in finally blocks not getting renamed
 
 
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java b/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java
-index 8ba1c6311feb0993a5603be756dd273cb7b35185..4032029f16cede8b2fe6ccbd17c9abda458e0e2d 100644
+index 13317a543c5122c97c86801e63e0872a49df8f77..b929df14dd217b8ca79c9170eeb3719d847cbec0 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/FinallyProcessor.java
-@@ -762,23 +762,29 @@ public class FinallyProcessor {
-                                        int finallytype,
+@@ -706,23 +706,29 @@ public class FinallyProcessor {
+                                        int finallyType,
                                         List<int[]> lstStoreVars) {
      InstructionSequence seqPattern = pattern.getSeq();
 +    List<Integer> instrOldOffsetsPattern = pattern.getOriginalOffsets();
@@ -21,24 +21,24 @@ index 8ba1c6311feb0993a5603be756dd273cb7b35185..4032029f16cede8b2fe6ccbd17c9abda
 +      instrOldOffsetsPattern = new ArrayList<>(instrOldOffsetsPattern);
  
        if ((type & 1) > 0) { // first
-         if (finallytype > 0) {
+         if (finallyType > 0) {
 +          instrOldOffsetsPattern.remove(0);
            seqPattern.removeInstruction(0);
          }
        }
  
        if ((type & 2) > 0) { // last
-         if (finallytype == 0 || finallytype == 2) {
+         if (finallyType == 0 || finallyType == 2) {
 +          instrOldOffsetsPattern.remove(instrOldOffsetsPattern.size() - 1);
            seqPattern.removeLast();
          }
  
-         if (finallytype == 2) {
+         if (finallyType == 2) {
 +          instrOldOffsetsPattern.remove(instrOldOffsetsPattern.size() - 1);
            seqPattern.removeLast();
          }
        }
-@@ -805,6 +811,7 @@ public class FinallyProcessor {
+@@ -749,6 +755,7 @@ public class FinallyProcessor {
          seq.addInstruction(0, seqSample.getInstr(i), -1);
          oldOffsets.addFirst(sample.getOriginalOffset(i));
          seqSample.removeInstruction(i);
@@ -46,33 +46,33 @@ index 8ba1c6311feb0993a5603be756dd273cb7b35185..4032029f16cede8b2fe6ccbd17c9abda
        }
  
        BasicBlock newBlock = new BasicBlock(++graph.last_id, seq);
-@@ -967,26 +974,31 @@ public class FinallyProcessor {
+@@ -910,26 +917,31 @@ public class FinallyProcessor {
  
-   private static void removeExceptionInstructionsEx(BasicBlock block, int blocktype, int finallytype) {
+   private static void removeExceptionInstructionsEx(BasicBlock block, int blockType, int finallyType) {
      InstructionSequence seq = block.getSeq();
 +    List<Integer> instrOldOffsets = block.getOriginalOffsets();
  
-     if (finallytype == 3) { // empty finally handler
+     if (finallyType == 3) { // empty finally handler
        for (int i = seq.length() - 1; i >= 0; i--) {
          seq.removeInstruction(i);
 +        instrOldOffsets.remove(i);
        }
      }
      else {
-       if ((blocktype & 1) > 0) { // first
-         if (finallytype == 2 || finallytype == 1) { // astore or pop
+       if ((blockType & 1) > 0) { // first
+         if (finallyType == 2 || finallyType == 1) { // `AStore` or `Pop`
            seq.removeInstruction(0);
 +          instrOldOffsets.remove(0);
          }
        }
  
-       if ((blocktype & 2) > 0) { // last
-         if (finallytype == 2 || finallytype == 0) {
+       if ((blockType & 2) > 0) { // last
+         if (finallyType == 2 || finallyType == 0) {
            seq.removeLast();
 +          instrOldOffsets.remove(instrOldOffsets.size() - 1);
          }
  
-         if (finallytype == 2) { // astore
+         if (finallyType == 2) { // `AStore`
            seq.removeLast();
 +          instrOldOffsets.remove(instrOldOffsets.size() - 1);
          }

--- a/FernFlower-Patches/0044-Search-generics-when-finding-where-to-inject-local-c.patch
+++ b/FernFlower-Patches/0044-Search-generics-when-finding-where-to-inject-local-c.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Search generics when finding where to inject local classes.
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-index b531db78bf55aed572f05215033c290bbb9e05c0..9cdaa21a937fb4ec4b326a00b9be942342fd716c 100644
+index 5a52b4d9b2c4810cceeb7df3e2271a3dd6ddbe7f..df6411f0d562826605d4f9b26666836ae09597b4 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 @@ -25,6 +25,7 @@ import org.jetbrains.java.decompiler.struct.attr.StructGeneralAttribute;
@@ -16,8 +16,8 @@ index b531db78bf55aed572f05215033c290bbb9e05c0..9cdaa21a937fb4ec4b326a00b9be9423
  import org.jetbrains.java.decompiler.util.DotExporter;
  import org.jetbrains.java.decompiler.util.InterpreterUtil;
  
-@@ -935,9 +936,15 @@ public class NestedClassProcessor {
-         case Exprent.EXPRENT_VAR:
+@@ -925,9 +926,15 @@ public class NestedClassProcessor {
+         case Exprent.EXPRENT_VAR -> {
            VarExprent varExpr = (VarExprent)expr;
            if (varExpr.isDefinition()) {
 -            VarType varType = varExpr.getVarType();
@@ -34,7 +34,7 @@ index b531db78bf55aed572f05215033c290bbb9e05c0..9cdaa21a937fb4ec4b326a00b9be9423
 +              }
              }
            }
-       }
+         }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java
 index 135c633ac8ed35d6ccb4d24131395ec6d94ea566..f670f30e2f5c8e2f619d22efc4b61842692b3f11 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/VarExprent.java

--- a/FernFlower-Patches/0044-Search-generics-when-finding-where-to-inject-local-c.patch
+++ b/FernFlower-Patches/0044-Search-generics-when-finding-where-to-inject-local-c.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Search generics when finding where to inject local classes.
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-index 5a52b4d9b2c4810cceeb7df3e2271a3dd6ddbe7f..df6411f0d562826605d4f9b26666836ae09597b4 100644
+index dae076784729d46291005ad024d02816ab4a5806..99b36b0271ae018e7df63166a795e8798813f32c 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 @@ -25,6 +25,7 @@ import org.jetbrains.java.decompiler.struct.attr.StructGeneralAttribute;

--- a/FernFlower-Patches/0044-Search-generics-when-finding-where-to-inject-local-c.patch
+++ b/FernFlower-Patches/0044-Search-generics-when-finding-where-to-inject-local-c.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Search generics when finding where to inject local classes.
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
-index dae076784729d46291005ad024d02816ab4a5806..99b36b0271ae018e7df63166a795e8798813f32c 100644
+index 5a52b4d9b2c4810cceeb7df3e2271a3dd6ddbe7f..df6411f0d562826605d4f9b26666836ae09597b4 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/NestedClassProcessor.java
 @@ -25,6 +25,7 @@ import org.jetbrains.java.decompiler.struct.attr.StructGeneralAttribute;

--- a/FernFlower-Patches/0045-Reduce-allocations-in-getAllExprents.patch
+++ b/FernFlower-Patches/0045-Reduce-allocations-in-getAllExprents.patch
@@ -68,10 +68,10 @@ index c713a4055dfc5aa05143a6cd856c5bd98e05c8c1..a67a38179233f983107222a963a3c766
      lst.add(right);
      return lst;
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
-index c1443e44c5ee72ae04faa1aaedc1c7912879cc91..eb44c08fdc883f577d50d03e31d2b4ac8d4176d9 100644
+index aa922882d5abd2395921bdea4173305810d88335..bd2f432a1bed30237c71f9c483ee8942c67d989b 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/ConstExprent.java
-@@ -186,8 +186,8 @@ public class ConstExprent extends Exprent {
+@@ -187,8 +187,8 @@ public class ConstExprent extends Exprent {
    }
  
    @Override
@@ -191,10 +191,10 @@ index e6e3e9d6f50239c716d285d64f37679bbf0ff553..e02bb03f2517be75a947175b212c3988
        lst.add(instance);
      }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
-index 90cfbde63ada4d96eb78c7192ed0e1fc940f5843..9c23c867139f2bdd5a15f7aae8281e69dd8d37dc 100644
+index c2136584b0ae2a5c7ba34370666bd8b5f4276aaa..2e020987da5a8d9013d12727427d56e369e00549 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/FunctionExprent.java
-@@ -447,8 +447,9 @@ public class FunctionExprent extends Exprent {
+@@ -427,8 +427,9 @@ public class FunctionExprent extends Exprent {
    }
  
    @Override
@@ -229,10 +229,10 @@ index 18d2c40d9af0e822004f4baaa3c6b567914a7545..de3723ed7b731fc76afe15482d4caff8
      return lst;
    }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index e98c97e61097b448de85182294006fa5603db421..6961e5b7ece731f18825dee674a5e1260548dc60 100644
+index 3cd5c4fe54755a06c7485aad5339e689e7b482d4..ec5fd69a7df387aefb9a618d6d3a61a543fd6fb4 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-@@ -530,8 +530,7 @@ public class InvocationExprent extends Exprent {
+@@ -523,8 +523,7 @@ public class InvocationExprent extends Exprent {
    }
  
    @Override

--- a/FernFlower-Patches/0045-Reduce-allocations-in-getAllExprents.patch
+++ b/FernFlower-Patches/0045-Reduce-allocations-in-getAllExprents.patch
@@ -229,7 +229,7 @@ index 18d2c40d9af0e822004f4baaa3c6b567914a7545..de3723ed7b731fc76afe15482d4caff8
      return lst;
    }
 diff --git a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
-index 3cd5c4fe54755a06c7485aad5339e689e7b482d4..ec5fd69a7df387aefb9a618d6d3a61a543fd6fb4 100644
+index fd4fb8c060432591710e25e2941d99c538b547b6..20a42e0a68dc8974fd4fc8bd3b50deddd66d307d 100644
 --- a/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 +++ b/src/org/jetbrains/java/decompiler/modules/decompiler/exps/InvocationExprent.java
 @@ -523,8 +523,7 @@ public class InvocationExprent extends Exprent {

--- a/FernFlower-Patches/0046-Cache-zip-file-instances-and-source-class-data.patch
+++ b/FernFlower-Patches/0046-Cache-zip-file-instances-and-source-class-data.patch
@@ -211,7 +211,7 @@ index 017d3975a3cbe06e485b65ca1b75d6c64d62c249..e4583691c76eee3a12c27f9e4d7538cd
      if (mappings == null || mappings.length == 0 || !DecompilerContext.getOption(IFernflowerPreferences.DUMP_CODE_LINES)) {
        return null;
 diff --git a/src/org/jetbrains/java/decompiler/struct/StructContext.java b/src/org/jetbrains/java/decompiler/struct/StructContext.java
-index 0f3dc610ec134a438e81561ee2b15bb97edc3fb3..c3cdea305c71f1add8da3e7aed5bbfd0f54a78d9 100644
+index 80ad6c5234031d18947bebfb87eda7895ace2550..87aacfb1b80ae371754ccf86ee1dec38bc029c80 100644
 --- a/src/org/jetbrains/java/decompiler/struct/StructContext.java
 +++ b/src/org/jetbrains/java/decompiler/struct/StructContext.java
 @@ -3,6 +3,7 @@ package org.jetbrains.java.decompiler.struct;
@@ -222,7 +222,7 @@ index 0f3dc610ec134a438e81561ee2b15bb97edc3fb3..c3cdea305c71f1add8da3e7aed5bbfd0
  import org.jetbrains.java.decompiler.main.extern.IFernflowerLogger.Severity;
  import org.jetbrains.java.decompiler.struct.gen.generics.GenericMain;
  import org.jetbrains.java.decompiler.struct.gen.generics.GenericMethodDescriptor;
-@@ -153,7 +154,7 @@ public class StructContext {
+@@ -158,7 +159,7 @@ public class StructContext {
              StructClass cl = StructClass.create(new DataInputFullStream(bytes), isOwn, loader);
              classes.put(cl.qualifiedName, cl);
              unit.addClass(cl, name);
@@ -231,7 +231,7 @@ index 0f3dc610ec134a438e81561ee2b15bb97edc3fb3..c3cdea305c71f1add8da3e7aed5bbfd0
            }
            else {
              unit.addOtherEntry(file.getAbsolutePath(), name);
-@@ -246,4 +247,12 @@ public class StructContext {
+@@ -251,4 +252,12 @@ public class StructContext {
      List<String> params = this.abstractNames.get(className + ' ' + methodName + ' ' + descriptor);
      return params != null && index < params.size() ? params.get(index) : _default;
    }
@@ -295,19 +295,19 @@ index 0000000000000000000000000000000000000000..f6eabd65a54198170927ef523deb63e5
 +  }
 +}
 diff --git a/test/org/jetbrains/java/decompiler/DecompilerTestFixture.java b/test/org/jetbrains/java/decompiler/DecompilerTestFixture.java
-index 7d29c198014cbfee8092fd31461208ce58e7f775..1af0ba49459b15bcc9d6bea2f618cf396a2202b2 100644
+index 49cbf8407df5952f3da980e6a10f284ff2f27817..ab0c999a20a8a4598993baf09affe91a3cdf5fc9 100644
 --- a/test/org/jetbrains/java/decompiler/DecompilerTestFixture.java
 +++ b/test/org/jetbrains/java/decompiler/DecompilerTestFixture.java
-@@ -60,7 +60,7 @@ public class DecompilerTestFixture {
-     if (tempDir != null && cleanup) {
-       delete(tempDir);
+@@ -62,7 +62,7 @@ public class DecompilerTestFixture {
+       }
      }
--    decompiler.close();
-+    decompiler.clear();
+     finally {
+-      decompiler.close();
++      decompiler.clear();
+     }
    }
  
-   public File getTestDataDir() {
-@@ -149,7 +149,7 @@ public class DecompilerTestFixture {
+@@ -157,7 +157,7 @@ public class DecompilerTestFixture {
        }
      }
  

--- a/FernFlower-Patches/0047-Fix-signature-polymorphic-methods.patch
+++ b/FernFlower-Patches/0047-Fix-signature-polymorphic-methods.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix signature polymorphic methods
 
 
 diff --git a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
-index 417f21f05257086df8f9f5974216d0e40e58c960..8f5843341e46cc2117780700bacbd5d72cd8099a 100644
+index f66e835ab7cd7b03ada0a433b1edf357f5d6efcd..c825f65f521ba8c1123217aa22bc731bc91b13e7 100644
 --- a/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
 +++ b/src/org/jetbrains/java/decompiler/main/rels/MethodProcessorRunnable.java
 @@ -193,6 +193,8 @@ public class MethodProcessorRunnable implements Runnable {


### PR DESCRIPTION
Rebases to upstream [0e3593f12741eed59e88368eba933bb10fd4f6a6](https://github.com/MinecraftForge/FernFlower/commit/0e3593f12741eed59e88368eba933bb10fd4f6a6).

See diff of upstream changes [here](https://github.com/MinecraftForge/FernFlower/compare/2545452a51edfbdbb35f46a6db75dc60530afb7a..0e3593f12741eed59e88368eba933bb10fd4f6a6).

Many patch failures were due to upstream changing to J17 & using enhanced switch expressions. While this PR does compile as-is, it has not been tested (and obviously also needs code review).